### PR TITLE
Add raw JSON data to the DOM for extensibility

### DIFF
--- a/ui/src/Components/Grid/AlertGrid/AlertGroup/Alert/__snapshots__/index.test.js.snap
+++ b/ui/src/Components/Grid/AlertGrid/AlertGroup/Alert/__snapshots__/index.test.js.snap
@@ -2,7 +2,9 @@
 
 exports[`<Alert /> matches snapshot with showAlertmanagers=false showReceiver=false 1`] = `
 "
-<li class=\\"components-grid-alertgrid-alertgroup-alert list-group-item pl-1 pr-0 py-0 my-1 rounded-0 border-left-1 border-right-0 border-top-0 border-bottom-0 border-danger\\">
+<li data-alert-json=\\"{&quot;annotations&quot;:[{&quot;name&quot;:&quot;help&quot;,&quot;value&quot;:&quot;some long text&quot;,&quot;visible&quot;:true,&quot;isLink&quot;:false},{&quot;name&quot;:&quot;hidden&quot;,&quot;value&quot;:&quot;some hidden text&quot;,&quot;visible&quot;:false,&quot;isLink&quot;:false},{&quot;name&quot;:&quot;link&quot;,&quot;value&quot;:&quot;http://localhost&quot;,&quot;visible&quot;:true,&quot;isLink&quot;:true}],&quot;labels&quot;:{&quot;job&quot;:&quot;node_exporter&quot;,&quot;cluster&quot;:&quot;dev&quot;},&quot;startsAt&quot;:&quot;2018-08-14T17:36:40.017867056Z&quot;,&quot;endsAt&quot;:&quot;0001-01-01T00:00:00Z&quot;,&quot;state&quot;:&quot;active&quot;,&quot;alertmanager&quot;:[{&quot;name&quot;:&quot;default&quot;,&quot;state&quot;:&quot;active&quot;,&quot;startsAt&quot;:&quot;2018-08-14T17:36:40.017867056Z&quot;,&quot;endsAt&quot;:&quot;0001-01-01T00:00:00Z&quot;,&quot;source&quot;:&quot;localhost/prometheus&quot;,&quot;silencedBy&quot;:[]}],&quot;receiver&quot;:&quot;by-name&quot;}\\"
+    class=\\"components-grid-alertgrid-alertgroup-alert list-group-item pl-1 pr-0 py-0 my-1 rounded-0 border-left-1 border-right-0 border-top-0 border-bottom-0 border-danger\\"
+>
   <div>
     <div class=\\"mr-1 mb-1 p-1 bg-light cursor-pointer d-inline-block rounded components-grid-annotation\\">
       <svg aria-hidden=\\"true\\"

--- a/ui/src/Components/Grid/AlertGrid/AlertGroup/Alert/index.js
+++ b/ui/src/Components/Grid/AlertGrid/AlertGroup/Alert/index.js
@@ -46,7 +46,7 @@ const Alert = observer(
       ];
 
       return (
-        <li className={classNames.join(" ")}>
+        <li data-alert-json={JSON.stringify(alert)} className={classNames.join(" ")}>
           <div>
             {alert.annotations.filter(a => a.isLink === false).map(a => (
               <RenderNonLinkAnnotation

--- a/ui/src/Components/Grid/AlertGrid/AlertGroup/index.js
+++ b/ui/src/Components/Grid/AlertGrid/AlertGroup/index.js
@@ -160,7 +160,7 @@ const AlertGroup = observer(
 
       return (
         <MountFade>
-          <div className="components-grid-alertgrid-alertgroup p-1">
+          <div data-group-json={JSON.stringify(group)} className="components-grid-alertgrid-alertgroup p-1">
             <div className="card">
               <div
                 className={`card-body ${


### PR DESCRIPTION
This PR adds the raw JSON from the `alert` and `alert group` entities to the DOM under `data-` properties. 

In my group's use-case, we want to use userscripts (https://tampermonkey.net/) to add 'Create jira ticket' buttons to the Karma UI just as we have done in the past, with the [unsee](https://github.com/cloudflare/unsee) dashboard.

In order to extract the necessary data from the DOM easily, I've added the JSON objects as `data-` properties. 

![image](https://user-images.githubusercontent.com/8252744/48927532-2ea9f800-ee9c-11e8-8a98-d882eda71de4.png)
