### PR TITLE
Revert "chore(ui): avoid full grid repack on new alerts"

### DIFF
--- a/ui/src/Components/Grid/AlertGrid/index.js
+++ b/ui/src/Components/Grid/AlertGrid/index.js
@@ -68,11 +68,9 @@ const AlertGrid = observer(
     });
 
     componentDidUpdate() {
-      // whenever grid component re-renders we need to ensure that new grid
-      // elements are packed correctly, but we don't need to do a full repack
-      if (this.masonryComponentReference.ref !== false) {
-        this.masonryComponentReference.ref.forceUpdate();
-      }
+      // whenever grid component re-renders we need to ensure that grid elements
+      // are packed correctly
+      this.masonryRepack();
     }
 
     render() {

--- a/ui/src/Components/Grid/AlertGrid/index.test.js
+++ b/ui/src/Components/Grid/AlertGrid/index.test.js
@@ -76,27 +76,16 @@ describe("<AlertGrid />", () => {
     expect(alertGroups).toHaveLength(80);
   });
 
-  it("calls masonryUpdate() after update`", () => {
+  it("calls masonryRepack() after update`", () => {
     const tree = ShallowAlertGrid();
     const instance = tree.instance();
-    // it's a shallow render so we don't really have masonry mounted, fake it
-    instance.masonryComponentReference.ref = {
-      forceUpdate: jest.fn()
-    };
-    instance.componentDidUpdate();
-    expect(
-      instance.masonryComponentReference.ref.forceUpdate
-    ).toHaveBeenCalled();
-  });
-
-  it("masonryRepack() calls forcePack() on the masonry instance`", () => {
-    const tree = ShallowAlertGrid();
-    const instance = tree.instance();
+    const repackSpy = jest.spyOn(instance, "masonryRepack");
     // it's a shallow render so we don't really have masonry mounted, fake it
     instance.masonryComponentReference.ref = {
       forcePack: jest.fn()
     };
-    instance.masonryRepack();
+    instance.componentDidUpdate();
+    expect(repackSpy).toHaveBeenCalled();
     expect(instance.masonryComponentReference.ref.forcePack).toHaveBeenCalled();
   });
 
@@ -105,15 +94,8 @@ describe("<AlertGrid />", () => {
     const instance = tree.instance();
     const repackSpy = jest.spyOn(instance, "masonryRepack");
     instance.masonryComponentReference.ref = false;
-    instance.masonryRepack();
-    expect(repackSpy).toHaveBeenCalled();
-  });
-
-  it("componentDidUpdate() doesn't crash when masonryComponentReference.ref=false`", () => {
-    const tree = ShallowAlertGrid();
-    const instance = tree.instance();
-    instance.masonryComponentReference.ref = false;
     instance.componentDidUpdate();
+    expect(repackSpy).toHaveBeenCalled();
   });
 
   it("calling storeMasonryRef() saves the ref in local store", () => {


### PR DESCRIPTION
This reverts commit d896fa72b2dd442c7615a63e6b9c934de310aab9.

This causes issues with grid rendering - when alert is removed space it was using is not reclaimed.