### PR TITLE
chore(build): store file metadata when generating binary assets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ endif
 	touch $@
 
 bindata_assetfs.go: .build/deps-build-go.ok .build/artifacts-bindata_assetfs.$(GO_BINDATA_MODE) .build/artifacts-ui.ok
-	go-bindata-assetfs -o bindata_assetfs.go -nometadata ui/build/... ui/src/...
+	go-bindata-assetfs -o bindata_assetfs.go ui/build/... ui/src/...
 
 $(NAME): .build/deps-build-go.ok go.mod bindata_assetfs.go $(SOURCES)
 	GO111MODULE=on go build -ldflags "-X main.version=$(VERSION)"

--- a/assets.go
+++ b/assets.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"html/template"
 	"net/http"
 	"os"
@@ -81,7 +82,7 @@ func serverFileOrEmpty(path string, contentType string, c *gin.Context) {
 		return
 	}
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		c.Data(200, contentType, nil)
+		c.Data(404, contentType, []byte(fmt.Sprintf("%s not found", path)))
 		return
 	}
 	c.File(path)

--- a/assets_test.go
+++ b/assets_test.go
@@ -33,15 +33,15 @@ func TestCustomizationAssets(t *testing.T) {
 		{
 			customJS: "foo/bar/custom.js",
 			path:     "/custom.js",
-			code:     200,
-			body:     "",
+			code:     404,
+			body:     "foo/bar/custom.js not found",
 			mime:     "application/javascript",
 		},
 		{
 			customCSS: "foo/bar/custom.css",
 			path:      "/custom.css",
-			code:      200,
-			body:      "",
+			code:      404,
+			body:      "foo/bar/custom.css not found",
 			mime:      "text/css",
 		},
 		{


### PR DESCRIPTION
This was disabled because bindata_assetfs.go file was stored in git, not it's not so we can re-enable it and get accurate Last-Modified headers in HTTP responses