### PR TITLE
Revert "chore(ui): use transform positioning for grid elements"

### DIFF
--- a/ui/src/Components/Grid/AlertGrid/index.js
+++ b/ui/src/Components/Grid/AlertGrid/index.js
@@ -82,7 +82,6 @@ const AlertGrid = observer(
             ref={this.storeMasonryRef}
             pack={true}
             sizes={GridSizesConfig}
-            position={false}
             loadMore={this.loadMore}
             hasMore={
               this.groupsToRender.value <


### PR DESCRIPTION
This reverts commit bc720412226e748dbcf43c877d358bd67b71d58c.

Breaks alert action menu, it gets hidden under next alert group div.