### PR TITLE
fix(config): default to 'karma.yaml' config file

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"bufio"
 	"bytes"
+	"os"
 	"strings"
 	"time"
 
@@ -106,6 +107,12 @@ func (config *configSchema) Read() {
 
 	v.SetConfigType("yaml")
 	configFile := v.GetString("config.file")
+	// if config file is not set then try loading karma.yaml from current directory
+	if configFile == "" {
+		if _, err = os.Stat("karma.yaml"); !os.IsNotExist(err) {
+			configFile = "karma.yaml"
+		}
+	}
 	if configFile != "" {
 		log.Infof("Reading configuration file %s", configFile)
 		v.SetConfigFile(configFile)


### PR DESCRIPTION
If config.file is not set try loading 'karma.yaml' from current directory. This is the documented behaviour and it used to work before, got broken when config.file was modified to accept a full path instead of just the file name

Fixes #261