### PR TITLE
chore(demo): pin alertmanager to 0.15.3 on demo site

### DIFF
--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -12,7 +12,7 @@ RUN CGO_ENABLED=0 make -C /go/src/github.com/prymitive/karma VERSION="${VERSION:
 FROM alpine:latest
 RUN apk add --update supervisor python && rm  -rf /tmp/* /var/cache/apk/*
 COPY demo/supervisord.conf /etc/supervisord.conf
-COPY --from=prom/alertmanager:latest /bin/alertmanager /alertmanager
+COPY --from=prom/alertmanager:v0.15.3 /bin/alertmanager /alertmanager
 COPY demo/alertmanager.yaml /etc/alertmanager.yaml
 COPY demo/generator.py /generator.py
 COPY --from=go-builder /go/src/github.com/prymitive/karma/karma /karma


### PR DESCRIPTION
`>= 0.16` doesn't yet work due to #115