### PR TITLE
fix(deploy): trigger docker deploy on new tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -131,7 +131,7 @@ jobs:
           tags: true
 
     - stage: Deploy docker image
-      if: repo = prymitive/karma AND type = push AND branch = master
+      if: repo = prymitive/karma AND branch = master AND (type = push OR tag = true)
       language: generic
       addons:
         apt:


### PR DESCRIPTION
It's triggered only on merges right now, needs to also happen on tag