### PR TITLE
Revert "fix(ui): always pass credentials with fetch()"

### DIFF
--- a/ui/src/Components/NavBar/FilterInput/index.js
+++ b/ui/src/Components/NavBar/FilterInput/index.js
@@ -72,8 +72,7 @@ const FilterInput = observer(
       action(({ value }) => {
         if (value !== "") {
           this.inputStore.suggestionsFetch = fetch(
-            FormatBackendURI(`autocomplete.json?term=${value}`),
-            { credentials: "include" }
+            FormatBackendURI(`autocomplete.json?term=${value}`)
           )
             .then(
               result => result.json(),

--- a/ui/src/Components/SilenceModal/LabelNameInput.js
+++ b/ui/src/Components/SilenceModal/LabelNameInput.js
@@ -18,9 +18,9 @@ const LabelNameInput = observer(
     populateNameSuggestions = action(() => {
       const { matcher } = this.props;
 
-      this.nameSuggestionsFetch = fetch(FormatBackendURI(`labelNames.json`), {
-        credentials: "include"
-      })
+      this.nameSuggestionsFetch = fetch(
+        FormatBackendURI(`labelNames.json`)
+      )
         .then(
           result => result.json(),
           err => {
@@ -43,10 +43,7 @@ const LabelNameInput = observer(
       const { matcher } = this.props;
 
       this.valueSuggestionsFetch = fetch(
-        FormatBackendURI(`labelValues.json?name=${matcher.name}`),
-        {
-          credentials: "include"
-        }
+        FormatBackendURI(`labelValues.json?name=${matcher.name}`)
       )
         .then(
           result => result.json(),

--- a/ui/src/Stores/AlertStore.js
+++ b/ui/src/Stores/AlertStore.js
@@ -199,7 +199,7 @@ class AlertStore {
       FormatBackendURI("alerts.json?") +
       FormatAPIFilterQuery(this.filters.values.map(f => f.raw));
 
-    return fetch(alertsURI, { credentials: "include" })
+    return fetch(alertsURI)
       .then(result => result.json())
       .then(result => {
         return this.parseAPIResponse(result);


### PR DESCRIPTION
This reverts commit c2a1468c5184798efb82ac1a1898a594ad686d09.

Using 'include' requires passing non-wildcard value in Access-Control-Allow-Origin, revert do default for now.

Related to #24 