### PR TITLE
chore(renovate): don't automatically rebase state PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
   "extends": ["config:base"],
-  "prConcurrentLimit": 1
+  "prConcurrentLimit": 1,
+  "rebaseStalePrs": false
 }


### PR DESCRIPTION
This causes a lot of concurrent CI jobs, better to rebase manually