### PR TITLE
fix(ui): set high z-index on react-select dropdown menu

### DIFF
--- a/ui/src/Components/MultiSelect/index.js
+++ b/ui/src/Components/MultiSelect/index.js
@@ -76,6 +76,10 @@ const ReactSelectStyles = {
     borderTopRightRadius: "0.25rem",
     borderBottomRightRadius: "0.25rem"
   }),
+  menu: (base, state) => ({
+    ...base,
+    zIndex: 100
+  }),
   option: (base, state) => ({
     ...base,
     color: "inherit",


### PR DESCRIPTION
It's currently 1 which is the same as buttons on the calendar picker used in the silence form, dropdown needs to have higher value