### PR TITLE
fix(heroku): use absolute path for heroku command on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -122,4 +122,4 @@ jobs:
         - docker push registry.heroku.com/karma-demo/web
         # bundled heroku cli doesn't know anything about containers, update it
         - curl https://cli-assets.heroku.com/install.sh | sh
-        - heroku container:release web --app karma-demo
+        - /usr/local/bin/heroku container:release web --app karma-demo


### PR DESCRIPTION
/usr/local/bin/heroku is installed by the script, /usr//bin/heroku might be there installed by travis, ensure we use the correct one