### PR TITLE
fix(ui): sort alert groups by id before slicing

### DIFF
--- a/ui/src/Components/Grid/AlertGrid/index.js
+++ b/ui/src/Components/Grid/AlertGrid/index.js
@@ -95,6 +95,7 @@ const AlertGrid = observer(
             }
           >
             {Object.keys(alertStore.data.groups)
+              .sort()
               .slice(0, this.groupsToRender.value)
               .map(id => (
                 <AlertGroup


### PR DESCRIPTION
This is a short term fix to reduce potential re-ordering of alert groups on the grid. This needs to be controlled by user.