### PR TITLE
fix(backend): don't cache custom assets

### DIFF
--- a/assets.go
+++ b/assets.go
@@ -78,6 +78,7 @@ func loadTemplate(t *template.Template, path string) *template.Template {
 }
 
 func serveFileOr404(path string, contentType string, c *gin.Context) {
+	c.Header("Cache-Control", "no-cache, no-store, must-revalidate")
 	if path == "" {
 		c.Data(200, contentType, nil)
 		return


### PR DESCRIPTION
Since those files can change at any time we should ensure that they are not cached