### PR TITLE
fix(ui): don't let multiple exceptions set multiple timers

### DIFF
--- a/ui/src/ErrorBoundary.js
+++ b/ui/src/ErrorBoundary.js
@@ -35,6 +35,7 @@ class ErrorBoundary extends Component {
 
   constructor(props) {
     super(props);
+    this.timer = null;
     this.state = { cachedError: null, reloadSeconds: 60 };
   }
 
@@ -55,7 +56,10 @@ class ErrorBoundary extends Component {
     });
     Sentry.captureException(error);
     // reload after 60s, this is to fix wall monitors automatically
-    setInterval(this.reloadApp, 1000);
+    // but only if the timer isn't set yet
+    if (this.timer === null) {
+      this.timer = setInterval(this.reloadApp, 1000);
+    }
   }
 
   render() {

--- a/ui/src/ErrorBoundary.test.js
+++ b/ui/src/ErrorBoundary.test.js
@@ -70,4 +70,19 @@ describe("<ErrorBoundary />", () => {
     expect(reloadSpy).toHaveBeenCalled();
     expect(consoleSpy).toHaveBeenCalled();
   });
+
+  it("reloadSeconds is 40 after 20s with multiple exceptions", () => {
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    const tree = MountedFailingComponent();
+    const instance = tree.instance();
+
+    instance.componentDidCatch("foo", { foo: "bar" });
+    jest.runTimersToTime(1000 * 10);
+    instance.componentDidCatch("foo", { foo: "bar" });
+    jest.runTimersToTime(1000 * 5);
+    instance.componentDidCatch("foo", { foo: "bar" });
+    jest.runTimersToTime(1000 * 5);
+    instance.componentDidCatch("foo", { foo: "bar" });
+    expect(tree.instance().state.reloadSeconds).toBe(40);
+  });
 });


### PR DESCRIPTION
As reported via #77 countdown timer might be updated more often than 1s since we don't protect against multiple setInterval() calls, add a check