### PR TITLE
fix(ci): drop go module tidy check from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,8 @@ jobs:
         - DESC="Lint Go code"
       before_script:
         - make mock-assets
+        # https://github.com/golang/go/issues/26794
+        - GO111MODULE=on go mod download
       script: make lint-go
 
     - stage: Lint
@@ -75,6 +77,8 @@ jobs:
         - nvm install $(< .nvmrc)
       script:
         - export GO111MODULE=on
+        # https://github.com/golang/go/issues/26794
+        - go mod download
         # compile assets via webpack and build those into bindata_assetfs.go file
         - make bindata_assetfs.go
         # verify that there are no uncommited changes from (re)compiling sass

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,8 +77,6 @@ jobs:
         - export GO111MODULE=on
         # compile assets via webpack and build those into bindata_assetfs.go file
         - make bindata_assetfs.go
-        # tidy module deps to ensure we only have what we needed (git diff will pick it up)
-        - go mod tidy -v
         # verify that there are no uncommited changes from (re)compiling sass
         # assets
         - git diff --exit-code

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
   "extends": ["config:base"],
-  "prConcurrentLimit": 1,
+  "prConcurrentLimit": 3,
   "rebaseStalePrs": false
 }


### PR DESCRIPTION
go modules leave checksums of old releases which gets removed when tidy is run, so the diff check is likely to pick us something every time a go module was bumped. Can't have it on CI this way as it will keep failing jobs