### PR TITLE
fix(proxy): check for trailing slash on listen.prefix when proxy is on

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -15,7 +15,11 @@ import (
 )
 
 func proxyPathPrefix(name string) string {
-	return fmt.Sprintf("%sproxy/alertmanager/%s", config.Config.Listen.Prefix, name)
+	maybeSlash := ""
+	if !strings.HasSuffix(config.Config.Listen.Prefix, "/") {
+		maybeSlash = "/"
+	}
+	return fmt.Sprintf("%s%sproxy/alertmanager/%s", config.Config.Listen.Prefix, maybeSlash, name)
 }
 
 func proxyPath(name, path string) string {


### PR DESCRIPTION
When constructing proxy path to listen on for requests to pass upstream check if listen.prefix ends with / and if no inject it.

Fixes #386