### PR TITLE
chore(ci): remove sudo options from Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,6 @@ jobs:
 
     - stage: Build Docker image
       language: generic
-      sudo: required
       addons:
         apt:
           packages:
@@ -114,7 +113,6 @@ jobs:
         # it on heroku app
         - secure: "zr1fHhSIZQgA7wT8PALNyAhilCZBpvziL2zuC7LJvYy9PSHatV1B+/Tl5Ao1MGlqiD9wHdRXhw/Z7Ol7vR84LlEXIQv/PZvpYtdGrwP/dmwEzRi59puNHW/sDa5fU27U5bgGW9VPYKzQFGBIknRz9yEpGAsDqzWSRwEQofgnuF1Cv0JJXN/tcZs/fcXz4AhFSXRb8Rde2geHRVGlz3UnuECQ9LnzTI/xxIP/+YORvMpTcwJtQwq/NhucYXzms19XM94xz5IE/cwf8yV9YZalm867aR2yQJvkMmOaufSYoFgRrghqnpzEe1wyuZvAXkwwZErw5swBY3Zo1YkGUeU761g3v+Nh+dlVKFaBVYgDt9W9bb1QsK1Lbgix4UYSx8Tz06X83xz2f6hWXS1Yvju7yE7M1VmjAhevWW+ZpTf3vwOH2UeUHyAMOddggMSIRfaxC9W74Trt8zxKlM+8sQiaEE3c6Ea+ZJxq1baDJvHQPdfuj2844uKaAL7qNVuRNRPAa0bp0qkzLyl3f5P3XK54mM4vayBRCQ+qflq+XGXY5G8+LukUNnKMq/KuPZZ1A6pOr3kTj4qKaxAcxOJQq4/xc+zJaiQFkzfMj1//LKMyvrRtqMnPV+P3qtgMGzA4Z3JlHUOgPHgbZ9WTlpV5yi066Onro+j2NFehjY+FV6R2gOI="
       language: generic
-      sudo: required
       addons:
         apt:
           packages:


### PR DESCRIPTION
sudo is being deprecated
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration