### PR TITLE
fix(ui): don't try to enable scrolling on unmounted modal

### DIFF
--- a/ui/src/Components/Modal/index.js
+++ b/ui/src/Components/Modal/index.js
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 
 import { observer } from "mobx-react";
 
-import { disableBodyScroll, enableBodyScroll } from "body-scroll-lock";
+import { disableBodyScroll, clearAllBodyScrollLocks } from "body-scroll-lock";
 
 import {
   MountModal,
@@ -23,7 +23,7 @@ const Modal = observer(
       if (isOpen) {
         disableBodyScroll(document.querySelector(".modal"));
       } else {
-        enableBodyScroll(document.querySelector(".modal"));
+        clearAllBodyScrollLocks();
       }
     };
 


### PR DESCRIPTION
when we call enableBodyScroll() .modal instance is already gone, which causes crashes on touch enabled devices