### PR TITLE
chore(docker): use ENTRYPOINT instead of CMD in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ RUN CGO_ENABLED=0 make -C /go/src/github.com/prymitive/karma VERSION="${VERSION:
 FROM gcr.io/distroless/base
 COPY --from=go-builder /go/src/github.com/prymitive/karma/karma /karma
 EXPOSE 8080
-CMD ["/karma"]
+ENTRYPOINT ["/karma"]


### PR DESCRIPTION
Fixes #21