### PR TITLE
chore(travis): limit number of open renovate bot PRs to 1

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,4 @@
 {
-  "extends": [
-    "config:base"
-  ]
+  "extends": ["config:base"],
+  "prConcurrentLimit": 1
 }


### PR DESCRIPTION
If there's more than 1 open PR then to merge outstanding ones they need to be reabased, so the CI job needs to be re-run. Limit number of open PRs to 1, so there will be no rebasing needed most of the time and travis will run less duplicated jobs