### PR TITLE
feat(api): use metrics to detect Alertmanager version

### DIFF
--- a/internal/mock/0.10.0/api/v1/alerts/groups
+++ b/internal/mock/0.10.0/api/v1/alerts/groups
@@ -19,7 +19,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-11-10T05:48:26.279681396Z",
+                            "startsAt": "2019-01-30T17:27:54.3287372Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -63,11 +63,11 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-11-10T05:48:26.279681396Z",
+                            "startsAt": "2019-01-30T17:27:54.3287372Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "5b654fc3-1e27-4047-847b-d2af3786f834"
+                                    "81367755-e06d-488d-8108-aa91bbb87584"
                                 ],
                                 "state": "suppressed"
                             }
@@ -86,7 +86,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-11-10T05:48:26.279681396Z",
+                            "startsAt": "2019-01-30T17:27:54.3287372Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -119,30 +119,6 @@
                                 "summary": "Example summary"
                             },
                             "endsAt": "0001-01-01T00:00:00Z",
-                            "fingerprint": "44497481566cd3c7",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "dev",
-                                "instance": "server7",
-                                "job": "node_ping"
-                            },
-                            "receivers": null,
-                            "startsAt": "2017-11-10T05:48:26.279681396Z",
-                            "status": {
-                                "inhibitedBy": null,
-                                "silencedBy": [
-                                    "191ef5b5-1672-4c42-80d1-d1cb67218760",
-                                    "781135a2-8ecf-417e-8722-fcdc27e1e651"
-                                ],
-                                "state": "suppressed"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
                             "fingerprint": "af9d8f2f0ccb3970",
                             "generatorURL": "localhost/prometheus",
                             "labels": {
@@ -152,11 +128,11 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-11-10T05:48:26.279681396Z",
+                            "startsAt": "2019-01-30T17:27:54.3287372Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "781135a2-8ecf-417e-8722-fcdc27e1e651"
+                                    "f62c0b79-a0ff-437f-b2c0-d44f868383d1"
                                 ],
                                 "state": "suppressed"
                             }
@@ -176,7 +152,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-11-10T05:48:26.279681396Z",
+                            "startsAt": "2019-01-30T17:27:54.3287372Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -197,7 +173,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-11-10T05:48:26.279681396Z",
+                            "startsAt": "2019-01-30T17:27:54.3287372Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -218,7 +194,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-11-10T05:48:26.279681396Z",
+                            "startsAt": "2019-01-30T17:27:54.3287372Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -239,7 +215,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-11-10T05:48:26.279681396Z",
+                            "startsAt": "2019-01-30T17:27:54.3287372Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -260,7 +236,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-11-10T05:48:26.279681396Z",
+                            "startsAt": "2019-01-30T17:27:54.3287372Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -281,11 +257,35 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-11-10T05:48:26.279681396Z",
+                            "startsAt": "2019-01-30T17:27:54.3287372Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "781135a2-8ecf-417e-8722-fcdc27e1e651"
+                                    "f62c0b79-a0ff-437f-b2c0-d44f868383d1"
+                                ],
+                                "state": "suppressed"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "fingerprint": "44497481566cd3c7",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "dev",
+                                "instance": "server7",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:27:54.3287372Z",
+                            "status": {
+                                "inhibitedBy": null,
+                                "silencedBy": [
+                                    "27b9f23c-9c5a-4934-a175-f940bcfd1e09",
+                                    "f62c0b79-a0ff-437f-b2c0-d44f868383d1"
                                 ],
                                 "state": "suppressed"
                             }
@@ -326,7 +326,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-11-10T05:48:26.279681396Z",
+                            "startsAt": "2019-01-30T17:27:54.3287372Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -369,7 +369,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-11-10T05:48:26.279681396Z",
+                            "startsAt": "2019-01-30T17:27:54.3287372Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -402,27 +402,6 @@
                     "alerts": [
                         {
                             "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "fingerprint": "5cb0dd95e7f3d9c0",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "HTTP_Probe_Failed",
-                                "cluster": "dev",
-                                "instance": "web2",
-                                "job": "node_exporter"
-                            },
-                            "receivers": null,
-                            "startsAt": "2017-11-10T05:48:26.279681396Z",
-                            "status": {
-                                "inhibitedBy": [],
-                                "silencedBy": [],
-                                "state": "active"
-                            }
-                        },
-                        {
-                            "annotations": {
                                 "help": "Example help annotation",
                                 "summary": "Example summary",
                                 "url": "http://localhost/example.html"
@@ -437,21 +416,42 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-11-10T05:48:26.279681396Z",
+                            "startsAt": "2019-01-30T17:27:54.3287372Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "5b654fc3-1e27-4047-847b-d2af3786f834"
+                                    "81367755-e06d-488d-8108-aa91bbb87584"
                                 ],
                                 "state": "suppressed"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "fingerprint": "5cb0dd95e7f3d9c0",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "HTTP_Probe_Failed",
+                                "cluster": "dev",
+                                "instance": "web2",
+                                "job": "node_exporter"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:27:54.3287372Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
                             }
                         }
                     ],
                     "routeOpts": {
                         "groupBy": [
-                            "service",
                             "alertname",
-                            "cluster"
+                            "cluster",
+                            "service"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,
@@ -475,6 +475,29 @@
                                 "summary": "Example summary"
                             },
                             "endsAt": "0001-01-01T00:00:00Z",
+                            "fingerprint": "0967807e4073b606",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "dev",
+                                "instance": "server6",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:27:54.3287372Z",
+                            "status": {
+                                "inhibitedBy": null,
+                                "silencedBy": [
+                                    "f62c0b79-a0ff-437f-b2c0-d44f868383d1"
+                                ],
+                                "state": "suppressed"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
                             "fingerprint": "44497481566cd3c7",
                             "generatorURL": "localhost/prometheus",
                             "labels": {
@@ -484,12 +507,12 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-11-10T05:48:26.279681396Z",
+                            "startsAt": "2019-01-30T17:27:54.3287372Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "191ef5b5-1672-4c42-80d1-d1cb67218760",
-                                    "781135a2-8ecf-417e-8722-fcdc27e1e651"
+                                    "27b9f23c-9c5a-4934-a175-f940bcfd1e09",
+                                    "f62c0b79-a0ff-437f-b2c0-d44f868383d1"
                                 ],
                                 "state": "suppressed"
                             }
@@ -508,34 +531,11 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-11-10T05:48:26.279681396Z",
+                            "startsAt": "2019-01-30T17:27:54.3287372Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "781135a2-8ecf-417e-8722-fcdc27e1e651"
-                                ],
-                                "state": "suppressed"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "fingerprint": "0967807e4073b606",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "dev",
-                                "instance": "server6",
-                                "job": "node_ping"
-                            },
-                            "receivers": null,
-                            "startsAt": "2017-11-10T05:48:26.279681396Z",
-                            "status": {
-                                "inhibitedBy": null,
-                                "silencedBy": [
-                                    "781135a2-8ecf-417e-8722-fcdc27e1e651"
+                                    "f62c0b79-a0ff-437f-b2c0-d44f868383d1"
                                 ],
                                 "state": "suppressed"
                             }
@@ -543,9 +543,9 @@
                     ],
                     "routeOpts": {
                         "groupBy": [
-                            "service",
                             "alertname",
-                            "cluster"
+                            "cluster",
+                            "service"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,
@@ -579,7 +579,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-11-10T05:48:26.279681396Z",
+                            "startsAt": "2019-01-30T17:27:54.3287372Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -600,7 +600,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-11-10T05:48:26.279681396Z",
+                            "startsAt": "2019-01-30T17:27:54.3287372Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -610,9 +610,9 @@
                     ],
                     "routeOpts": {
                         "groupBy": [
+                            "alertname",
                             "cluster",
-                            "service",
-                            "alertname"
+                            "service"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,
@@ -636,6 +636,27 @@
                                 "summary": "Example summary"
                             },
                             "endsAt": "0001-01-01T00:00:00Z",
+                            "fingerprint": "5f1306dab6671183",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "staging",
+                                "instance": "server5",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:27:54.3287372Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
                             "fingerprint": "24e4121619386f95",
                             "generatorURL": "localhost/prometheus",
                             "labels": {
@@ -645,7 +666,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-11-10T05:48:26.279681396Z",
+                            "startsAt": "2019-01-30T17:27:54.3287372Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -666,28 +687,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-11-10T05:48:26.279681396Z",
-                            "status": {
-                                "inhibitedBy": [],
-                                "silencedBy": [],
-                                "state": "active"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "fingerprint": "5f1306dab6671183",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "staging",
-                                "instance": "server5",
-                                "job": "node_ping"
-                            },
-                            "receivers": null,
-                            "startsAt": "2017-11-10T05:48:26.279681396Z",
+                            "startsAt": "2019-01-30T17:27:54.3287372Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -733,7 +733,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-11-10T05:48:26.279681396Z",
+                            "startsAt": "2019-01-30T17:27:54.3287372Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],

--- a/internal/mock/0.10.0/api/v1/silences
+++ b/internal/mock/0.10.0/api/v1/silences
@@ -1,10 +1,28 @@
 {
     "data": [
         {
+            "comment": "Silenced server7",
+            "createdBy": "john@example.com",
+            "endsAt": "2063-01-01T00:00:00Z",
+            "id": "27b9f23c-9c5a-4934-a175-f940bcfd1e09",
+            "matchers": [
+                {
+                    "isRegex": false,
+                    "name": "instance",
+                    "value": "server7"
+                }
+            ],
+            "startsAt": "2019-01-30T17:27:54.3240749Z",
+            "status": {
+                "state": "active"
+            },
+            "updatedAt": "2019-01-30T17:27:54.3240998Z"
+        },
+        {
             "comment": "Silenced instance",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "5b654fc3-1e27-4047-847b-d2af3786f834",
+            "id": "81367755-e06d-488d-8108-aa91bbb87584",
             "matchers": [
                 {
                     "isRegex": false,
@@ -12,17 +30,17 @@
                     "value": "web1"
                 }
             ],
-            "startsAt": "2017-11-10T05:48:26.273292806Z",
+            "startsAt": "2019-01-30T17:27:54.3161904Z",
             "status": {
                 "state": "active"
             },
-            "updatedAt": "2017-11-10T05:48:26.273300272Z"
+            "updatedAt": "2019-01-30T17:27:54.3162112Z"
         },
         {
             "comment": "Silenced Host_Down alerts in the dev cluster",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "781135a2-8ecf-417e-8722-fcdc27e1e651",
+            "id": "f62c0b79-a0ff-437f-b2c0-d44f868383d1",
             "matchers": [
                 {
                     "isRegex": false,
@@ -35,29 +53,11 @@
                     "value": "dev"
                 }
             ],
-            "startsAt": "2017-11-10T05:48:26.27587092Z",
+            "startsAt": "2019-01-30T17:27:54.3202506Z",
             "status": {
                 "state": "active"
             },
-            "updatedAt": "2017-11-10T05:48:26.275874531Z"
-        },
-        {
-            "comment": "Silenced server7",
-            "createdBy": "john@example.com",
-            "endsAt": "2063-01-01T00:00:00Z",
-            "id": "191ef5b5-1672-4c42-80d1-d1cb67218760",
-            "matchers": [
-                {
-                    "isRegex": false,
-                    "name": "instance",
-                    "value": "server7"
-                }
-            ],
-            "startsAt": "2017-11-10T05:48:26.277670977Z",
-            "status": {
-                "state": "active"
-            },
-            "updatedAt": "2017-11-10T05:48:26.277674828Z"
+            "updatedAt": "2019-01-30T17:27:54.3202773Z"
         }
     ],
     "status": "success"

--- a/internal/mock/0.10.0/api/v1/status
+++ b/internal/mock/0.10.0/api/v1/status
@@ -73,16 +73,16 @@
         "configYAML": "global:\n  resolve_timeout: 5m\n  smtp_require_tls: true\n  pagerduty_url: https://events.pagerduty.com/v2/enqueue\n  hipchat_url: https://api.hipchat.com/\n  opsgenie_api_host: https://api.opsgenie.com/\n  victorops_api_url: https://alert.victorops.com/integrations/generic/20131114/alert/\nroute:\n  receiver: default\n  group_by:\n  - alertname\n  routes:\n  - receiver: by-cluster-service\n    group_by:\n    - alertname\n    - cluster\n    - service\n    match_re:\n      alertname: ^(?:.*)$\n    continue: true\n  - receiver: by-name\n    group_by:\n    - alertname\n    match_re:\n      alertname: ^(?:.*)$\n    continue: true\n  group_wait: 15s\n  group_interval: 35s\n  repeat_interval: 999h\ninhibit_rules:\n- source_match:\n    severity: critical\n  target_match:\n    severity: warning\n  equal:\n  - alertname\n  - cluster\n  - service\nreceivers:\n- name: default\n- name: by-cluster-service\n- name: by-name\ntemplates: []\n",
         "meshStatus": {
             "name": "02:42:ac:11:00:02",
-            "nickName": "478a83a834f7",
+            "nickName": "b017b877f2d6",
             "peers": [
                 {
                     "name": "02:42:ac:11:00:02",
-                    "nickName": "478a83a834f7",
-                    "uid": 10870432523890148676
+                    "nickName": "b017b877f2d6",
+                    "uid": 11862144914482473370
                 }
             ]
         },
-        "uptime": "2017-11-10T05:48:11.094854954Z",
+        "uptime": "2019-01-30T17:27:39.1469329Z",
         "versionInfo": {
             "branch": "HEAD",
             "buildDate": "20171109-15:34:53",

--- a/internal/mock/0.10.0/metrics
+++ b/internal/mock/0.10.0/metrics
@@ -1,0 +1,456 @@
+# HELP alertmanager_alerts How many alerts by state.
+# TYPE alertmanager_alerts gauge
+alertmanager_alerts{state="active"} 8
+alertmanager_alerts{state="suppressed"} 4
+# HELP alertmanager_alerts_invalid_total The total number of received alerts that were invalid.
+# TYPE alertmanager_alerts_invalid_total counter
+alertmanager_alerts_invalid_total 0
+# HELP alertmanager_alerts_received_total The total number of received alerts.
+# TYPE alertmanager_alerts_received_total counter
+alertmanager_alerts_received_total{status="firing"} 60
+# HELP alertmanager_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which alertmanager was built.
+# TYPE alertmanager_build_info gauge
+alertmanager_build_info{branch="HEAD",goversion="go1.9.2",revision="133c888ef3644b47a52acbaeffb09f4cc637df1b",version="0.10.0"} 1
+# HELP alertmanager_config_hash Hash of the currently loaded alertmanager configuration.
+# TYPE alertmanager_config_hash gauge
+alertmanager_config_hash 6.2645753076152e+13
+# HELP alertmanager_config_last_reload_success_timestamp_seconds Timestamp of the last successful configuration reload.
+# TYPE alertmanager_config_last_reload_success_timestamp_seconds gauge
+alertmanager_config_last_reload_success_timestamp_seconds 1.548869259e+09
+# HELP alertmanager_config_last_reload_successful Whether the last configuration reload attempt was successful.
+# TYPE alertmanager_config_last_reload_successful gauge
+alertmanager_config_last_reload_successful 1
+# HELP alertmanager_nflog_gc_duration_seconds Duration of the last notification log garbage collection cycle.
+# TYPE alertmanager_nflog_gc_duration_seconds summary
+alertmanager_nflog_gc_duration_seconds{quantile="0.5"} NaN
+alertmanager_nflog_gc_duration_seconds{quantile="0.9"} NaN
+alertmanager_nflog_gc_duration_seconds{quantile="0.99"} NaN
+alertmanager_nflog_gc_duration_seconds_sum 0
+alertmanager_nflog_gc_duration_seconds_count 0
+# HELP alertmanager_nflog_queries_total Number of notification log queries were received.
+# TYPE alertmanager_nflog_queries_total counter
+alertmanager_nflog_queries_total 0
+# HELP alertmanager_nflog_query_duration_seconds Duration of notification log query evaluation.
+# TYPE alertmanager_nflog_query_duration_seconds histogram
+alertmanager_nflog_query_duration_seconds_bucket{le="0.005"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.01"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.025"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.05"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.1"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.25"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="1"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="2.5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="10"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="+Inf"} 0
+alertmanager_nflog_query_duration_seconds_sum 0
+alertmanager_nflog_query_duration_seconds_count 0
+# HELP alertmanager_nflog_query_errors_total Number notification log received queries that failed.
+# TYPE alertmanager_nflog_query_errors_total counter
+alertmanager_nflog_query_errors_total 0
+# HELP alertmanager_nflog_snapshot_duration_seconds Duration of the last notification log snapshot.
+# TYPE alertmanager_nflog_snapshot_duration_seconds summary
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.5"} NaN
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.9"} NaN
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.99"} NaN
+alertmanager_nflog_snapshot_duration_seconds_sum 0
+alertmanager_nflog_snapshot_duration_seconds_count 0
+# HELP alertmanager_notifications_failed_total The total number of failed notifications.
+# TYPE alertmanager_notifications_failed_total counter
+alertmanager_notifications_failed_total{integration="email"} 0
+alertmanager_notifications_failed_total{integration="hipchat"} 0
+alertmanager_notifications_failed_total{integration="opsgenie"} 0
+alertmanager_notifications_failed_total{integration="pagerduty"} 0
+alertmanager_notifications_failed_total{integration="pushover"} 0
+alertmanager_notifications_failed_total{integration="slack"} 0
+alertmanager_notifications_failed_total{integration="victorops"} 0
+alertmanager_notifications_failed_total{integration="webhook"} 0
+# HELP alertmanager_notifications_total The total number of attempted notifications.
+# TYPE alertmanager_notifications_total counter
+alertmanager_notifications_total{integration="email"} 0
+alertmanager_notifications_total{integration="hipchat"} 0
+alertmanager_notifications_total{integration="opsgenie"} 0
+alertmanager_notifications_total{integration="pagerduty"} 0
+alertmanager_notifications_total{integration="pushover"} 0
+alertmanager_notifications_total{integration="slack"} 0
+alertmanager_notifications_total{integration="victorops"} 0
+alertmanager_notifications_total{integration="webhook"} 0
+# HELP alertmanager_peer_position Position the Alertmanager instance believes it's in. The position determines a peer's behavior in the cluster.
+# TYPE alertmanager_peer_position gauge
+alertmanager_peer_position 0
+# HELP alertmanager_silences How many silences by state.
+# TYPE alertmanager_silences gauge
+alertmanager_silences{state="active"} 3
+alertmanager_silences{state="expired"} 0
+alertmanager_silences{state="pending"} 0
+# HELP alertmanager_silences_gc_duration_seconds Duration of the last silence garbage collection cycle.
+# TYPE alertmanager_silences_gc_duration_seconds summary
+alertmanager_silences_gc_duration_seconds{quantile="0.5"} NaN
+alertmanager_silences_gc_duration_seconds{quantile="0.9"} NaN
+alertmanager_silences_gc_duration_seconds{quantile="0.99"} NaN
+alertmanager_silences_gc_duration_seconds_sum 0
+alertmanager_silences_gc_duration_seconds_count 0
+# HELP alertmanager_silences_queries_total How many silence queries were received.
+# TYPE alertmanager_silences_queries_total counter
+alertmanager_silences_queries_total 51
+# HELP alertmanager_silences_query_duration_seconds Duration of silence query evaluation.
+# TYPE alertmanager_silences_query_duration_seconds histogram
+alertmanager_silences_query_duration_seconds_bucket{le="0.005"} 51
+alertmanager_silences_query_duration_seconds_bucket{le="0.01"} 51
+alertmanager_silences_query_duration_seconds_bucket{le="0.025"} 51
+alertmanager_silences_query_duration_seconds_bucket{le="0.05"} 51
+alertmanager_silences_query_duration_seconds_bucket{le="0.1"} 51
+alertmanager_silences_query_duration_seconds_bucket{le="0.25"} 51
+alertmanager_silences_query_duration_seconds_bucket{le="0.5"} 51
+alertmanager_silences_query_duration_seconds_bucket{le="1"} 51
+alertmanager_silences_query_duration_seconds_bucket{le="2.5"} 51
+alertmanager_silences_query_duration_seconds_bucket{le="5"} 51
+alertmanager_silences_query_duration_seconds_bucket{le="10"} 51
+alertmanager_silences_query_duration_seconds_bucket{le="+Inf"} 51
+alertmanager_silences_query_duration_seconds_sum 0.002692600000000001
+alertmanager_silences_query_duration_seconds_count 51
+# HELP alertmanager_silences_query_errors_total How many silence received queries did not succeed.
+# TYPE alertmanager_silences_query_errors_total counter
+alertmanager_silences_query_errors_total 0
+# HELP alertmanager_silences_snapshot_duration_seconds Duration of the last silence snapshot.
+# TYPE alertmanager_silences_snapshot_duration_seconds summary
+alertmanager_silences_snapshot_duration_seconds{quantile="0.5"} NaN
+alertmanager_silences_snapshot_duration_seconds{quantile="0.9"} NaN
+alertmanager_silences_snapshot_duration_seconds{quantile="0.99"} NaN
+alertmanager_silences_snapshot_duration_seconds_sum 0
+alertmanager_silences_snapshot_duration_seconds_count 0
+# HELP go_gc_duration_seconds A summary of the GC invocation durations.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0"} 0.0007904
+go_gc_duration_seconds{quantile="0.25"} 0.0007904
+go_gc_duration_seconds{quantile="0.5"} 0.0007904
+go_gc_duration_seconds{quantile="0.75"} 0.0007904
+go_gc_duration_seconds{quantile="1"} 0.0007904
+go_gc_duration_seconds_sum 0.0007904
+go_gc_duration_seconds_count 1
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 68
+# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+# TYPE go_memstats_alloc_bytes gauge
+go_memstats_alloc_bytes 4.912656e+06
+# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
+# TYPE go_memstats_alloc_bytes_total counter
+go_memstats_alloc_bytes_total 5.500736e+06
+# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
+# TYPE go_memstats_buck_hash_sys_bytes gauge
+go_memstats_buck_hash_sys_bytes 1.445073e+06
+# HELP go_memstats_frees_total Total number of frees.
+# TYPE go_memstats_frees_total counter
+go_memstats_frees_total 4515
+# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+# TYPE go_memstats_gc_sys_bytes gauge
+go_memstats_gc_sys_bytes 372736
+# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
+# TYPE go_memstats_heap_alloc_bytes gauge
+go_memstats_heap_alloc_bytes 4.912656e+06
+# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
+# TYPE go_memstats_heap_idle_bytes gauge
+go_memstats_heap_idle_bytes 860160
+# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
+# TYPE go_memstats_heap_inuse_bytes gauge
+go_memstats_heap_inuse_bytes 5.726208e+06
+# HELP go_memstats_heap_objects Number of allocated objects.
+# TYPE go_memstats_heap_objects gauge
+go_memstats_heap_objects 18067
+# HELP go_memstats_heap_released_bytes_total Total number of heap bytes released to OS.
+# TYPE go_memstats_heap_released_bytes_total counter
+go_memstats_heap_released_bytes_total 0
+# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
+# TYPE go_memstats_heap_sys_bytes gauge
+go_memstats_heap_sys_bytes 6.586368e+06
+# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
+# TYPE go_memstats_last_gc_time_seconds gauge
+go_memstats_last_gc_time_seconds 1.5488692591678646e+09
+# HELP go_memstats_lookups_total Total number of pointer lookups.
+# TYPE go_memstats_lookups_total counter
+go_memstats_lookups_total 40
+# HELP go_memstats_mallocs_total Total number of mallocs.
+# TYPE go_memstats_mallocs_total counter
+go_memstats_mallocs_total 22582
+# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
+# TYPE go_memstats_mcache_inuse_bytes gauge
+go_memstats_mcache_inuse_bytes 3472
+# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
+# TYPE go_memstats_mcache_sys_bytes gauge
+go_memstats_mcache_sys_bytes 16384
+# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
+# TYPE go_memstats_mspan_inuse_bytes gauge
+go_memstats_mspan_inuse_bytes 64448
+# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
+# TYPE go_memstats_mspan_sys_bytes gauge
+go_memstats_mspan_sys_bytes 65536
+# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
+# TYPE go_memstats_next_gc_bytes gauge
+go_memstats_next_gc_bytes 5.99056e+06
+# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
+# TYPE go_memstats_other_sys_bytes gauge
+go_memstats_other_sys_bytes 760871
+# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
+# TYPE go_memstats_stack_inuse_bytes gauge
+go_memstats_stack_inuse_bytes 753664
+# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
+# TYPE go_memstats_stack_sys_bytes gauge
+go_memstats_stack_sys_bytes 753664
+# HELP go_memstats_sys_bytes Number of bytes obtained by system. Sum of all system allocations.
+# TYPE go_memstats_sys_bytes gauge
+go_memstats_sys_bytes 1.0000632e+07
+# HELP http_request_duration_microseconds The HTTP request latencies in microseconds.
+# TYPE http_request_duration_microseconds summary
+http_request_duration_microseconds{handler="add_alerts",quantile="0.5"} 614.7
+http_request_duration_microseconds{handler="add_alerts",quantile="0.9"} 890.9
+http_request_duration_microseconds{handler="add_alerts",quantile="0.99"} 890.9
+http_request_duration_microseconds_sum{handler="add_alerts"} 3744.4000000000005
+http_request_duration_microseconds_count{handler="add_alerts"} 5
+http_request_duration_microseconds{handler="add_silence",quantile="0.5"} 236.5
+http_request_duration_microseconds{handler="add_silence",quantile="0.9"} 267.1
+http_request_duration_microseconds{handler="add_silence",quantile="0.99"} 267.1
+http_request_duration_microseconds_sum{handler="add_silence"} 788.6
+http_request_duration_microseconds_count{handler="add_silence"} 3
+http_request_duration_microseconds{handler="alert_groups",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="alert_groups",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="alert_groups",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="alert_groups"} 0
+http_request_duration_microseconds_count{handler="alert_groups"} 0
+http_request_duration_microseconds{handler="app",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="app",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="app",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="app"} 0
+http_request_duration_microseconds_count{handler="app"} 0
+http_request_duration_microseconds{handler="del_silence",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="del_silence",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="del_silence",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="del_silence"} 0
+http_request_duration_microseconds_count{handler="del_silence"} 0
+http_request_duration_microseconds{handler="get_silence",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="get_silence",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="get_silence",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="get_silence"} 0
+http_request_duration_microseconds_count{handler="get_silence"} 0
+http_request_duration_microseconds{handler="index",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="index",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="index",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="index"} 0
+http_request_duration_microseconds_count{handler="index"} 0
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="legacy_add_alerts"} 0
+http_request_duration_microseconds_count{handler="legacy_add_alerts"} 0
+http_request_duration_microseconds{handler="lib_files",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="lib_files",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="lib_files",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="lib_files"} 0
+http_request_duration_microseconds_count{handler="lib_files"} 0
+http_request_duration_microseconds{handler="list_alerts",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="list_alerts",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="list_alerts",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="list_alerts"} 0
+http_request_duration_microseconds_count{handler="list_alerts"} 0
+http_request_duration_microseconds{handler="list_silences",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="list_silences",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="list_silences",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="list_silences"} 0
+http_request_duration_microseconds_count{handler="list_silences"} 0
+http_request_duration_microseconds{handler="options",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="options",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="options",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="options"} 0
+http_request_duration_microseconds_count{handler="options"} 0
+http_request_duration_microseconds{handler="prometheus",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="prometheus",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="prometheus",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="prometheus"} 0
+http_request_duration_microseconds_count{handler="prometheus"} 0
+http_request_duration_microseconds{handler="receivers",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="receivers",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="receivers",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="receivers"} 0
+http_request_duration_microseconds_count{handler="receivers"} 0
+http_request_duration_microseconds{handler="status",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="status",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="status",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="status"} 0
+http_request_duration_microseconds_count{handler="status"} 0
+# HELP http_request_size_bytes The HTTP request sizes in bytes.
+# TYPE http_request_size_bytes summary
+http_request_size_bytes{handler="add_alerts",quantile="0.5"} 2719
+http_request_size_bytes{handler="add_alerts",quantile="0.9"} 2719
+http_request_size_bytes{handler="add_alerts",quantile="0.99"} 2719
+http_request_size_bytes_sum{handler="add_alerts"} 13595
+http_request_size_bytes_count{handler="add_alerts"} 5
+http_request_size_bytes{handler="add_silence",quantile="0.5"} 358
+http_request_size_bytes{handler="add_silence",quantile="0.9"} 360
+http_request_size_bytes{handler="add_silence",quantile="0.99"} 360
+http_request_size_bytes_sum{handler="add_silence"} 1164
+http_request_size_bytes_count{handler="add_silence"} 3
+http_request_size_bytes{handler="alert_groups",quantile="0.5"} NaN
+http_request_size_bytes{handler="alert_groups",quantile="0.9"} NaN
+http_request_size_bytes{handler="alert_groups",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="alert_groups"} 0
+http_request_size_bytes_count{handler="alert_groups"} 0
+http_request_size_bytes{handler="app",quantile="0.5"} NaN
+http_request_size_bytes{handler="app",quantile="0.9"} NaN
+http_request_size_bytes{handler="app",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="app"} 0
+http_request_size_bytes_count{handler="app"} 0
+http_request_size_bytes{handler="del_silence",quantile="0.5"} NaN
+http_request_size_bytes{handler="del_silence",quantile="0.9"} NaN
+http_request_size_bytes{handler="del_silence",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="del_silence"} 0
+http_request_size_bytes_count{handler="del_silence"} 0
+http_request_size_bytes{handler="get_silence",quantile="0.5"} NaN
+http_request_size_bytes{handler="get_silence",quantile="0.9"} NaN
+http_request_size_bytes{handler="get_silence",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="get_silence"} 0
+http_request_size_bytes_count{handler="get_silence"} 0
+http_request_size_bytes{handler="index",quantile="0.5"} NaN
+http_request_size_bytes{handler="index",quantile="0.9"} NaN
+http_request_size_bytes{handler="index",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="index"} 0
+http_request_size_bytes_count{handler="index"} 0
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="legacy_add_alerts"} 0
+http_request_size_bytes_count{handler="legacy_add_alerts"} 0
+http_request_size_bytes{handler="lib_files",quantile="0.5"} NaN
+http_request_size_bytes{handler="lib_files",quantile="0.9"} NaN
+http_request_size_bytes{handler="lib_files",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="lib_files"} 0
+http_request_size_bytes_count{handler="lib_files"} 0
+http_request_size_bytes{handler="list_alerts",quantile="0.5"} NaN
+http_request_size_bytes{handler="list_alerts",quantile="0.9"} NaN
+http_request_size_bytes{handler="list_alerts",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="list_alerts"} 0
+http_request_size_bytes_count{handler="list_alerts"} 0
+http_request_size_bytes{handler="list_silences",quantile="0.5"} NaN
+http_request_size_bytes{handler="list_silences",quantile="0.9"} NaN
+http_request_size_bytes{handler="list_silences",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="list_silences"} 0
+http_request_size_bytes_count{handler="list_silences"} 0
+http_request_size_bytes{handler="options",quantile="0.5"} NaN
+http_request_size_bytes{handler="options",quantile="0.9"} NaN
+http_request_size_bytes{handler="options",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="options"} 0
+http_request_size_bytes_count{handler="options"} 0
+http_request_size_bytes{handler="prometheus",quantile="0.5"} NaN
+http_request_size_bytes{handler="prometheus",quantile="0.9"} NaN
+http_request_size_bytes{handler="prometheus",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="prometheus"} 0
+http_request_size_bytes_count{handler="prometheus"} 0
+http_request_size_bytes{handler="receivers",quantile="0.5"} NaN
+http_request_size_bytes{handler="receivers",quantile="0.9"} NaN
+http_request_size_bytes{handler="receivers",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="receivers"} 0
+http_request_size_bytes_count{handler="receivers"} 0
+http_request_size_bytes{handler="status",quantile="0.5"} NaN
+http_request_size_bytes{handler="status",quantile="0.9"} NaN
+http_request_size_bytes{handler="status",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="status"} 0
+http_request_size_bytes_count{handler="status"} 0
+# HELP http_requests_total Total number of HTTP requests made.
+# TYPE http_requests_total counter
+http_requests_total{code="200",handler="add_alerts",method="post"} 5
+http_requests_total{code="200",handler="add_silence",method="post"} 3
+# HELP http_response_size_bytes The HTTP response sizes in bytes.
+# TYPE http_response_size_bytes summary
+http_response_size_bytes{handler="add_alerts",quantile="0.5"} 20
+http_response_size_bytes{handler="add_alerts",quantile="0.9"} 20
+http_response_size_bytes{handler="add_alerts",quantile="0.99"} 20
+http_response_size_bytes_sum{handler="add_alerts"} 100
+http_response_size_bytes_count{handler="add_alerts"} 5
+http_response_size_bytes{handler="add_silence",quantile="0.5"} 80
+http_response_size_bytes{handler="add_silence",quantile="0.9"} 80
+http_response_size_bytes{handler="add_silence",quantile="0.99"} 80
+http_response_size_bytes_sum{handler="add_silence"} 240
+http_response_size_bytes_count{handler="add_silence"} 3
+http_response_size_bytes{handler="alert_groups",quantile="0.5"} NaN
+http_response_size_bytes{handler="alert_groups",quantile="0.9"} NaN
+http_response_size_bytes{handler="alert_groups",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="alert_groups"} 0
+http_response_size_bytes_count{handler="alert_groups"} 0
+http_response_size_bytes{handler="app",quantile="0.5"} NaN
+http_response_size_bytes{handler="app",quantile="0.9"} NaN
+http_response_size_bytes{handler="app",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="app"} 0
+http_response_size_bytes_count{handler="app"} 0
+http_response_size_bytes{handler="del_silence",quantile="0.5"} NaN
+http_response_size_bytes{handler="del_silence",quantile="0.9"} NaN
+http_response_size_bytes{handler="del_silence",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="del_silence"} 0
+http_response_size_bytes_count{handler="del_silence"} 0
+http_response_size_bytes{handler="get_silence",quantile="0.5"} NaN
+http_response_size_bytes{handler="get_silence",quantile="0.9"} NaN
+http_response_size_bytes{handler="get_silence",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="get_silence"} 0
+http_response_size_bytes_count{handler="get_silence"} 0
+http_response_size_bytes{handler="index",quantile="0.5"} NaN
+http_response_size_bytes{handler="index",quantile="0.9"} NaN
+http_response_size_bytes{handler="index",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="index"} 0
+http_response_size_bytes_count{handler="index"} 0
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="legacy_add_alerts"} 0
+http_response_size_bytes_count{handler="legacy_add_alerts"} 0
+http_response_size_bytes{handler="lib_files",quantile="0.5"} NaN
+http_response_size_bytes{handler="lib_files",quantile="0.9"} NaN
+http_response_size_bytes{handler="lib_files",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="lib_files"} 0
+http_response_size_bytes_count{handler="lib_files"} 0
+http_response_size_bytes{handler="list_alerts",quantile="0.5"} NaN
+http_response_size_bytes{handler="list_alerts",quantile="0.9"} NaN
+http_response_size_bytes{handler="list_alerts",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="list_alerts"} 0
+http_response_size_bytes_count{handler="list_alerts"} 0
+http_response_size_bytes{handler="list_silences",quantile="0.5"} NaN
+http_response_size_bytes{handler="list_silences",quantile="0.9"} NaN
+http_response_size_bytes{handler="list_silences",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="list_silences"} 0
+http_response_size_bytes_count{handler="list_silences"} 0
+http_response_size_bytes{handler="options",quantile="0.5"} NaN
+http_response_size_bytes{handler="options",quantile="0.9"} NaN
+http_response_size_bytes{handler="options",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="options"} 0
+http_response_size_bytes_count{handler="options"} 0
+http_response_size_bytes{handler="prometheus",quantile="0.5"} NaN
+http_response_size_bytes{handler="prometheus",quantile="0.9"} NaN
+http_response_size_bytes{handler="prometheus",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="prometheus"} 0
+http_response_size_bytes_count{handler="prometheus"} 0
+http_response_size_bytes{handler="receivers",quantile="0.5"} NaN
+http_response_size_bytes{handler="receivers",quantile="0.9"} NaN
+http_response_size_bytes{handler="receivers",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="receivers"} 0
+http_response_size_bytes_count{handler="receivers"} 0
+http_response_size_bytes{handler="status",quantile="0.5"} NaN
+http_response_size_bytes{handler="status",quantile="0.9"} NaN
+http_response_size_bytes{handler="status",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="status"} 0
+http_response_size_bytes_count{handler="status"} 0
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 0.12
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+process_max_fds 1.048576e+06
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+process_open_fds 8
+# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes 1.138688e+07
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds 1.54886925778e+09
+# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE process_virtual_memory_bytes gauge
+process_virtual_memory_bytes 2.0410368e+07

--- a/internal/mock/0.11.0/api/v1/alerts/groups
+++ b/internal/mock/0.11.0/api/v1/alerts/groups
@@ -19,7 +19,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-11-18T05:52:31.508769178Z",
+                            "startsAt": "2019-01-30T17:29:05.3449114Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -49,27 +49,6 @@
                     "alerts": [
                         {
                             "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "fingerprint": "5cb0dd95e7f3d9c0",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "HTTP_Probe_Failed",
-                                "cluster": "dev",
-                                "instance": "web2",
-                                "job": "node_exporter"
-                            },
-                            "receivers": null,
-                            "startsAt": "2017-11-18T05:52:31.508769178Z",
-                            "status": {
-                                "inhibitedBy": [],
-                                "silencedBy": [],
-                                "state": "active"
-                            }
-                        },
-                        {
-                            "annotations": {
                                 "help": "Example help annotation",
                                 "summary": "Example summary",
                                 "url": "http://localhost/example.html"
@@ -84,13 +63,34 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-11-18T05:52:31.508769178Z",
+                            "startsAt": "2019-01-30T17:29:05.3449114Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "1e55eccc-1fba-45ce-a053-e025724b522e"
+                                    "0919574a-ead5-4540-be4f-37e8f5f7ece3"
                                 ],
                                 "state": "suppressed"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "fingerprint": "5cb0dd95e7f3d9c0",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "HTTP_Probe_Failed",
+                                "cluster": "dev",
+                                "instance": "web2",
+                                "job": "node_exporter"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:29:05.3449114Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
                             }
                         }
                     ],
@@ -119,92 +119,6 @@
                                 "summary": "Example summary"
                             },
                             "endsAt": "0001-01-01T00:00:00Z",
-                            "fingerprint": "24e4121619386f95",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "staging",
-                                "instance": "server3",
-                                "job": "node_ping"
-                            },
-                            "receivers": null,
-                            "startsAt": "2017-11-18T05:52:31.508769178Z",
-                            "status": {
-                                "inhibitedBy": [],
-                                "silencedBy": [],
-                                "state": "active"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "fingerprint": "d9067fcc9686d942",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "staging",
-                                "instance": "server4",
-                                "job": "node_ping"
-                            },
-                            "receivers": null,
-                            "startsAt": "2017-11-18T05:52:31.508769178Z",
-                            "status": {
-                                "inhibitedBy": [],
-                                "silencedBy": [],
-                                "state": "active"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "fingerprint": "5f1306dab6671183",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "staging",
-                                "instance": "server5",
-                                "job": "node_ping"
-                            },
-                            "receivers": null,
-                            "startsAt": "2017-11-18T05:52:31.508769178Z",
-                            "status": {
-                                "inhibitedBy": [],
-                                "silencedBy": [],
-                                "state": "active"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "fingerprint": "0967807e4073b606",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "dev",
-                                "instance": "server6",
-                                "job": "node_ping"
-                            },
-                            "receivers": null,
-                            "startsAt": "2017-11-18T05:52:31.508769178Z",
-                            "status": {
-                                "inhibitedBy": null,
-                                "silencedBy": [
-                                    "29dc1204-6618-447f-8436-0c9068c1d05d"
-                                ],
-                                "state": "suppressed"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
                             "fingerprint": "44497481566cd3c7",
                             "generatorURL": "localhost/prometheus",
                             "labels": {
@@ -214,12 +128,12 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-11-18T05:52:31.508769178Z",
+                            "startsAt": "2019-01-30T17:29:05.3449114Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "29dc1204-6618-447f-8436-0c9068c1d05d",
-                                    "169a2b61-8926-4271-abef-bf67317932e5"
+                                    "7823a0fc-942a-4eab-bf09-32fce1099b32",
+                                    "e4512e24-5a2a-4ad8-9d25-28814a98fee9"
                                 ],
                                 "state": "suppressed"
                             }
@@ -238,11 +152,11 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-11-18T05:52:31.508769178Z",
+                            "startsAt": "2019-01-30T17:29:05.3449114Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "29dc1204-6618-447f-8436-0c9068c1d05d"
+                                    "7823a0fc-942a-4eab-bf09-32fce1099b32"
                                 ],
                                 "state": "suppressed"
                             }
@@ -262,7 +176,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-11-18T05:52:31.508769178Z",
+                            "startsAt": "2019-01-30T17:29:05.3449114Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -283,11 +197,97 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-11-18T05:52:31.508769178Z",
+                            "startsAt": "2019-01-30T17:29:05.3449114Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
                                 "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "fingerprint": "24e4121619386f95",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "staging",
+                                "instance": "server3",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:29:05.3449114Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "fingerprint": "d9067fcc9686d942",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "staging",
+                                "instance": "server4",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:29:05.3449114Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "fingerprint": "5f1306dab6671183",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "staging",
+                                "instance": "server5",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:29:05.3449114Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "fingerprint": "0967807e4073b606",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "dev",
+                                "instance": "server6",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:29:05.3449114Z",
+                            "status": {
+                                "inhibitedBy": null,
+                                "silencedBy": [
+                                    "7823a0fc-942a-4eab-bf09-32fce1099b32"
+                                ],
+                                "state": "suppressed"
                             }
                         }
                     ],
@@ -326,7 +326,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-11-18T05:52:31.508769178Z",
+                            "startsAt": "2019-01-30T17:29:05.3449114Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -369,7 +369,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-11-18T05:52:31.508769178Z",
+                            "startsAt": "2019-01-30T17:29:05.3449114Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -416,11 +416,11 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-11-18T05:52:31.508769178Z",
+                            "startsAt": "2019-01-30T17:29:05.3449114Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "1e55eccc-1fba-45ce-a053-e025724b522e"
+                                    "0919574a-ead5-4540-be4f-37e8f5f7ece3"
                                 ],
                                 "state": "suppressed"
                             }
@@ -439,7 +439,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-11-18T05:52:31.508769178Z",
+                            "startsAt": "2019-01-30T17:29:05.3449114Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -475,6 +475,29 @@
                                 "summary": "Example summary"
                             },
                             "endsAt": "0001-01-01T00:00:00Z",
+                            "fingerprint": "af9d8f2f0ccb3970",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "dev",
+                                "instance": "server8",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:29:05.3449114Z",
+                            "status": {
+                                "inhibitedBy": null,
+                                "silencedBy": [
+                                    "7823a0fc-942a-4eab-bf09-32fce1099b32"
+                                ],
+                                "state": "suppressed"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
                             "fingerprint": "0967807e4073b606",
                             "generatorURL": "localhost/prometheus",
                             "labels": {
@@ -484,11 +507,11 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-11-18T05:52:31.508769178Z",
+                            "startsAt": "2019-01-30T17:29:05.3449114Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "29dc1204-6618-447f-8436-0c9068c1d05d"
+                                    "7823a0fc-942a-4eab-bf09-32fce1099b32"
                                 ],
                                 "state": "suppressed"
                             }
@@ -507,35 +530,12 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-11-18T05:52:31.508769178Z",
+                            "startsAt": "2019-01-30T17:29:05.3449114Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "29dc1204-6618-447f-8436-0c9068c1d05d",
-                                    "169a2b61-8926-4271-abef-bf67317932e5"
-                                ],
-                                "state": "suppressed"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "fingerprint": "af9d8f2f0ccb3970",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "dev",
-                                "instance": "server8",
-                                "job": "node_ping"
-                            },
-                            "receivers": null,
-                            "startsAt": "2017-11-18T05:52:31.508769178Z",
-                            "status": {
-                                "inhibitedBy": null,
-                                "silencedBy": [
-                                    "29dc1204-6618-447f-8436-0c9068c1d05d"
+                                    "7823a0fc-942a-4eab-bf09-32fce1099b32",
+                                    "e4512e24-5a2a-4ad8-9d25-28814a98fee9"
                                 ],
                                 "state": "suppressed"
                             }
@@ -579,7 +579,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-11-18T05:52:31.508769178Z",
+                            "startsAt": "2019-01-30T17:29:05.3449114Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -600,7 +600,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-11-18T05:52:31.508769178Z",
+                            "startsAt": "2019-01-30T17:29:05.3449114Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -645,7 +645,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-11-18T05:52:31.508769178Z",
+                            "startsAt": "2019-01-30T17:29:05.3449114Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -666,7 +666,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-11-18T05:52:31.508769178Z",
+                            "startsAt": "2019-01-30T17:29:05.3449114Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -687,7 +687,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-11-18T05:52:31.508769178Z",
+                            "startsAt": "2019-01-30T17:29:05.3449114Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -733,7 +733,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-11-18T05:52:31.508769178Z",
+                            "startsAt": "2019-01-30T17:29:05.3449114Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],

--- a/internal/mock/0.11.0/api/v1/silences
+++ b/internal/mock/0.11.0/api/v1/silences
@@ -1,28 +1,10 @@
 {
     "data": [
         {
-            "comment": "Silenced instance",
-            "createdBy": "john@example.com",
-            "endsAt": "2063-01-01T00:00:00Z",
-            "id": "1e55eccc-1fba-45ce-a053-e025724b522e",
-            "matchers": [
-                {
-                    "isRegex": false,
-                    "name": "instance",
-                    "value": "web1"
-                }
-            ],
-            "startsAt": "2017-11-18T05:52:31.502126065Z",
-            "status": {
-                "state": "active"
-            },
-            "updatedAt": "2017-11-18T05:52:31.502132992Z"
-        },
-        {
             "comment": "Silenced Host_Down alerts in the dev cluster",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "29dc1204-6618-447f-8436-0c9068c1d05d",
+            "id": "7823a0fc-942a-4eab-bf09-32fce1099b32",
             "matchers": [
                 {
                     "isRegex": false,
@@ -35,17 +17,17 @@
                     "value": "dev"
                 }
             ],
-            "startsAt": "2017-11-18T05:52:31.504448469Z",
+            "startsAt": "2019-01-30T17:29:05.3367201Z",
             "status": {
                 "state": "active"
             },
-            "updatedAt": "2017-11-18T05:52:31.504453686Z"
+            "updatedAt": "2019-01-30T17:29:05.3367377Z"
         },
         {
             "comment": "Silenced server7",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "169a2b61-8926-4271-abef-bf67317932e5",
+            "id": "e4512e24-5a2a-4ad8-9d25-28814a98fee9",
             "matchers": [
                 {
                     "isRegex": false,
@@ -53,11 +35,29 @@
                     "value": "server7"
                 }
             ],
-            "startsAt": "2017-11-18T05:52:31.506169376Z",
+            "startsAt": "2019-01-30T17:29:05.3403788Z",
             "status": {
                 "state": "active"
             },
-            "updatedAt": "2017-11-18T05:52:31.506173805Z"
+            "updatedAt": "2019-01-30T17:29:05.3403957Z"
+        },
+        {
+            "comment": "Silenced instance",
+            "createdBy": "john@example.com",
+            "endsAt": "2063-01-01T00:00:00Z",
+            "id": "0919574a-ead5-4540-be4f-37e8f5f7ece3",
+            "matchers": [
+                {
+                    "isRegex": false,
+                    "name": "instance",
+                    "value": "web1"
+                }
+            ],
+            "startsAt": "2019-01-30T17:29:05.3331842Z",
+            "status": {
+                "state": "active"
+            },
+            "updatedAt": "2019-01-30T17:29:05.3332012Z"
         }
     ],
     "status": "success"

--- a/internal/mock/0.11.0/api/v1/status
+++ b/internal/mock/0.11.0/api/v1/status
@@ -73,16 +73,16 @@
         "configYAML": "global:\n  resolve_timeout: 5m\n  smtp_require_tls: true\n  pagerduty_url: https://events.pagerduty.com/v2/enqueue\n  hipchat_api_url: https://api.hipchat.com/\n  opsgenie_api_url: https://api.opsgenie.com/\n  victorops_api_url: https://alert.victorops.com/integrations/generic/20131114/alert/\nroute:\n  receiver: default\n  group_by:\n  - alertname\n  routes:\n  - receiver: by-cluster-service\n    group_by:\n    - alertname\n    - cluster\n    - service\n    match_re:\n      alertname: ^(?:.*)$\n    continue: true\n  - receiver: by-name\n    group_by:\n    - alertname\n    match_re:\n      alertname: ^(?:.*)$\n    continue: true\n  group_wait: 15s\n  group_interval: 35s\n  repeat_interval: 999h\ninhibit_rules:\n- source_match:\n    severity: critical\n  target_match:\n    severity: warning\n  equal:\n  - alertname\n  - cluster\n  - service\nreceivers:\n- name: default\n- name: by-cluster-service\n- name: by-name\ntemplates: []\n",
         "meshStatus": {
             "name": "02:42:ac:11:00:02",
-            "nickName": "7b404cf24939",
+            "nickName": "974fe6a991a0",
             "peers": [
                 {
                     "name": "02:42:ac:11:00:02",
-                    "nickName": "7b404cf24939",
-                    "uid": 3862700015286939413
+                    "nickName": "974fe6a991a0",
+                    "uid": 4220008795799732303
                 }
             ]
         },
-        "uptime": "2017-11-18T05:52:16.299600147Z",
+        "uptime": "2019-01-30T17:28:50.1656236Z",
         "versionInfo": {
             "branch": "HEAD",
             "buildDate": "20171116-17:43:56",

--- a/internal/mock/0.11.0/metrics
+++ b/internal/mock/0.11.0/metrics
@@ -1,0 +1,456 @@
+# HELP alertmanager_alerts How many alerts by state.
+# TYPE alertmanager_alerts gauge
+alertmanager_alerts{state="active"} 8
+alertmanager_alerts{state="suppressed"} 4
+# HELP alertmanager_alerts_invalid_total The total number of received alerts that were invalid.
+# TYPE alertmanager_alerts_invalid_total counter
+alertmanager_alerts_invalid_total 0
+# HELP alertmanager_alerts_received_total The total number of received alerts.
+# TYPE alertmanager_alerts_received_total counter
+alertmanager_alerts_received_total{status="firing"} 60
+# HELP alertmanager_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which alertmanager was built.
+# TYPE alertmanager_build_info gauge
+alertmanager_build_info{branch="HEAD",goversion="go1.9.2",revision="30dd0426c08b6479d9a26259ea5efd63bc1ee273",version="0.11.0"} 1
+# HELP alertmanager_config_hash Hash of the currently loaded alertmanager configuration.
+# TYPE alertmanager_config_hash gauge
+alertmanager_config_hash 6.2645753076152e+13
+# HELP alertmanager_config_last_reload_success_timestamp_seconds Timestamp of the last successful configuration reload.
+# TYPE alertmanager_config_last_reload_success_timestamp_seconds gauge
+alertmanager_config_last_reload_success_timestamp_seconds 1.54886933e+09
+# HELP alertmanager_config_last_reload_successful Whether the last configuration reload attempt was successful.
+# TYPE alertmanager_config_last_reload_successful gauge
+alertmanager_config_last_reload_successful 1
+# HELP alertmanager_nflog_gc_duration_seconds Duration of the last notification log garbage collection cycle.
+# TYPE alertmanager_nflog_gc_duration_seconds summary
+alertmanager_nflog_gc_duration_seconds{quantile="0.5"} NaN
+alertmanager_nflog_gc_duration_seconds{quantile="0.9"} NaN
+alertmanager_nflog_gc_duration_seconds{quantile="0.99"} NaN
+alertmanager_nflog_gc_duration_seconds_sum 0
+alertmanager_nflog_gc_duration_seconds_count 0
+# HELP alertmanager_nflog_queries_total Number of notification log queries were received.
+# TYPE alertmanager_nflog_queries_total counter
+alertmanager_nflog_queries_total 0
+# HELP alertmanager_nflog_query_duration_seconds Duration of notification log query evaluation.
+# TYPE alertmanager_nflog_query_duration_seconds histogram
+alertmanager_nflog_query_duration_seconds_bucket{le="0.005"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.01"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.025"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.05"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.1"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.25"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="1"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="2.5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="10"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="+Inf"} 0
+alertmanager_nflog_query_duration_seconds_sum 0
+alertmanager_nflog_query_duration_seconds_count 0
+# HELP alertmanager_nflog_query_errors_total Number notification log received queries that failed.
+# TYPE alertmanager_nflog_query_errors_total counter
+alertmanager_nflog_query_errors_total 0
+# HELP alertmanager_nflog_snapshot_duration_seconds Duration of the last notification log snapshot.
+# TYPE alertmanager_nflog_snapshot_duration_seconds summary
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.5"} NaN
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.9"} NaN
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.99"} NaN
+alertmanager_nflog_snapshot_duration_seconds_sum 0
+alertmanager_nflog_snapshot_duration_seconds_count 0
+# HELP alertmanager_notifications_failed_total The total number of failed notifications.
+# TYPE alertmanager_notifications_failed_total counter
+alertmanager_notifications_failed_total{integration="email"} 0
+alertmanager_notifications_failed_total{integration="hipchat"} 0
+alertmanager_notifications_failed_total{integration="opsgenie"} 0
+alertmanager_notifications_failed_total{integration="pagerduty"} 0
+alertmanager_notifications_failed_total{integration="pushover"} 0
+alertmanager_notifications_failed_total{integration="slack"} 0
+alertmanager_notifications_failed_total{integration="victorops"} 0
+alertmanager_notifications_failed_total{integration="webhook"} 0
+# HELP alertmanager_notifications_total The total number of attempted notifications.
+# TYPE alertmanager_notifications_total counter
+alertmanager_notifications_total{integration="email"} 0
+alertmanager_notifications_total{integration="hipchat"} 0
+alertmanager_notifications_total{integration="opsgenie"} 0
+alertmanager_notifications_total{integration="pagerduty"} 0
+alertmanager_notifications_total{integration="pushover"} 0
+alertmanager_notifications_total{integration="slack"} 0
+alertmanager_notifications_total{integration="victorops"} 0
+alertmanager_notifications_total{integration="webhook"} 0
+# HELP alertmanager_peer_position Position the Alertmanager instance believes it's in. The position determines a peer's behavior in the cluster.
+# TYPE alertmanager_peer_position gauge
+alertmanager_peer_position 0
+# HELP alertmanager_silences How many silences by state.
+# TYPE alertmanager_silences gauge
+alertmanager_silences{state="active"} 3
+alertmanager_silences{state="expired"} 0
+alertmanager_silences{state="pending"} 0
+# HELP alertmanager_silences_gc_duration_seconds Duration of the last silence garbage collection cycle.
+# TYPE alertmanager_silences_gc_duration_seconds summary
+alertmanager_silences_gc_duration_seconds{quantile="0.5"} NaN
+alertmanager_silences_gc_duration_seconds{quantile="0.9"} NaN
+alertmanager_silences_gc_duration_seconds{quantile="0.99"} NaN
+alertmanager_silences_gc_duration_seconds_sum 0
+alertmanager_silences_gc_duration_seconds_count 0
+# HELP alertmanager_silences_queries_total How many silence queries were received.
+# TYPE alertmanager_silences_queries_total counter
+alertmanager_silences_queries_total 50
+# HELP alertmanager_silences_query_duration_seconds Duration of silence query evaluation.
+# TYPE alertmanager_silences_query_duration_seconds histogram
+alertmanager_silences_query_duration_seconds_bucket{le="0.005"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.01"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.025"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.05"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.1"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.25"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.5"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="1"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="2.5"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="5"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="10"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="+Inf"} 48
+alertmanager_silences_query_duration_seconds_sum 0.0022452000000000006
+alertmanager_silences_query_duration_seconds_count 48
+# HELP alertmanager_silences_query_errors_total How many silence received queries did not succeed.
+# TYPE alertmanager_silences_query_errors_total counter
+alertmanager_silences_query_errors_total 0
+# HELP alertmanager_silences_snapshot_duration_seconds Duration of the last silence snapshot.
+# TYPE alertmanager_silences_snapshot_duration_seconds summary
+alertmanager_silences_snapshot_duration_seconds{quantile="0.5"} NaN
+alertmanager_silences_snapshot_duration_seconds{quantile="0.9"} NaN
+alertmanager_silences_snapshot_duration_seconds{quantile="0.99"} NaN
+alertmanager_silences_snapshot_duration_seconds_sum 0
+alertmanager_silences_snapshot_duration_seconds_count 0
+# HELP go_gc_duration_seconds A summary of the GC invocation durations.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0"} 0.0015283
+go_gc_duration_seconds{quantile="0.25"} 0.0015283
+go_gc_duration_seconds{quantile="0.5"} 0.0015283
+go_gc_duration_seconds{quantile="0.75"} 0.0015283
+go_gc_duration_seconds{quantile="1"} 0.0015283
+go_gc_duration_seconds_sum 0.0015283
+go_gc_duration_seconds_count 1
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 117
+# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+# TYPE go_memstats_alloc_bytes gauge
+go_memstats_alloc_bytes 4.841192e+06
+# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
+# TYPE go_memstats_alloc_bytes_total counter
+go_memstats_alloc_bytes_total 5.422272e+06
+# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
+# TYPE go_memstats_buck_hash_sys_bytes gauge
+go_memstats_buck_hash_sys_bytes 1.445153e+06
+# HELP go_memstats_frees_total Total number of frees.
+# TYPE go_memstats_frees_total counter
+go_memstats_frees_total 4376
+# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+# TYPE go_memstats_gc_sys_bytes gauge
+go_memstats_gc_sys_bytes 372736
+# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
+# TYPE go_memstats_heap_alloc_bytes gauge
+go_memstats_heap_alloc_bytes 4.841192e+06
+# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
+# TYPE go_memstats_heap_idle_bytes gauge
+go_memstats_heap_idle_bytes 843776
+# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
+# TYPE go_memstats_heap_inuse_bytes gauge
+go_memstats_heap_inuse_bytes 5.677056e+06
+# HELP go_memstats_heap_objects Number of allocated objects.
+# TYPE go_memstats_heap_objects gauge
+go_memstats_heap_objects 17785
+# HELP go_memstats_heap_released_bytes_total Total number of heap bytes released to OS.
+# TYPE go_memstats_heap_released_bytes_total counter
+go_memstats_heap_released_bytes_total 0
+# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
+# TYPE go_memstats_heap_sys_bytes gauge
+go_memstats_heap_sys_bytes 6.520832e+06
+# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
+# TYPE go_memstats_last_gc_time_seconds gauge
+go_memstats_last_gc_time_seconds 1.5488693301895785e+09
+# HELP go_memstats_lookups_total Total number of pointer lookups.
+# TYPE go_memstats_lookups_total counter
+go_memstats_lookups_total 32
+# HELP go_memstats_mallocs_total Total number of mallocs.
+# TYPE go_memstats_mallocs_total counter
+go_memstats_mallocs_total 22161
+# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
+# TYPE go_memstats_mcache_inuse_bytes gauge
+go_memstats_mcache_inuse_bytes 3472
+# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
+# TYPE go_memstats_mcache_sys_bytes gauge
+go_memstats_mcache_sys_bytes 16384
+# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
+# TYPE go_memstats_mspan_inuse_bytes gauge
+go_memstats_mspan_inuse_bytes 63688
+# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
+# TYPE go_memstats_mspan_sys_bytes gauge
+go_memstats_mspan_sys_bytes 65536
+# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
+# TYPE go_memstats_next_gc_bytes gauge
+go_memstats_next_gc_bytes 7.606592e+06
+# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
+# TYPE go_memstats_other_sys_bytes gauge
+go_memstats_other_sys_bytes 760791
+# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
+# TYPE go_memstats_stack_inuse_bytes gauge
+go_memstats_stack_inuse_bytes 819200
+# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
+# TYPE go_memstats_stack_sys_bytes gauge
+go_memstats_stack_sys_bytes 819200
+# HELP go_memstats_sys_bytes Number of bytes obtained by system. Sum of all system allocations.
+# TYPE go_memstats_sys_bytes gauge
+go_memstats_sys_bytes 1.0000632e+07
+# HELP http_request_duration_microseconds The HTTP request latencies in microseconds.
+# TYPE http_request_duration_microseconds summary
+http_request_duration_microseconds{handler="add_alerts",quantile="0.5"} 494.6
+http_request_duration_microseconds{handler="add_alerts",quantile="0.9"} 1129
+http_request_duration_microseconds{handler="add_alerts",quantile="0.99"} 1129
+http_request_duration_microseconds_sum{handler="add_alerts"} 4182.2
+http_request_duration_microseconds_count{handler="add_alerts"} 5
+http_request_duration_microseconds{handler="add_silence",quantile="0.5"} 217.9
+http_request_duration_microseconds{handler="add_silence",quantile="0.9"} 235.2
+http_request_duration_microseconds{handler="add_silence",quantile="0.99"} 235.2
+http_request_duration_microseconds_sum{handler="add_silence"} 690
+http_request_duration_microseconds_count{handler="add_silence"} 3
+http_request_duration_microseconds{handler="alert_groups",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="alert_groups",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="alert_groups",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="alert_groups"} 0
+http_request_duration_microseconds_count{handler="alert_groups"} 0
+http_request_duration_microseconds{handler="app",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="app",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="app",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="app"} 0
+http_request_duration_microseconds_count{handler="app"} 0
+http_request_duration_microseconds{handler="del_silence",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="del_silence",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="del_silence",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="del_silence"} 0
+http_request_duration_microseconds_count{handler="del_silence"} 0
+http_request_duration_microseconds{handler="get_silence",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="get_silence",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="get_silence",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="get_silence"} 0
+http_request_duration_microseconds_count{handler="get_silence"} 0
+http_request_duration_microseconds{handler="index",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="index",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="index",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="index"} 0
+http_request_duration_microseconds_count{handler="index"} 0
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="legacy_add_alerts"} 0
+http_request_duration_microseconds_count{handler="legacy_add_alerts"} 0
+http_request_duration_microseconds{handler="lib_files",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="lib_files",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="lib_files",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="lib_files"} 0
+http_request_duration_microseconds_count{handler="lib_files"} 0
+http_request_duration_microseconds{handler="list_alerts",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="list_alerts",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="list_alerts",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="list_alerts"} 0
+http_request_duration_microseconds_count{handler="list_alerts"} 0
+http_request_duration_microseconds{handler="list_silences",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="list_silences",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="list_silences",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="list_silences"} 0
+http_request_duration_microseconds_count{handler="list_silences"} 0
+http_request_duration_microseconds{handler="options",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="options",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="options",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="options"} 0
+http_request_duration_microseconds_count{handler="options"} 0
+http_request_duration_microseconds{handler="prometheus",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="prometheus",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="prometheus",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="prometheus"} 0
+http_request_duration_microseconds_count{handler="prometheus"} 0
+http_request_duration_microseconds{handler="receivers",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="receivers",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="receivers",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="receivers"} 0
+http_request_duration_microseconds_count{handler="receivers"} 0
+http_request_duration_microseconds{handler="status",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="status",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="status",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="status"} 0
+http_request_duration_microseconds_count{handler="status"} 0
+# HELP http_request_size_bytes The HTTP request sizes in bytes.
+# TYPE http_request_size_bytes summary
+http_request_size_bytes{handler="add_alerts",quantile="0.5"} 2719
+http_request_size_bytes{handler="add_alerts",quantile="0.9"} 2719
+http_request_size_bytes{handler="add_alerts",quantile="0.99"} 2719
+http_request_size_bytes_sum{handler="add_alerts"} 13595
+http_request_size_bytes_count{handler="add_alerts"} 5
+http_request_size_bytes{handler="add_silence",quantile="0.5"} 358
+http_request_size_bytes{handler="add_silence",quantile="0.9"} 360
+http_request_size_bytes{handler="add_silence",quantile="0.99"} 360
+http_request_size_bytes_sum{handler="add_silence"} 1164
+http_request_size_bytes_count{handler="add_silence"} 3
+http_request_size_bytes{handler="alert_groups",quantile="0.5"} NaN
+http_request_size_bytes{handler="alert_groups",quantile="0.9"} NaN
+http_request_size_bytes{handler="alert_groups",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="alert_groups"} 0
+http_request_size_bytes_count{handler="alert_groups"} 0
+http_request_size_bytes{handler="app",quantile="0.5"} NaN
+http_request_size_bytes{handler="app",quantile="0.9"} NaN
+http_request_size_bytes{handler="app",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="app"} 0
+http_request_size_bytes_count{handler="app"} 0
+http_request_size_bytes{handler="del_silence",quantile="0.5"} NaN
+http_request_size_bytes{handler="del_silence",quantile="0.9"} NaN
+http_request_size_bytes{handler="del_silence",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="del_silence"} 0
+http_request_size_bytes_count{handler="del_silence"} 0
+http_request_size_bytes{handler="get_silence",quantile="0.5"} NaN
+http_request_size_bytes{handler="get_silence",quantile="0.9"} NaN
+http_request_size_bytes{handler="get_silence",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="get_silence"} 0
+http_request_size_bytes_count{handler="get_silence"} 0
+http_request_size_bytes{handler="index",quantile="0.5"} NaN
+http_request_size_bytes{handler="index",quantile="0.9"} NaN
+http_request_size_bytes{handler="index",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="index"} 0
+http_request_size_bytes_count{handler="index"} 0
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="legacy_add_alerts"} 0
+http_request_size_bytes_count{handler="legacy_add_alerts"} 0
+http_request_size_bytes{handler="lib_files",quantile="0.5"} NaN
+http_request_size_bytes{handler="lib_files",quantile="0.9"} NaN
+http_request_size_bytes{handler="lib_files",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="lib_files"} 0
+http_request_size_bytes_count{handler="lib_files"} 0
+http_request_size_bytes{handler="list_alerts",quantile="0.5"} NaN
+http_request_size_bytes{handler="list_alerts",quantile="0.9"} NaN
+http_request_size_bytes{handler="list_alerts",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="list_alerts"} 0
+http_request_size_bytes_count{handler="list_alerts"} 0
+http_request_size_bytes{handler="list_silences",quantile="0.5"} NaN
+http_request_size_bytes{handler="list_silences",quantile="0.9"} NaN
+http_request_size_bytes{handler="list_silences",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="list_silences"} 0
+http_request_size_bytes_count{handler="list_silences"} 0
+http_request_size_bytes{handler="options",quantile="0.5"} NaN
+http_request_size_bytes{handler="options",quantile="0.9"} NaN
+http_request_size_bytes{handler="options",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="options"} 0
+http_request_size_bytes_count{handler="options"} 0
+http_request_size_bytes{handler="prometheus",quantile="0.5"} NaN
+http_request_size_bytes{handler="prometheus",quantile="0.9"} NaN
+http_request_size_bytes{handler="prometheus",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="prometheus"} 0
+http_request_size_bytes_count{handler="prometheus"} 0
+http_request_size_bytes{handler="receivers",quantile="0.5"} NaN
+http_request_size_bytes{handler="receivers",quantile="0.9"} NaN
+http_request_size_bytes{handler="receivers",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="receivers"} 0
+http_request_size_bytes_count{handler="receivers"} 0
+http_request_size_bytes{handler="status",quantile="0.5"} NaN
+http_request_size_bytes{handler="status",quantile="0.9"} NaN
+http_request_size_bytes{handler="status",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="status"} 0
+http_request_size_bytes_count{handler="status"} 0
+# HELP http_requests_total Total number of HTTP requests made.
+# TYPE http_requests_total counter
+http_requests_total{code="200",handler="add_alerts",method="post"} 5
+http_requests_total{code="200",handler="add_silence",method="post"} 3
+# HELP http_response_size_bytes The HTTP response sizes in bytes.
+# TYPE http_response_size_bytes summary
+http_response_size_bytes{handler="add_alerts",quantile="0.5"} 20
+http_response_size_bytes{handler="add_alerts",quantile="0.9"} 20
+http_response_size_bytes{handler="add_alerts",quantile="0.99"} 20
+http_response_size_bytes_sum{handler="add_alerts"} 100
+http_response_size_bytes_count{handler="add_alerts"} 5
+http_response_size_bytes{handler="add_silence",quantile="0.5"} 80
+http_response_size_bytes{handler="add_silence",quantile="0.9"} 80
+http_response_size_bytes{handler="add_silence",quantile="0.99"} 80
+http_response_size_bytes_sum{handler="add_silence"} 240
+http_response_size_bytes_count{handler="add_silence"} 3
+http_response_size_bytes{handler="alert_groups",quantile="0.5"} NaN
+http_response_size_bytes{handler="alert_groups",quantile="0.9"} NaN
+http_response_size_bytes{handler="alert_groups",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="alert_groups"} 0
+http_response_size_bytes_count{handler="alert_groups"} 0
+http_response_size_bytes{handler="app",quantile="0.5"} NaN
+http_response_size_bytes{handler="app",quantile="0.9"} NaN
+http_response_size_bytes{handler="app",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="app"} 0
+http_response_size_bytes_count{handler="app"} 0
+http_response_size_bytes{handler="del_silence",quantile="0.5"} NaN
+http_response_size_bytes{handler="del_silence",quantile="0.9"} NaN
+http_response_size_bytes{handler="del_silence",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="del_silence"} 0
+http_response_size_bytes_count{handler="del_silence"} 0
+http_response_size_bytes{handler="get_silence",quantile="0.5"} NaN
+http_response_size_bytes{handler="get_silence",quantile="0.9"} NaN
+http_response_size_bytes{handler="get_silence",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="get_silence"} 0
+http_response_size_bytes_count{handler="get_silence"} 0
+http_response_size_bytes{handler="index",quantile="0.5"} NaN
+http_response_size_bytes{handler="index",quantile="0.9"} NaN
+http_response_size_bytes{handler="index",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="index"} 0
+http_response_size_bytes_count{handler="index"} 0
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="legacy_add_alerts"} 0
+http_response_size_bytes_count{handler="legacy_add_alerts"} 0
+http_response_size_bytes{handler="lib_files",quantile="0.5"} NaN
+http_response_size_bytes{handler="lib_files",quantile="0.9"} NaN
+http_response_size_bytes{handler="lib_files",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="lib_files"} 0
+http_response_size_bytes_count{handler="lib_files"} 0
+http_response_size_bytes{handler="list_alerts",quantile="0.5"} NaN
+http_response_size_bytes{handler="list_alerts",quantile="0.9"} NaN
+http_response_size_bytes{handler="list_alerts",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="list_alerts"} 0
+http_response_size_bytes_count{handler="list_alerts"} 0
+http_response_size_bytes{handler="list_silences",quantile="0.5"} NaN
+http_response_size_bytes{handler="list_silences",quantile="0.9"} NaN
+http_response_size_bytes{handler="list_silences",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="list_silences"} 0
+http_response_size_bytes_count{handler="list_silences"} 0
+http_response_size_bytes{handler="options",quantile="0.5"} NaN
+http_response_size_bytes{handler="options",quantile="0.9"} NaN
+http_response_size_bytes{handler="options",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="options"} 0
+http_response_size_bytes_count{handler="options"} 0
+http_response_size_bytes{handler="prometheus",quantile="0.5"} NaN
+http_response_size_bytes{handler="prometheus",quantile="0.9"} NaN
+http_response_size_bytes{handler="prometheus",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="prometheus"} 0
+http_response_size_bytes_count{handler="prometheus"} 0
+http_response_size_bytes{handler="receivers",quantile="0.5"} NaN
+http_response_size_bytes{handler="receivers",quantile="0.9"} NaN
+http_response_size_bytes{handler="receivers",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="receivers"} 0
+http_response_size_bytes_count{handler="receivers"} 0
+http_response_size_bytes{handler="status",quantile="0.5"} NaN
+http_response_size_bytes{handler="status",quantile="0.9"} NaN
+http_response_size_bytes{handler="status",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="status"} 0
+http_response_size_bytes_count{handler="status"} 0
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 0.12
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+process_max_fds 1.048576e+06
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+process_open_fds 8
+# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes 1.0932224e+07
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds 1.54886932891e+09
+# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE process_virtual_memory_bytes gauge
+process_virtual_memory_bytes 2.0402176e+07

--- a/internal/mock/0.12.0/api/v1/alerts/groups
+++ b/internal/mock/0.12.0/api/v1/alerts/groups
@@ -19,7 +19,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-12-22T21:13:04.890844023Z",
+                            "startsAt": "2019-01-30T17:30:17.2234021Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -63,11 +63,11 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-12-22T21:13:04.890844023Z",
+                            "startsAt": "2019-01-30T17:30:17.2234021Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "99f307a7-db56-4691-a66f-2bb80b2ae6cf"
+                                    "cab57692-0105-4dca-9ee7-f01e18d3042e"
                                 ],
                                 "state": "suppressed"
                             }
@@ -86,7 +86,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-12-22T21:13:04.890844023Z",
+                            "startsAt": "2019-01-30T17:30:17.2234021Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -119,51 +119,6 @@
                                 "summary": "Example summary"
                             },
                             "endsAt": "0001-01-01T00:00:00Z",
-                            "fingerprint": "af9d8f2f0ccb3970",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "dev",
-                                "instance": "server8",
-                                "job": "node_ping"
-                            },
-                            "receivers": null,
-                            "startsAt": "2017-12-22T21:13:04.890844023Z",
-                            "status": {
-                                "inhibitedBy": null,
-                                "silencedBy": [
-                                    "36230d98-5fab-4b77-a577-a882b56006fe"
-                                ],
-                                "state": "suppressed"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary",
-                                "url": "http://localhost/example.html"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "fingerprint": "d0aee2649e71388b",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "prod",
-                                "instance": "server1",
-                                "job": "node_ping"
-                            },
-                            "receivers": null,
-                            "startsAt": "2017-12-22T21:13:04.890844023Z",
-                            "status": {
-                                "inhibitedBy": [],
-                                "silencedBy": [],
-                                "state": "active"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
                             "fingerprint": "3bdb8b68bdce2ae0",
                             "generatorURL": "localhost/prometheus",
                             "labels": {
@@ -173,7 +128,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-12-22T21:13:04.890844023Z",
+                            "startsAt": "2019-01-30T17:30:17.2234021Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -194,7 +149,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-12-22T21:13:04.890844023Z",
+                            "startsAt": "2019-01-30T17:30:17.2234021Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -215,7 +170,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-12-22T21:13:04.890844023Z",
+                            "startsAt": "2019-01-30T17:30:17.2234021Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -236,7 +191,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-12-22T21:13:04.890844023Z",
+                            "startsAt": "2019-01-30T17:30:17.2234021Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -257,11 +212,11 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-12-22T21:13:04.890844023Z",
+                            "startsAt": "2019-01-30T17:30:17.2234021Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "36230d98-5fab-4b77-a577-a882b56006fe"
+                                    "ccca8397-b714-44cb-9e80-6def9c992ef6"
                                 ],
                                 "state": "suppressed"
                             }
@@ -280,14 +235,59 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-12-22T21:13:04.890844023Z",
+                            "startsAt": "2019-01-30T17:30:17.2234021Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "ecbd66eb-ae22-4a1c-807e-396a57fc79c3",
-                                    "36230d98-5fab-4b77-a577-a882b56006fe"
+                                    "ccca8397-b714-44cb-9e80-6def9c992ef6",
+                                    "610ac883-a400-490f-94a6-36a81b228877"
                                 ],
                                 "state": "suppressed"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "fingerprint": "af9d8f2f0ccb3970",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "dev",
+                                "instance": "server8",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:30:17.2234021Z",
+                            "status": {
+                                "inhibitedBy": null,
+                                "silencedBy": [
+                                    "ccca8397-b714-44cb-9e80-6def9c992ef6"
+                                ],
+                                "state": "suppressed"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary",
+                                "url": "http://localhost/example.html"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "fingerprint": "d0aee2649e71388b",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "prod",
+                                "instance": "server1",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:30:17.2234021Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
                             }
                         }
                     ],
@@ -326,7 +326,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-12-22T21:13:04.890844023Z",
+                            "startsAt": "2019-01-30T17:30:17.2234021Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -369,7 +369,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-12-22T21:13:04.890844023Z",
+                            "startsAt": "2019-01-30T17:30:17.2234021Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -416,11 +416,11 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-12-22T21:13:04.890844023Z",
+                            "startsAt": "2019-01-30T17:30:17.2234021Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "99f307a7-db56-4691-a66f-2bb80b2ae6cf"
+                                    "cab57692-0105-4dca-9ee7-f01e18d3042e"
                                 ],
                                 "state": "suppressed"
                             }
@@ -439,7 +439,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-12-22T21:13:04.890844023Z",
+                            "startsAt": "2019-01-30T17:30:17.2234021Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -449,9 +449,9 @@
                     ],
                     "routeOpts": {
                         "groupBy": [
-                            "service",
                             "alertname",
-                            "cluster"
+                            "cluster",
+                            "service"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,
@@ -484,11 +484,11 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-12-22T21:13:04.890844023Z",
+                            "startsAt": "2019-01-30T17:30:17.2234021Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "36230d98-5fab-4b77-a577-a882b56006fe"
+                                    "ccca8397-b714-44cb-9e80-6def9c992ef6"
                                 ],
                                 "state": "suppressed"
                             }
@@ -507,12 +507,12 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-12-22T21:13:04.890844023Z",
+                            "startsAt": "2019-01-30T17:30:17.2234021Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "ecbd66eb-ae22-4a1c-807e-396a57fc79c3",
-                                    "36230d98-5fab-4b77-a577-a882b56006fe"
+                                    "ccca8397-b714-44cb-9e80-6def9c992ef6",
+                                    "610ac883-a400-490f-94a6-36a81b228877"
                                 ],
                                 "state": "suppressed"
                             }
@@ -531,11 +531,11 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-12-22T21:13:04.890844023Z",
+                            "startsAt": "2019-01-30T17:30:17.2234021Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "36230d98-5fab-4b77-a577-a882b56006fe"
+                                    "ccca8397-b714-44cb-9e80-6def9c992ef6"
                                 ],
                                 "state": "suppressed"
                             }
@@ -579,7 +579,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-12-22T21:13:04.890844023Z",
+                            "startsAt": "2019-01-30T17:30:17.2234021Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -600,7 +600,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-12-22T21:13:04.890844023Z",
+                            "startsAt": "2019-01-30T17:30:17.2234021Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -610,9 +610,9 @@
                     ],
                     "routeOpts": {
                         "groupBy": [
-                            "alertname",
                             "cluster",
-                            "service"
+                            "service",
+                            "alertname"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,
@@ -645,7 +645,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-12-22T21:13:04.890844023Z",
+                            "startsAt": "2019-01-30T17:30:17.2234021Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -666,7 +666,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-12-22T21:13:04.890844023Z",
+                            "startsAt": "2019-01-30T17:30:17.2234021Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -687,7 +687,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-12-22T21:13:04.890844023Z",
+                            "startsAt": "2019-01-30T17:30:17.2234021Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -733,7 +733,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-12-22T21:13:04.890844023Z",
+                            "startsAt": "2019-01-30T17:30:17.2234021Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],

--- a/internal/mock/0.12.0/api/v1/silences
+++ b/internal/mock/0.12.0/api/v1/silences
@@ -4,7 +4,7 @@
             "comment": "Silenced server7",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "ecbd66eb-ae22-4a1c-807e-396a57fc79c3",
+            "id": "610ac883-a400-490f-94a6-36a81b228877",
             "matchers": [
                 {
                     "isRegex": false,
@@ -12,17 +12,17 @@
                     "value": "server7"
                 }
             ],
-            "startsAt": "2017-12-22T21:13:04.888969442Z",
+            "startsAt": "2019-01-30T17:30:17.2199739Z",
             "status": {
                 "state": "active"
             },
-            "updatedAt": "2017-12-22T21:13:04.888974836Z"
+            "updatedAt": "2019-01-30T17:30:17.2199941Z"
         },
         {
             "comment": "Silenced instance",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "99f307a7-db56-4691-a66f-2bb80b2ae6cf",
+            "id": "cab57692-0105-4dca-9ee7-f01e18d3042e",
             "matchers": [
                 {
                     "isRegex": false,
@@ -30,17 +30,17 @@
                     "value": "web1"
                 }
             ],
-            "startsAt": "2017-12-22T21:13:04.884944393Z",
+            "startsAt": "2019-01-30T17:30:17.2111407Z",
             "status": {
                 "state": "active"
             },
-            "updatedAt": "2017-12-22T21:13:04.884949893Z"
+            "updatedAt": "2019-01-30T17:30:17.2111635Z"
         },
         {
             "comment": "Silenced Host_Down alerts in the dev cluster",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "36230d98-5fab-4b77-a577-a882b56006fe",
+            "id": "ccca8397-b714-44cb-9e80-6def9c992ef6",
             "matchers": [
                 {
                     "isRegex": false,
@@ -53,11 +53,11 @@
                     "value": "dev"
                 }
             ],
-            "startsAt": "2017-12-22T21:13:04.887252474Z",
+            "startsAt": "2019-01-30T17:30:17.2147369Z",
             "status": {
                 "state": "active"
             },
-            "updatedAt": "2017-12-22T21:13:04.88725659Z"
+            "updatedAt": "2019-01-30T17:30:17.2147583Z"
         }
     ],
     "status": "success"

--- a/internal/mock/0.12.0/api/v1/status
+++ b/internal/mock/0.12.0/api/v1/status
@@ -74,16 +74,16 @@
         "configYAML": "global:\n  resolve_timeout: 5m\n  smtp_require_tls: true\n  pagerduty_url: https://events.pagerduty.com/v2/enqueue\n  hipchat_api_url: https://api.hipchat.com/\n  opsgenie_api_url: https://api.opsgenie.com/\n  wechat_api_url: https://qyapi.weixin.qq.com/cgi-bin/\n  victorops_api_url: https://alert.victorops.com/integrations/generic/20131114/alert/\nroute:\n  receiver: default\n  group_by:\n  - alertname\n  routes:\n  - receiver: by-cluster-service\n    group_by:\n    - alertname\n    - cluster\n    - service\n    match_re:\n      alertname: ^(?:.*)$\n    continue: true\n  - receiver: by-name\n    group_by:\n    - alertname\n    match_re:\n      alertname: ^(?:.*)$\n    continue: true\n  group_wait: 15s\n  group_interval: 35s\n  repeat_interval: 999h\ninhibit_rules:\n- source_match:\n    severity: critical\n  target_match:\n    severity: warning\n  equal:\n  - alertname\n  - cluster\n  - service\nreceivers:\n- name: default\n- name: by-cluster-service\n- name: by-name\ntemplates: []\n",
         "meshStatus": {
             "name": "02:42:ac:11:00:02",
-            "nickName": "24ebb37c5251",
+            "nickName": "508225064f82",
             "peers": [
                 {
                     "name": "02:42:ac:11:00:02",
-                    "nickName": "24ebb37c5251",
-                    "uid": 6589206068519979673
+                    "nickName": "508225064f82",
+                    "uid": 11187596441851003591
                 }
             ]
         },
-        "uptime": "2017-12-22T21:12:49.516935587Z",
+        "uptime": "2019-01-30T17:30:02.0865936Z",
         "versionInfo": {
             "branch": "HEAD",
             "buildDate": "20171215-14:13:20",

--- a/internal/mock/0.12.0/metrics
+++ b/internal/mock/0.12.0/metrics
@@ -1,0 +1,458 @@
+# HELP alertmanager_alerts How many alerts by state.
+# TYPE alertmanager_alerts gauge
+alertmanager_alerts{state="active"} 8
+alertmanager_alerts{state="suppressed"} 4
+# HELP alertmanager_alerts_invalid_total The total number of received alerts that were invalid.
+# TYPE alertmanager_alerts_invalid_total counter
+alertmanager_alerts_invalid_total 0
+# HELP alertmanager_alerts_received_total The total number of received alerts.
+# TYPE alertmanager_alerts_received_total counter
+alertmanager_alerts_received_total{status="firing"} 60
+# HELP alertmanager_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which alertmanager was built.
+# TYPE alertmanager_build_info gauge
+alertmanager_build_info{branch="HEAD",goversion="go1.9.2",revision="fc33cc78036f82ef8d4734c197a96f7cb6c952a3",version="0.12.0"} 1
+# HELP alertmanager_config_hash Hash of the currently loaded alertmanager configuration.
+# TYPE alertmanager_config_hash gauge
+alertmanager_config_hash 6.2645753076152e+13
+# HELP alertmanager_config_last_reload_success_timestamp_seconds Timestamp of the last successful configuration reload.
+# TYPE alertmanager_config_last_reload_success_timestamp_seconds gauge
+alertmanager_config_last_reload_success_timestamp_seconds 1.548869402e+09
+# HELP alertmanager_config_last_reload_successful Whether the last configuration reload attempt was successful.
+# TYPE alertmanager_config_last_reload_successful gauge
+alertmanager_config_last_reload_successful 1
+# HELP alertmanager_nflog_gc_duration_seconds Duration of the last notification log garbage collection cycle.
+# TYPE alertmanager_nflog_gc_duration_seconds summary
+alertmanager_nflog_gc_duration_seconds{quantile="0.5"} NaN
+alertmanager_nflog_gc_duration_seconds{quantile="0.9"} NaN
+alertmanager_nflog_gc_duration_seconds{quantile="0.99"} NaN
+alertmanager_nflog_gc_duration_seconds_sum 0
+alertmanager_nflog_gc_duration_seconds_count 0
+# HELP alertmanager_nflog_queries_total Number of notification log queries were received.
+# TYPE alertmanager_nflog_queries_total counter
+alertmanager_nflog_queries_total 0
+# HELP alertmanager_nflog_query_duration_seconds Duration of notification log query evaluation.
+# TYPE alertmanager_nflog_query_duration_seconds histogram
+alertmanager_nflog_query_duration_seconds_bucket{le="0.005"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.01"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.025"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.05"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.1"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.25"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="1"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="2.5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="10"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="+Inf"} 0
+alertmanager_nflog_query_duration_seconds_sum 0
+alertmanager_nflog_query_duration_seconds_count 0
+# HELP alertmanager_nflog_query_errors_total Number notification log received queries that failed.
+# TYPE alertmanager_nflog_query_errors_total counter
+alertmanager_nflog_query_errors_total 0
+# HELP alertmanager_nflog_snapshot_duration_seconds Duration of the last notification log snapshot.
+# TYPE alertmanager_nflog_snapshot_duration_seconds summary
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.5"} NaN
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.9"} NaN
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.99"} NaN
+alertmanager_nflog_snapshot_duration_seconds_sum 0
+alertmanager_nflog_snapshot_duration_seconds_count 0
+# HELP alertmanager_notifications_failed_total The total number of failed notifications.
+# TYPE alertmanager_notifications_failed_total counter
+alertmanager_notifications_failed_total{integration="email"} 0
+alertmanager_notifications_failed_total{integration="hipchat"} 0
+alertmanager_notifications_failed_total{integration="opsgenie"} 0
+alertmanager_notifications_failed_total{integration="pagerduty"} 0
+alertmanager_notifications_failed_total{integration="pushover"} 0
+alertmanager_notifications_failed_total{integration="slack"} 0
+alertmanager_notifications_failed_total{integration="victorops"} 0
+alertmanager_notifications_failed_total{integration="webhook"} 0
+alertmanager_notifications_failed_total{integration="wechat"} 0
+# HELP alertmanager_notifications_total The total number of attempted notifications.
+# TYPE alertmanager_notifications_total counter
+alertmanager_notifications_total{integration="email"} 0
+alertmanager_notifications_total{integration="hipchat"} 0
+alertmanager_notifications_total{integration="opsgenie"} 0
+alertmanager_notifications_total{integration="pagerduty"} 0
+alertmanager_notifications_total{integration="pushover"} 0
+alertmanager_notifications_total{integration="slack"} 0
+alertmanager_notifications_total{integration="victorops"} 0
+alertmanager_notifications_total{integration="webhook"} 0
+alertmanager_notifications_total{integration="wechat"} 0
+# HELP alertmanager_peer_position Position the Alertmanager instance believes it's in. The position determines a peer's behavior in the cluster.
+# TYPE alertmanager_peer_position gauge
+alertmanager_peer_position 0
+# HELP alertmanager_silences How many silences by state.
+# TYPE alertmanager_silences gauge
+alertmanager_silences{state="active"} 3
+alertmanager_silences{state="expired"} 0
+alertmanager_silences{state="pending"} 0
+# HELP alertmanager_silences_gc_duration_seconds Duration of the last silence garbage collection cycle.
+# TYPE alertmanager_silences_gc_duration_seconds summary
+alertmanager_silences_gc_duration_seconds{quantile="0.5"} NaN
+alertmanager_silences_gc_duration_seconds{quantile="0.9"} NaN
+alertmanager_silences_gc_duration_seconds{quantile="0.99"} NaN
+alertmanager_silences_gc_duration_seconds_sum 0
+alertmanager_silences_gc_duration_seconds_count 0
+# HELP alertmanager_silences_queries_total How many silence queries were received.
+# TYPE alertmanager_silences_queries_total counter
+alertmanager_silences_queries_total 49
+# HELP alertmanager_silences_query_duration_seconds Duration of silence query evaluation.
+# TYPE alertmanager_silences_query_duration_seconds histogram
+alertmanager_silences_query_duration_seconds_bucket{le="0.005"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="0.01"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="0.025"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="0.05"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="0.1"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="0.25"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="0.5"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="1"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="2.5"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="5"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="10"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="+Inf"} 49
+alertmanager_silences_query_duration_seconds_sum 0.004909300000000001
+alertmanager_silences_query_duration_seconds_count 49
+# HELP alertmanager_silences_query_errors_total How many silence received queries did not succeed.
+# TYPE alertmanager_silences_query_errors_total counter
+alertmanager_silences_query_errors_total 0
+# HELP alertmanager_silences_snapshot_duration_seconds Duration of the last silence snapshot.
+# TYPE alertmanager_silences_snapshot_duration_seconds summary
+alertmanager_silences_snapshot_duration_seconds{quantile="0.5"} NaN
+alertmanager_silences_snapshot_duration_seconds{quantile="0.9"} NaN
+alertmanager_silences_snapshot_duration_seconds{quantile="0.99"} NaN
+alertmanager_silences_snapshot_duration_seconds_sum 0
+alertmanager_silences_snapshot_duration_seconds_count 0
+# HELP go_gc_duration_seconds A summary of the GC invocation durations.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0"} 0.0011538
+go_gc_duration_seconds{quantile="0.25"} 0.0011538
+go_gc_duration_seconds{quantile="0.5"} 0.0011538
+go_gc_duration_seconds{quantile="0.75"} 0.0011538
+go_gc_duration_seconds{quantile="1"} 0.0011538
+go_gc_duration_seconds_sum 0.0011538
+go_gc_duration_seconds_count 1
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 62
+# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+# TYPE go_memstats_alloc_bytes gauge
+go_memstats_alloc_bytes 4.847672e+06
+# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
+# TYPE go_memstats_alloc_bytes_total counter
+go_memstats_alloc_bytes_total 5.433064e+06
+# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
+# TYPE go_memstats_buck_hash_sys_bytes gauge
+go_memstats_buck_hash_sys_bytes 3117
+# HELP go_memstats_frees_total Total number of frees.
+# TYPE go_memstats_frees_total counter
+go_memstats_frees_total 4492
+# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+# TYPE go_memstats_gc_sys_bytes gauge
+go_memstats_gc_sys_bytes 372736
+# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
+# TYPE go_memstats_heap_alloc_bytes gauge
+go_memstats_heap_alloc_bytes 4.847672e+06
+# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
+# TYPE go_memstats_heap_idle_bytes gauge
+go_memstats_heap_idle_bytes 843776
+# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
+# TYPE go_memstats_heap_inuse_bytes gauge
+go_memstats_heap_inuse_bytes 5.709824e+06
+# HELP go_memstats_heap_objects Number of allocated objects.
+# TYPE go_memstats_heap_objects gauge
+go_memstats_heap_objects 17948
+# HELP go_memstats_heap_released_bytes_total Total number of heap bytes released to OS.
+# TYPE go_memstats_heap_released_bytes_total counter
+go_memstats_heap_released_bytes_total 0
+# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
+# TYPE go_memstats_heap_sys_bytes gauge
+go_memstats_heap_sys_bytes 6.5536e+06
+# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
+# TYPE go_memstats_last_gc_time_seconds gauge
+go_memstats_last_gc_time_seconds 1.5488694021014354e+09
+# HELP go_memstats_lookups_total Total number of pointer lookups.
+# TYPE go_memstats_lookups_total counter
+go_memstats_lookups_total 32
+# HELP go_memstats_mallocs_total Total number of mallocs.
+# TYPE go_memstats_mallocs_total counter
+go_memstats_mallocs_total 22440
+# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
+# TYPE go_memstats_mcache_inuse_bytes gauge
+go_memstats_mcache_inuse_bytes 3472
+# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
+# TYPE go_memstats_mcache_sys_bytes gauge
+go_memstats_mcache_sys_bytes 16384
+# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
+# TYPE go_memstats_mspan_inuse_bytes gauge
+go_memstats_mspan_inuse_bytes 64144
+# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
+# TYPE go_memstats_mspan_sys_bytes gauge
+go_memstats_mspan_sys_bytes 65536
+# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
+# TYPE go_memstats_next_gc_bytes gauge
+go_memstats_next_gc_bytes 7.192528e+06
+# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
+# TYPE go_memstats_other_sys_bytes gauge
+go_memstats_other_sys_bytes 762835
+# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
+# TYPE go_memstats_stack_inuse_bytes gauge
+go_memstats_stack_inuse_bytes 786432
+# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
+# TYPE go_memstats_stack_sys_bytes gauge
+go_memstats_stack_sys_bytes 786432
+# HELP go_memstats_sys_bytes Number of bytes obtained by system. Sum of all system allocations.
+# TYPE go_memstats_sys_bytes gauge
+go_memstats_sys_bytes 8.56064e+06
+# HELP http_request_duration_microseconds The HTTP request latencies in microseconds.
+# TYPE http_request_duration_microseconds summary
+http_request_duration_microseconds{handler="add_alerts",quantile="0.5"} 394.8
+http_request_duration_microseconds{handler="add_alerts",quantile="0.9"} 1099.3
+http_request_duration_microseconds{handler="add_alerts",quantile="0.99"} 1099.3
+http_request_duration_microseconds_sum{handler="add_alerts"} 6587.5
+http_request_duration_microseconds_count{handler="add_alerts"} 5
+http_request_duration_microseconds{handler="add_silence",quantile="0.5"} 162.4
+http_request_duration_microseconds{handler="add_silence",quantile="0.9"} 208
+http_request_duration_microseconds{handler="add_silence",quantile="0.99"} 208
+http_request_duration_microseconds_sum{handler="add_silence"} 637.6
+http_request_duration_microseconds_count{handler="add_silence"} 3
+http_request_duration_microseconds{handler="alert_groups",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="alert_groups",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="alert_groups",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="alert_groups"} 0
+http_request_duration_microseconds_count{handler="alert_groups"} 0
+http_request_duration_microseconds{handler="app",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="app",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="app",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="app"} 0
+http_request_duration_microseconds_count{handler="app"} 0
+http_request_duration_microseconds{handler="del_silence",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="del_silence",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="del_silence",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="del_silence"} 0
+http_request_duration_microseconds_count{handler="del_silence"} 0
+http_request_duration_microseconds{handler="get_silence",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="get_silence",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="get_silence",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="get_silence"} 0
+http_request_duration_microseconds_count{handler="get_silence"} 0
+http_request_duration_microseconds{handler="index",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="index",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="index",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="index"} 0
+http_request_duration_microseconds_count{handler="index"} 0
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="legacy_add_alerts"} 0
+http_request_duration_microseconds_count{handler="legacy_add_alerts"} 0
+http_request_duration_microseconds{handler="lib_files",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="lib_files",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="lib_files",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="lib_files"} 0
+http_request_duration_microseconds_count{handler="lib_files"} 0
+http_request_duration_microseconds{handler="list_alerts",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="list_alerts",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="list_alerts",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="list_alerts"} 0
+http_request_duration_microseconds_count{handler="list_alerts"} 0
+http_request_duration_microseconds{handler="list_silences",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="list_silences",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="list_silences",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="list_silences"} 0
+http_request_duration_microseconds_count{handler="list_silences"} 0
+http_request_duration_microseconds{handler="options",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="options",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="options",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="options"} 0
+http_request_duration_microseconds_count{handler="options"} 0
+http_request_duration_microseconds{handler="prometheus",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="prometheus",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="prometheus",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="prometheus"} 0
+http_request_duration_microseconds_count{handler="prometheus"} 0
+http_request_duration_microseconds{handler="receivers",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="receivers",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="receivers",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="receivers"} 0
+http_request_duration_microseconds_count{handler="receivers"} 0
+http_request_duration_microseconds{handler="status",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="status",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="status",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="status"} 0
+http_request_duration_microseconds_count{handler="status"} 0
+# HELP http_request_size_bytes The HTTP request sizes in bytes.
+# TYPE http_request_size_bytes summary
+http_request_size_bytes{handler="add_alerts",quantile="0.5"} 2719
+http_request_size_bytes{handler="add_alerts",quantile="0.9"} 2719
+http_request_size_bytes{handler="add_alerts",quantile="0.99"} 2719
+http_request_size_bytes_sum{handler="add_alerts"} 13595
+http_request_size_bytes_count{handler="add_alerts"} 5
+http_request_size_bytes{handler="add_silence",quantile="0.5"} 358
+http_request_size_bytes{handler="add_silence",quantile="0.9"} 360
+http_request_size_bytes{handler="add_silence",quantile="0.99"} 360
+http_request_size_bytes_sum{handler="add_silence"} 1164
+http_request_size_bytes_count{handler="add_silence"} 3
+http_request_size_bytes{handler="alert_groups",quantile="0.5"} NaN
+http_request_size_bytes{handler="alert_groups",quantile="0.9"} NaN
+http_request_size_bytes{handler="alert_groups",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="alert_groups"} 0
+http_request_size_bytes_count{handler="alert_groups"} 0
+http_request_size_bytes{handler="app",quantile="0.5"} NaN
+http_request_size_bytes{handler="app",quantile="0.9"} NaN
+http_request_size_bytes{handler="app",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="app"} 0
+http_request_size_bytes_count{handler="app"} 0
+http_request_size_bytes{handler="del_silence",quantile="0.5"} NaN
+http_request_size_bytes{handler="del_silence",quantile="0.9"} NaN
+http_request_size_bytes{handler="del_silence",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="del_silence"} 0
+http_request_size_bytes_count{handler="del_silence"} 0
+http_request_size_bytes{handler="get_silence",quantile="0.5"} NaN
+http_request_size_bytes{handler="get_silence",quantile="0.9"} NaN
+http_request_size_bytes{handler="get_silence",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="get_silence"} 0
+http_request_size_bytes_count{handler="get_silence"} 0
+http_request_size_bytes{handler="index",quantile="0.5"} NaN
+http_request_size_bytes{handler="index",quantile="0.9"} NaN
+http_request_size_bytes{handler="index",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="index"} 0
+http_request_size_bytes_count{handler="index"} 0
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="legacy_add_alerts"} 0
+http_request_size_bytes_count{handler="legacy_add_alerts"} 0
+http_request_size_bytes{handler="lib_files",quantile="0.5"} NaN
+http_request_size_bytes{handler="lib_files",quantile="0.9"} NaN
+http_request_size_bytes{handler="lib_files",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="lib_files"} 0
+http_request_size_bytes_count{handler="lib_files"} 0
+http_request_size_bytes{handler="list_alerts",quantile="0.5"} NaN
+http_request_size_bytes{handler="list_alerts",quantile="0.9"} NaN
+http_request_size_bytes{handler="list_alerts",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="list_alerts"} 0
+http_request_size_bytes_count{handler="list_alerts"} 0
+http_request_size_bytes{handler="list_silences",quantile="0.5"} NaN
+http_request_size_bytes{handler="list_silences",quantile="0.9"} NaN
+http_request_size_bytes{handler="list_silences",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="list_silences"} 0
+http_request_size_bytes_count{handler="list_silences"} 0
+http_request_size_bytes{handler="options",quantile="0.5"} NaN
+http_request_size_bytes{handler="options",quantile="0.9"} NaN
+http_request_size_bytes{handler="options",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="options"} 0
+http_request_size_bytes_count{handler="options"} 0
+http_request_size_bytes{handler="prometheus",quantile="0.5"} NaN
+http_request_size_bytes{handler="prometheus",quantile="0.9"} NaN
+http_request_size_bytes{handler="prometheus",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="prometheus"} 0
+http_request_size_bytes_count{handler="prometheus"} 0
+http_request_size_bytes{handler="receivers",quantile="0.5"} NaN
+http_request_size_bytes{handler="receivers",quantile="0.9"} NaN
+http_request_size_bytes{handler="receivers",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="receivers"} 0
+http_request_size_bytes_count{handler="receivers"} 0
+http_request_size_bytes{handler="status",quantile="0.5"} NaN
+http_request_size_bytes{handler="status",quantile="0.9"} NaN
+http_request_size_bytes{handler="status",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="status"} 0
+http_request_size_bytes_count{handler="status"} 0
+# HELP http_requests_total Total number of HTTP requests made.
+# TYPE http_requests_total counter
+http_requests_total{code="200",handler="add_alerts",method="post"} 5
+http_requests_total{code="200",handler="add_silence",method="post"} 3
+# HELP http_response_size_bytes The HTTP response sizes in bytes.
+# TYPE http_response_size_bytes summary
+http_response_size_bytes{handler="add_alerts",quantile="0.5"} 20
+http_response_size_bytes{handler="add_alerts",quantile="0.9"} 20
+http_response_size_bytes{handler="add_alerts",quantile="0.99"} 20
+http_response_size_bytes_sum{handler="add_alerts"} 100
+http_response_size_bytes_count{handler="add_alerts"} 5
+http_response_size_bytes{handler="add_silence",quantile="0.5"} 80
+http_response_size_bytes{handler="add_silence",quantile="0.9"} 80
+http_response_size_bytes{handler="add_silence",quantile="0.99"} 80
+http_response_size_bytes_sum{handler="add_silence"} 240
+http_response_size_bytes_count{handler="add_silence"} 3
+http_response_size_bytes{handler="alert_groups",quantile="0.5"} NaN
+http_response_size_bytes{handler="alert_groups",quantile="0.9"} NaN
+http_response_size_bytes{handler="alert_groups",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="alert_groups"} 0
+http_response_size_bytes_count{handler="alert_groups"} 0
+http_response_size_bytes{handler="app",quantile="0.5"} NaN
+http_response_size_bytes{handler="app",quantile="0.9"} NaN
+http_response_size_bytes{handler="app",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="app"} 0
+http_response_size_bytes_count{handler="app"} 0
+http_response_size_bytes{handler="del_silence",quantile="0.5"} NaN
+http_response_size_bytes{handler="del_silence",quantile="0.9"} NaN
+http_response_size_bytes{handler="del_silence",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="del_silence"} 0
+http_response_size_bytes_count{handler="del_silence"} 0
+http_response_size_bytes{handler="get_silence",quantile="0.5"} NaN
+http_response_size_bytes{handler="get_silence",quantile="0.9"} NaN
+http_response_size_bytes{handler="get_silence",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="get_silence"} 0
+http_response_size_bytes_count{handler="get_silence"} 0
+http_response_size_bytes{handler="index",quantile="0.5"} NaN
+http_response_size_bytes{handler="index",quantile="0.9"} NaN
+http_response_size_bytes{handler="index",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="index"} 0
+http_response_size_bytes_count{handler="index"} 0
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="legacy_add_alerts"} 0
+http_response_size_bytes_count{handler="legacy_add_alerts"} 0
+http_response_size_bytes{handler="lib_files",quantile="0.5"} NaN
+http_response_size_bytes{handler="lib_files",quantile="0.9"} NaN
+http_response_size_bytes{handler="lib_files",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="lib_files"} 0
+http_response_size_bytes_count{handler="lib_files"} 0
+http_response_size_bytes{handler="list_alerts",quantile="0.5"} NaN
+http_response_size_bytes{handler="list_alerts",quantile="0.9"} NaN
+http_response_size_bytes{handler="list_alerts",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="list_alerts"} 0
+http_response_size_bytes_count{handler="list_alerts"} 0
+http_response_size_bytes{handler="list_silences",quantile="0.5"} NaN
+http_response_size_bytes{handler="list_silences",quantile="0.9"} NaN
+http_response_size_bytes{handler="list_silences",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="list_silences"} 0
+http_response_size_bytes_count{handler="list_silences"} 0
+http_response_size_bytes{handler="options",quantile="0.5"} NaN
+http_response_size_bytes{handler="options",quantile="0.9"} NaN
+http_response_size_bytes{handler="options",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="options"} 0
+http_response_size_bytes_count{handler="options"} 0
+http_response_size_bytes{handler="prometheus",quantile="0.5"} NaN
+http_response_size_bytes{handler="prometheus",quantile="0.9"} NaN
+http_response_size_bytes{handler="prometheus",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="prometheus"} 0
+http_response_size_bytes_count{handler="prometheus"} 0
+http_response_size_bytes{handler="receivers",quantile="0.5"} NaN
+http_response_size_bytes{handler="receivers",quantile="0.9"} NaN
+http_response_size_bytes{handler="receivers",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="receivers"} 0
+http_response_size_bytes_count{handler="receivers"} 0
+http_response_size_bytes{handler="status",quantile="0.5"} NaN
+http_response_size_bytes{handler="status",quantile="0.9"} NaN
+http_response_size_bytes{handler="status",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="status"} 0
+http_response_size_bytes_count{handler="status"} 0
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 0.12
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+process_max_fds 1.048576e+06
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+process_open_fds 8
+# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes 1.0891264e+07
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds 1.54886940089e+09
+# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE process_virtual_memory_bytes gauge
+process_virtual_memory_bytes 1.8993152e+07

--- a/internal/mock/0.13.0/api/v1/alerts/groups
+++ b/internal/mock/0.13.0/api/v1/alerts/groups
@@ -19,7 +19,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-01-12T23:45:34.56091428Z",
+                            "startsAt": "2019-01-30T17:31:29.6905263Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -63,11 +63,11 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-01-12T23:45:34.56091428Z",
+                            "startsAt": "2019-01-30T17:31:29.6905263Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "c523259e-1292-4381-9eac-5d937656b42f"
+                                    "17865710-be02-4e51-8d46-dea846d24d38"
                                 ],
                                 "state": "suppressed"
                             }
@@ -86,7 +86,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-01-12T23:45:34.56091428Z",
+                            "startsAt": "2019-01-30T17:31:29.6905263Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -129,7 +129,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-01-12T23:45:34.56091428Z",
+                            "startsAt": "2019-01-30T17:31:29.6905263Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -150,7 +150,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-01-12T23:45:34.56091428Z",
+                            "startsAt": "2019-01-30T17:31:29.6905263Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -171,7 +171,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-01-12T23:45:34.56091428Z",
+                            "startsAt": "2019-01-30T17:31:29.6905263Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -192,7 +192,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-01-12T23:45:34.56091428Z",
+                            "startsAt": "2019-01-30T17:31:29.6905263Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -213,7 +213,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-01-12T23:45:34.56091428Z",
+                            "startsAt": "2019-01-30T17:31:29.6905263Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -234,11 +234,11 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-01-12T23:45:34.56091428Z",
+                            "startsAt": "2019-01-30T17:31:29.6905263Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "c887ecfa-c248-411e-8a7b-4a4943ad0123"
+                                    "228eeaca-7656-442f-a871-fdc58f87f610"
                                 ],
                                 "state": "suppressed"
                             }
@@ -257,12 +257,12 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-01-12T23:45:34.56091428Z",
+                            "startsAt": "2019-01-30T17:31:29.6905263Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "c887ecfa-c248-411e-8a7b-4a4943ad0123",
-                                    "680aee35-6a08-4285-a9a2-93033d3dfd4a"
+                                    "228eeaca-7656-442f-a871-fdc58f87f610",
+                                    "b31ed206-1c67-446e-8937-f3a533658201"
                                 ],
                                 "state": "suppressed"
                             }
@@ -281,11 +281,11 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-01-12T23:45:34.56091428Z",
+                            "startsAt": "2019-01-30T17:31:29.6905263Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "c887ecfa-c248-411e-8a7b-4a4943ad0123"
+                                    "228eeaca-7656-442f-a871-fdc58f87f610"
                                 ],
                                 "state": "suppressed"
                             }
@@ -326,7 +326,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-01-12T23:45:34.56091428Z",
+                            "startsAt": "2019-01-30T17:31:29.6905263Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -369,7 +369,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-01-12T23:45:34.56091428Z",
+                            "startsAt": "2019-01-30T17:31:29.6905263Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -402,27 +402,6 @@
                     "alerts": [
                         {
                             "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "fingerprint": "5cb0dd95e7f3d9c0",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "HTTP_Probe_Failed",
-                                "cluster": "dev",
-                                "instance": "web2",
-                                "job": "node_exporter"
-                            },
-                            "receivers": null,
-                            "startsAt": "2018-01-12T23:45:34.56091428Z",
-                            "status": {
-                                "inhibitedBy": [],
-                                "silencedBy": [],
-                                "state": "active"
-                            }
-                        },
-                        {
-                            "annotations": {
                                 "help": "Example help annotation",
                                 "summary": "Example summary",
                                 "url": "http://localhost/example.html"
@@ -437,21 +416,42 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-01-12T23:45:34.56091428Z",
+                            "startsAt": "2019-01-30T17:31:29.6905263Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "c523259e-1292-4381-9eac-5d937656b42f"
+                                    "17865710-be02-4e51-8d46-dea846d24d38"
                                 ],
                                 "state": "suppressed"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "fingerprint": "5cb0dd95e7f3d9c0",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "HTTP_Probe_Failed",
+                                "cluster": "dev",
+                                "instance": "web2",
+                                "job": "node_exporter"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:31:29.6905263Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
                             }
                         }
                     ],
                     "routeOpts": {
                         "groupBy": [
+                            "service",
                             "alertname",
-                            "cluster",
-                            "service"
+                            "cluster"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,
@@ -475,29 +475,6 @@
                                 "summary": "Example summary"
                             },
                             "endsAt": "0001-01-01T00:00:00Z",
-                            "fingerprint": "af9d8f2f0ccb3970",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "dev",
-                                "instance": "server8",
-                                "job": "node_ping"
-                            },
-                            "receivers": null,
-                            "startsAt": "2018-01-12T23:45:34.56091428Z",
-                            "status": {
-                                "inhibitedBy": null,
-                                "silencedBy": [
-                                    "c887ecfa-c248-411e-8a7b-4a4943ad0123"
-                                ],
-                                "state": "suppressed"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
                             "fingerprint": "0967807e4073b606",
                             "generatorURL": "localhost/prometheus",
                             "labels": {
@@ -507,11 +484,11 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-01-12T23:45:34.56091428Z",
+                            "startsAt": "2019-01-30T17:31:29.6905263Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "c887ecfa-c248-411e-8a7b-4a4943ad0123"
+                                    "228eeaca-7656-442f-a871-fdc58f87f610"
                                 ],
                                 "state": "suppressed"
                             }
@@ -530,12 +507,35 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-01-12T23:45:34.56091428Z",
+                            "startsAt": "2019-01-30T17:31:29.6905263Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "c887ecfa-c248-411e-8a7b-4a4943ad0123",
-                                    "680aee35-6a08-4285-a9a2-93033d3dfd4a"
+                                    "228eeaca-7656-442f-a871-fdc58f87f610",
+                                    "b31ed206-1c67-446e-8937-f3a533658201"
+                                ],
+                                "state": "suppressed"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "fingerprint": "af9d8f2f0ccb3970",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "dev",
+                                "instance": "server8",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:31:29.6905263Z",
+                            "status": {
+                                "inhibitedBy": null,
+                                "silencedBy": [
+                                    "228eeaca-7656-442f-a871-fdc58f87f610"
                                 ],
                                 "state": "suppressed"
                             }
@@ -579,7 +579,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-01-12T23:45:34.56091428Z",
+                            "startsAt": "2019-01-30T17:31:29.6905263Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -600,7 +600,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-01-12T23:45:34.56091428Z",
+                            "startsAt": "2019-01-30T17:31:29.6905263Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -610,9 +610,9 @@
                     ],
                     "routeOpts": {
                         "groupBy": [
+                            "service",
                             "alertname",
-                            "cluster",
-                            "service"
+                            "cluster"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,
@@ -645,7 +645,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-01-12T23:45:34.56091428Z",
+                            "startsAt": "2019-01-30T17:31:29.6905263Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -666,7 +666,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-01-12T23:45:34.56091428Z",
+                            "startsAt": "2019-01-30T17:31:29.6905263Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -687,7 +687,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-01-12T23:45:34.56091428Z",
+                            "startsAt": "2019-01-30T17:31:29.6905263Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -733,7 +733,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-01-12T23:45:34.56091428Z",
+                            "startsAt": "2019-01-30T17:31:29.6905263Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -743,9 +743,9 @@
                     ],
                     "routeOpts": {
                         "groupBy": [
+                            "alertname",
                             "cluster",
-                            "service",
-                            "alertname"
+                            "service"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,

--- a/internal/mock/0.13.0/api/v1/silences
+++ b/internal/mock/0.13.0/api/v1/silences
@@ -4,7 +4,7 @@
             "comment": "Silenced instance",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "c523259e-1292-4381-9eac-5d937656b42f",
+            "id": "17865710-be02-4e51-8d46-dea846d24d38",
             "matchers": [
                 {
                     "isRegex": false,
@@ -12,17 +12,17 @@
                     "value": "web1"
                 }
             ],
-            "startsAt": "2018-01-12T23:45:34.552771094Z",
+            "startsAt": "2019-01-30T17:31:29.6666103Z",
             "status": {
                 "state": "active"
             },
-            "updatedAt": "2018-01-12T23:45:34.552777827Z"
+            "updatedAt": "2019-01-30T17:31:29.6666334Z"
         },
         {
             "comment": "Silenced Host_Down alerts in the dev cluster",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "c887ecfa-c248-411e-8a7b-4a4943ad0123",
+            "id": "228eeaca-7656-442f-a871-fdc58f87f610",
             "matchers": [
                 {
                     "isRegex": false,
@@ -35,17 +35,17 @@
                     "value": "dev"
                 }
             ],
-            "startsAt": "2018-01-12T23:45:34.555366166Z",
+            "startsAt": "2019-01-30T17:31:29.6731016Z",
             "status": {
                 "state": "active"
             },
-            "updatedAt": "2018-01-12T23:45:34.555370752Z"
+            "updatedAt": "2019-01-30T17:31:29.673123Z"
         },
         {
             "comment": "Silenced server7",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "680aee35-6a08-4285-a9a2-93033d3dfd4a",
+            "id": "b31ed206-1c67-446e-8937-f3a533658201",
             "matchers": [
                 {
                     "isRegex": false,
@@ -53,11 +53,11 @@
                     "value": "server7"
                 }
             ],
-            "startsAt": "2018-01-12T23:45:34.557806458Z",
+            "startsAt": "2019-01-30T17:31:29.6816255Z",
             "status": {
                 "state": "active"
             },
-            "updatedAt": "2018-01-12T23:45:34.557811545Z"
+            "updatedAt": "2019-01-30T17:31:29.6816544Z"
         }
     ],
     "status": "success"

--- a/internal/mock/0.13.0/api/v1/status
+++ b/internal/mock/0.13.0/api/v1/status
@@ -75,16 +75,16 @@
         "meshStatus": {
             "connections": [],
             "name": "02:42:ac:11:00:02",
-            "nickName": "6867200b225a",
+            "nickName": "7e7ab6c54cf0",
             "peers": [
                 {
                     "name": "02:42:ac:11:00:02",
-                    "nickName": "6867200b225a",
-                    "uid": 13204550549420218031
+                    "nickName": "7e7ab6c54cf0",
+                    "uid": 8303912432754838329
                 }
             ]
         },
-        "uptime": "2018-01-12T23:45:19.261437769Z",
+        "uptime": "2019-01-30T17:31:14.4779349Z",
         "versionInfo": {
             "branch": "HEAD",
             "buildDate": "20180112-10:32:46",

--- a/internal/mock/0.13.0/metrics
+++ b/internal/mock/0.13.0/metrics
@@ -1,0 +1,461 @@
+# HELP alertmanager_alerts How many alerts by state.
+# TYPE alertmanager_alerts gauge
+alertmanager_alerts{state="active"} 8
+alertmanager_alerts{state="suppressed"} 4
+# HELP alertmanager_alerts_invalid_total The total number of received alerts that were invalid.
+# TYPE alertmanager_alerts_invalid_total counter
+alertmanager_alerts_invalid_total 0
+# HELP alertmanager_alerts_received_total The total number of received alerts.
+# TYPE alertmanager_alerts_received_total counter
+alertmanager_alerts_received_total{status="firing"} 60
+# HELP alertmanager_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which alertmanager was built.
+# TYPE alertmanager_build_info gauge
+alertmanager_build_info{branch="HEAD",goversion="go1.9.2",revision="fb713f6d8239b57c646cae30f78e8b4b8861a1aa",version="0.13.0"} 1
+# HELP alertmanager_config_hash Hash of the currently loaded alertmanager configuration.
+# TYPE alertmanager_config_hash gauge
+alertmanager_config_hash 6.2645753076152e+13
+# HELP alertmanager_config_last_reload_success_timestamp_seconds Timestamp of the last successful configuration reload.
+# TYPE alertmanager_config_last_reload_success_timestamp_seconds gauge
+alertmanager_config_last_reload_success_timestamp_seconds 1.548869474e+09
+# HELP alertmanager_config_last_reload_successful Whether the last configuration reload attempt was successful.
+# TYPE alertmanager_config_last_reload_successful gauge
+alertmanager_config_last_reload_successful 1
+# HELP alertmanager_nflog_gc_duration_seconds Duration of the last notification log garbage collection cycle.
+# TYPE alertmanager_nflog_gc_duration_seconds summary
+alertmanager_nflog_gc_duration_seconds{quantile="0.5"} NaN
+alertmanager_nflog_gc_duration_seconds{quantile="0.9"} NaN
+alertmanager_nflog_gc_duration_seconds{quantile="0.99"} NaN
+alertmanager_nflog_gc_duration_seconds_sum 0
+alertmanager_nflog_gc_duration_seconds_count 0
+# HELP alertmanager_nflog_queries_total Number of notification log queries were received.
+# TYPE alertmanager_nflog_queries_total counter
+alertmanager_nflog_queries_total 0
+# HELP alertmanager_nflog_query_duration_seconds Duration of notification log query evaluation.
+# TYPE alertmanager_nflog_query_duration_seconds histogram
+alertmanager_nflog_query_duration_seconds_bucket{le="0.005"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.01"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.025"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.05"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.1"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.25"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="1"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="2.5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="10"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="+Inf"} 0
+alertmanager_nflog_query_duration_seconds_sum 0
+alertmanager_nflog_query_duration_seconds_count 0
+# HELP alertmanager_nflog_query_errors_total Number notification log received queries that failed.
+# TYPE alertmanager_nflog_query_errors_total counter
+alertmanager_nflog_query_errors_total 0
+# HELP alertmanager_nflog_snapshot_duration_seconds Duration of the last notification log snapshot.
+# TYPE alertmanager_nflog_snapshot_duration_seconds summary
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.5"} NaN
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.9"} NaN
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.99"} NaN
+alertmanager_nflog_snapshot_duration_seconds_sum 0
+alertmanager_nflog_snapshot_duration_seconds_count 0
+# HELP alertmanager_notifications_failed_total The total number of failed notifications.
+# TYPE alertmanager_notifications_failed_total counter
+alertmanager_notifications_failed_total{integration="email"} 0
+alertmanager_notifications_failed_total{integration="hipchat"} 0
+alertmanager_notifications_failed_total{integration="opsgenie"} 0
+alertmanager_notifications_failed_total{integration="pagerduty"} 0
+alertmanager_notifications_failed_total{integration="pushover"} 0
+alertmanager_notifications_failed_total{integration="slack"} 0
+alertmanager_notifications_failed_total{integration="victorops"} 0
+alertmanager_notifications_failed_total{integration="webhook"} 0
+alertmanager_notifications_failed_total{integration="wechat"} 0
+# HELP alertmanager_notifications_total The total number of attempted notifications.
+# TYPE alertmanager_notifications_total counter
+alertmanager_notifications_total{integration="email"} 0
+alertmanager_notifications_total{integration="hipchat"} 0
+alertmanager_notifications_total{integration="opsgenie"} 0
+alertmanager_notifications_total{integration="pagerduty"} 0
+alertmanager_notifications_total{integration="pushover"} 0
+alertmanager_notifications_total{integration="slack"} 0
+alertmanager_notifications_total{integration="victorops"} 0
+alertmanager_notifications_total{integration="webhook"} 0
+alertmanager_notifications_total{integration="wechat"} 0
+# HELP alertmanager_peer_position Position the Alertmanager instance believes it's in. The position determines a peer's behavior in the cluster.
+# TYPE alertmanager_peer_position gauge
+alertmanager_peer_position 0
+# HELP alertmanager_silences How many silences by state.
+# TYPE alertmanager_silences gauge
+alertmanager_silences{state="active"} 3
+alertmanager_silences{state="expired"} 0
+alertmanager_silences{state="pending"} 0
+# HELP alertmanager_silences_gc_duration_seconds Duration of the last silence garbage collection cycle.
+# TYPE alertmanager_silences_gc_duration_seconds summary
+alertmanager_silences_gc_duration_seconds{quantile="0.5"} NaN
+alertmanager_silences_gc_duration_seconds{quantile="0.9"} NaN
+alertmanager_silences_gc_duration_seconds{quantile="0.99"} NaN
+alertmanager_silences_gc_duration_seconds_sum 0
+alertmanager_silences_gc_duration_seconds_count 0
+# HELP alertmanager_silences_queries_total How many silence queries were received.
+# TYPE alertmanager_silences_queries_total counter
+alertmanager_silences_queries_total 51
+# HELP alertmanager_silences_query_duration_seconds Duration of silence query evaluation.
+# TYPE alertmanager_silences_query_duration_seconds histogram
+alertmanager_silences_query_duration_seconds_bucket{le="0.005"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.01"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.025"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.05"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.1"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.25"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.5"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="1"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="2.5"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="5"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="10"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="+Inf"} 48
+alertmanager_silences_query_duration_seconds_sum 0.0023302000000000006
+alertmanager_silences_query_duration_seconds_count 48
+# HELP alertmanager_silences_query_errors_total How many silence received queries did not succeed.
+# TYPE alertmanager_silences_query_errors_total counter
+alertmanager_silences_query_errors_total 0
+# HELP alertmanager_silences_snapshot_duration_seconds Duration of the last silence snapshot.
+# TYPE alertmanager_silences_snapshot_duration_seconds summary
+alertmanager_silences_snapshot_duration_seconds{quantile="0.5"} NaN
+alertmanager_silences_snapshot_duration_seconds{quantile="0.9"} NaN
+alertmanager_silences_snapshot_duration_seconds{quantile="0.99"} NaN
+alertmanager_silences_snapshot_duration_seconds_sum 0
+alertmanager_silences_snapshot_duration_seconds_count 0
+# HELP alertmanager_silences_snapshot_size_bytes Size of the last silence snapshot in bytes.
+# TYPE alertmanager_silences_snapshot_size_bytes gauge
+alertmanager_silences_snapshot_size_bytes 0
+# HELP go_gc_duration_seconds A summary of the GC invocation durations.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0"} 0.0007559
+go_gc_duration_seconds{quantile="0.25"} 0.0007559
+go_gc_duration_seconds{quantile="0.5"} 0.0007961
+go_gc_duration_seconds{quantile="0.75"} 0.0007961
+go_gc_duration_seconds{quantile="1"} 0.0007961
+go_gc_duration_seconds_sum 0.001552
+go_gc_duration_seconds_count 2
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 104
+# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+# TYPE go_memstats_alloc_bytes gauge
+go_memstats_alloc_bytes 4.921848e+06
+# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
+# TYPE go_memstats_alloc_bytes_total counter
+go_memstats_alloc_bytes_total 5.769256e+06
+# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
+# TYPE go_memstats_buck_hash_sys_bytes gauge
+go_memstats_buck_hash_sys_bytes 1.443404e+06
+# HELP go_memstats_frees_total Total number of frees.
+# TYPE go_memstats_frees_total counter
+go_memstats_frees_total 6795
+# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+# TYPE go_memstats_gc_sys_bytes gauge
+go_memstats_gc_sys_bytes 438272
+# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
+# TYPE go_memstats_heap_alloc_bytes gauge
+go_memstats_heap_alloc_bytes 4.921848e+06
+# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
+# TYPE go_memstats_heap_idle_bytes gauge
+go_memstats_heap_idle_bytes 630784
+# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
+# TYPE go_memstats_heap_inuse_bytes gauge
+go_memstats_heap_inuse_bytes 5.890048e+06
+# HELP go_memstats_heap_objects Number of allocated objects.
+# TYPE go_memstats_heap_objects gauge
+go_memstats_heap_objects 18578
+# HELP go_memstats_heap_released_bytes_total Total number of heap bytes released to OS.
+# TYPE go_memstats_heap_released_bytes_total counter
+go_memstats_heap_released_bytes_total 0
+# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
+# TYPE go_memstats_heap_sys_bytes gauge
+go_memstats_heap_sys_bytes 6.520832e+06
+# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
+# TYPE go_memstats_last_gc_time_seconds gauge
+go_memstats_last_gc_time_seconds 1.5488694896695564e+09
+# HELP go_memstats_lookups_total Total number of pointer lookups.
+# TYPE go_memstats_lookups_total counter
+go_memstats_lookups_total 32
+# HELP go_memstats_mallocs_total Total number of mallocs.
+# TYPE go_memstats_mallocs_total counter
+go_memstats_mallocs_total 25373
+# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
+# TYPE go_memstats_mcache_inuse_bytes gauge
+go_memstats_mcache_inuse_bytes 3472
+# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
+# TYPE go_memstats_mcache_sys_bytes gauge
+go_memstats_mcache_sys_bytes 16384
+# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
+# TYPE go_memstats_mspan_inuse_bytes gauge
+go_memstats_mspan_inuse_bytes 66576
+# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
+# TYPE go_memstats_mspan_sys_bytes gauge
+go_memstats_mspan_sys_bytes 81920
+# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
+# TYPE go_memstats_next_gc_bytes gauge
+go_memstats_next_gc_bytes 8.839856e+06
+# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
+# TYPE go_memstats_other_sys_bytes gauge
+go_memstats_other_sys_bytes 746156
+# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
+# TYPE go_memstats_stack_inuse_bytes gauge
+go_memstats_stack_inuse_bytes 819200
+# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
+# TYPE go_memstats_stack_sys_bytes gauge
+go_memstats_stack_sys_bytes 819200
+# HELP go_memstats_sys_bytes Number of bytes obtained by system. Sum of all system allocations.
+# TYPE go_memstats_sys_bytes gauge
+go_memstats_sys_bytes 1.0066168e+07
+# HELP http_request_duration_microseconds The HTTP request latencies in microseconds.
+# TYPE http_request_duration_microseconds summary
+http_request_duration_microseconds{handler="add_alerts",quantile="0.5"} 1248.6
+http_request_duration_microseconds{handler="add_alerts",quantile="0.9"} 1397
+http_request_duration_microseconds{handler="add_alerts",quantile="0.99"} 1397
+http_request_duration_microseconds_sum{handler="add_alerts"} 6450.500000000001
+http_request_duration_microseconds_count{handler="add_alerts"} 5
+http_request_duration_microseconds{handler="add_silence",quantile="0.5"} 404.6
+http_request_duration_microseconds{handler="add_silence",quantile="0.9"} 722.1
+http_request_duration_microseconds{handler="add_silence",quantile="0.99"} 722.1
+http_request_duration_microseconds_sum{handler="add_silence"} 2245.7999999999997
+http_request_duration_microseconds_count{handler="add_silence"} 3
+http_request_duration_microseconds{handler="alert_groups",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="alert_groups",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="alert_groups",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="alert_groups"} 0
+http_request_duration_microseconds_count{handler="alert_groups"} 0
+http_request_duration_microseconds{handler="app",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="app",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="app",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="app"} 0
+http_request_duration_microseconds_count{handler="app"} 0
+http_request_duration_microseconds{handler="del_silence",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="del_silence",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="del_silence",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="del_silence"} 0
+http_request_duration_microseconds_count{handler="del_silence"} 0
+http_request_duration_microseconds{handler="get_silence",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="get_silence",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="get_silence",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="get_silence"} 0
+http_request_duration_microseconds_count{handler="get_silence"} 0
+http_request_duration_microseconds{handler="index",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="index",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="index",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="index"} 0
+http_request_duration_microseconds_count{handler="index"} 0
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="legacy_add_alerts"} 0
+http_request_duration_microseconds_count{handler="legacy_add_alerts"} 0
+http_request_duration_microseconds{handler="lib_files",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="lib_files",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="lib_files",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="lib_files"} 0
+http_request_duration_microseconds_count{handler="lib_files"} 0
+http_request_duration_microseconds{handler="list_alerts",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="list_alerts",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="list_alerts",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="list_alerts"} 0
+http_request_duration_microseconds_count{handler="list_alerts"} 0
+http_request_duration_microseconds{handler="list_silences",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="list_silences",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="list_silences",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="list_silences"} 0
+http_request_duration_microseconds_count{handler="list_silences"} 0
+http_request_duration_microseconds{handler="options",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="options",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="options",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="options"} 0
+http_request_duration_microseconds_count{handler="options"} 0
+http_request_duration_microseconds{handler="prometheus",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="prometheus",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="prometheus",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="prometheus"} 0
+http_request_duration_microseconds_count{handler="prometheus"} 0
+http_request_duration_microseconds{handler="receivers",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="receivers",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="receivers",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="receivers"} 0
+http_request_duration_microseconds_count{handler="receivers"} 0
+http_request_duration_microseconds{handler="status",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="status",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="status",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="status"} 0
+http_request_duration_microseconds_count{handler="status"} 0
+# HELP http_request_size_bytes The HTTP request sizes in bytes.
+# TYPE http_request_size_bytes summary
+http_request_size_bytes{handler="add_alerts",quantile="0.5"} 2719
+http_request_size_bytes{handler="add_alerts",quantile="0.9"} 2719
+http_request_size_bytes{handler="add_alerts",quantile="0.99"} 2719
+http_request_size_bytes_sum{handler="add_alerts"} 13595
+http_request_size_bytes_count{handler="add_alerts"} 5
+http_request_size_bytes{handler="add_silence",quantile="0.5"} 358
+http_request_size_bytes{handler="add_silence",quantile="0.9"} 360
+http_request_size_bytes{handler="add_silence",quantile="0.99"} 360
+http_request_size_bytes_sum{handler="add_silence"} 1164
+http_request_size_bytes_count{handler="add_silence"} 3
+http_request_size_bytes{handler="alert_groups",quantile="0.5"} NaN
+http_request_size_bytes{handler="alert_groups",quantile="0.9"} NaN
+http_request_size_bytes{handler="alert_groups",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="alert_groups"} 0
+http_request_size_bytes_count{handler="alert_groups"} 0
+http_request_size_bytes{handler="app",quantile="0.5"} NaN
+http_request_size_bytes{handler="app",quantile="0.9"} NaN
+http_request_size_bytes{handler="app",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="app"} 0
+http_request_size_bytes_count{handler="app"} 0
+http_request_size_bytes{handler="del_silence",quantile="0.5"} NaN
+http_request_size_bytes{handler="del_silence",quantile="0.9"} NaN
+http_request_size_bytes{handler="del_silence",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="del_silence"} 0
+http_request_size_bytes_count{handler="del_silence"} 0
+http_request_size_bytes{handler="get_silence",quantile="0.5"} NaN
+http_request_size_bytes{handler="get_silence",quantile="0.9"} NaN
+http_request_size_bytes{handler="get_silence",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="get_silence"} 0
+http_request_size_bytes_count{handler="get_silence"} 0
+http_request_size_bytes{handler="index",quantile="0.5"} NaN
+http_request_size_bytes{handler="index",quantile="0.9"} NaN
+http_request_size_bytes{handler="index",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="index"} 0
+http_request_size_bytes_count{handler="index"} 0
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="legacy_add_alerts"} 0
+http_request_size_bytes_count{handler="legacy_add_alerts"} 0
+http_request_size_bytes{handler="lib_files",quantile="0.5"} NaN
+http_request_size_bytes{handler="lib_files",quantile="0.9"} NaN
+http_request_size_bytes{handler="lib_files",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="lib_files"} 0
+http_request_size_bytes_count{handler="lib_files"} 0
+http_request_size_bytes{handler="list_alerts",quantile="0.5"} NaN
+http_request_size_bytes{handler="list_alerts",quantile="0.9"} NaN
+http_request_size_bytes{handler="list_alerts",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="list_alerts"} 0
+http_request_size_bytes_count{handler="list_alerts"} 0
+http_request_size_bytes{handler="list_silences",quantile="0.5"} NaN
+http_request_size_bytes{handler="list_silences",quantile="0.9"} NaN
+http_request_size_bytes{handler="list_silences",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="list_silences"} 0
+http_request_size_bytes_count{handler="list_silences"} 0
+http_request_size_bytes{handler="options",quantile="0.5"} NaN
+http_request_size_bytes{handler="options",quantile="0.9"} NaN
+http_request_size_bytes{handler="options",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="options"} 0
+http_request_size_bytes_count{handler="options"} 0
+http_request_size_bytes{handler="prometheus",quantile="0.5"} NaN
+http_request_size_bytes{handler="prometheus",quantile="0.9"} NaN
+http_request_size_bytes{handler="prometheus",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="prometheus"} 0
+http_request_size_bytes_count{handler="prometheus"} 0
+http_request_size_bytes{handler="receivers",quantile="0.5"} NaN
+http_request_size_bytes{handler="receivers",quantile="0.9"} NaN
+http_request_size_bytes{handler="receivers",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="receivers"} 0
+http_request_size_bytes_count{handler="receivers"} 0
+http_request_size_bytes{handler="status",quantile="0.5"} NaN
+http_request_size_bytes{handler="status",quantile="0.9"} NaN
+http_request_size_bytes{handler="status",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="status"} 0
+http_request_size_bytes_count{handler="status"} 0
+# HELP http_requests_total Total number of HTTP requests made.
+# TYPE http_requests_total counter
+http_requests_total{code="200",handler="add_alerts",method="post"} 5
+http_requests_total{code="200",handler="add_silence",method="post"} 3
+# HELP http_response_size_bytes The HTTP response sizes in bytes.
+# TYPE http_response_size_bytes summary
+http_response_size_bytes{handler="add_alerts",quantile="0.5"} 20
+http_response_size_bytes{handler="add_alerts",quantile="0.9"} 20
+http_response_size_bytes{handler="add_alerts",quantile="0.99"} 20
+http_response_size_bytes_sum{handler="add_alerts"} 100
+http_response_size_bytes_count{handler="add_alerts"} 5
+http_response_size_bytes{handler="add_silence",quantile="0.5"} 80
+http_response_size_bytes{handler="add_silence",quantile="0.9"} 80
+http_response_size_bytes{handler="add_silence",quantile="0.99"} 80
+http_response_size_bytes_sum{handler="add_silence"} 240
+http_response_size_bytes_count{handler="add_silence"} 3
+http_response_size_bytes{handler="alert_groups",quantile="0.5"} NaN
+http_response_size_bytes{handler="alert_groups",quantile="0.9"} NaN
+http_response_size_bytes{handler="alert_groups",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="alert_groups"} 0
+http_response_size_bytes_count{handler="alert_groups"} 0
+http_response_size_bytes{handler="app",quantile="0.5"} NaN
+http_response_size_bytes{handler="app",quantile="0.9"} NaN
+http_response_size_bytes{handler="app",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="app"} 0
+http_response_size_bytes_count{handler="app"} 0
+http_response_size_bytes{handler="del_silence",quantile="0.5"} NaN
+http_response_size_bytes{handler="del_silence",quantile="0.9"} NaN
+http_response_size_bytes{handler="del_silence",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="del_silence"} 0
+http_response_size_bytes_count{handler="del_silence"} 0
+http_response_size_bytes{handler="get_silence",quantile="0.5"} NaN
+http_response_size_bytes{handler="get_silence",quantile="0.9"} NaN
+http_response_size_bytes{handler="get_silence",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="get_silence"} 0
+http_response_size_bytes_count{handler="get_silence"} 0
+http_response_size_bytes{handler="index",quantile="0.5"} NaN
+http_response_size_bytes{handler="index",quantile="0.9"} NaN
+http_response_size_bytes{handler="index",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="index"} 0
+http_response_size_bytes_count{handler="index"} 0
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="legacy_add_alerts"} 0
+http_response_size_bytes_count{handler="legacy_add_alerts"} 0
+http_response_size_bytes{handler="lib_files",quantile="0.5"} NaN
+http_response_size_bytes{handler="lib_files",quantile="0.9"} NaN
+http_response_size_bytes{handler="lib_files",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="lib_files"} 0
+http_response_size_bytes_count{handler="lib_files"} 0
+http_response_size_bytes{handler="list_alerts",quantile="0.5"} NaN
+http_response_size_bytes{handler="list_alerts",quantile="0.9"} NaN
+http_response_size_bytes{handler="list_alerts",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="list_alerts"} 0
+http_response_size_bytes_count{handler="list_alerts"} 0
+http_response_size_bytes{handler="list_silences",quantile="0.5"} NaN
+http_response_size_bytes{handler="list_silences",quantile="0.9"} NaN
+http_response_size_bytes{handler="list_silences",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="list_silences"} 0
+http_response_size_bytes_count{handler="list_silences"} 0
+http_response_size_bytes{handler="options",quantile="0.5"} NaN
+http_response_size_bytes{handler="options",quantile="0.9"} NaN
+http_response_size_bytes{handler="options",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="options"} 0
+http_response_size_bytes_count{handler="options"} 0
+http_response_size_bytes{handler="prometheus",quantile="0.5"} NaN
+http_response_size_bytes{handler="prometheus",quantile="0.9"} NaN
+http_response_size_bytes{handler="prometheus",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="prometheus"} 0
+http_response_size_bytes_count{handler="prometheus"} 0
+http_response_size_bytes{handler="receivers",quantile="0.5"} NaN
+http_response_size_bytes{handler="receivers",quantile="0.9"} NaN
+http_response_size_bytes{handler="receivers",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="receivers"} 0
+http_response_size_bytes_count{handler="receivers"} 0
+http_response_size_bytes{handler="status",quantile="0.5"} NaN
+http_response_size_bytes{handler="status",quantile="0.9"} NaN
+http_response_size_bytes{handler="status",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="status"} 0
+http_response_size_bytes_count{handler="status"} 0
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 0.17
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+process_max_fds 1.048576e+06
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+process_open_fds 8
+# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes 1.1481088e+07
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds 1.54886947336e+09
+# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE process_virtual_memory_bytes gauge
+process_virtual_memory_bytes 2.1233664e+07

--- a/internal/mock/0.14.0/api/v1/alerts/groups
+++ b/internal/mock/0.14.0/api/v1/alerts/groups
@@ -19,7 +19,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-02-13T22:41:17.691429964Z",
+                            "startsAt": "2019-01-30T17:32:42.4394189Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -49,6 +49,27 @@
                     "alerts": [
                         {
                             "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "fingerprint": "5cb0dd95e7f3d9c0",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "HTTP_Probe_Failed",
+                                "cluster": "dev",
+                                "instance": "web2",
+                                "job": "node_exporter"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:32:42.4394189Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
                                 "help": "Example help annotation",
                                 "summary": "Example summary",
                                 "url": "http://localhost/example.html"
@@ -63,34 +84,13 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-02-13T22:41:17.691429964Z",
+                            "startsAt": "2019-01-30T17:32:42.4394189Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "9a32b09e-0c74-4f69-8ad9-600bdcc7b4cc"
+                                    "f447c3b3-51d7-4148-8674-c5cbc369c645"
                                 ],
                                 "state": "suppressed"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "fingerprint": "5cb0dd95e7f3d9c0",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "HTTP_Probe_Failed",
-                                "cluster": "dev",
-                                "instance": "web2",
-                                "job": "node_exporter"
-                            },
-                            "receivers": null,
-                            "startsAt": "2018-02-13T22:41:17.691429964Z",
-                            "status": {
-                                "inhibitedBy": [],
-                                "silencedBy": [],
-                                "state": "active"
                             }
                         }
                     ],
@@ -119,27 +119,6 @@
                                 "summary": "Example summary"
                             },
                             "endsAt": "0001-01-01T00:00:00Z",
-                            "fingerprint": "3bdb8b68bdce2ae0",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "prod",
-                                "instance": "server2",
-                                "job": "node_ping"
-                            },
-                            "receivers": null,
-                            "startsAt": "2018-02-13T22:41:17.691429964Z",
-                            "status": {
-                                "inhibitedBy": [],
-                                "silencedBy": [],
-                                "state": "active"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
                             "fingerprint": "24e4121619386f95",
                             "generatorURL": "localhost/prometheus",
                             "labels": {
@@ -149,7 +128,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-02-13T22:41:17.691429964Z",
+                            "startsAt": "2019-01-30T17:32:42.4394189Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -170,7 +149,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-02-13T22:41:17.691429964Z",
+                            "startsAt": "2019-01-30T17:32:42.4394189Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -191,7 +170,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-02-13T22:41:17.691429964Z",
+                            "startsAt": "2019-01-30T17:32:42.4394189Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -212,11 +191,11 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-02-13T22:41:17.691429964Z",
+                            "startsAt": "2019-01-30T17:32:42.4394189Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "1167d99e-60dd-4576-b514-64cf03891be2"
+                                    "a610b58d-4452-4c4c-963c-1c666c6751f2"
                                 ],
                                 "state": "suppressed"
                             }
@@ -235,12 +214,12 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-02-13T22:41:17.691429964Z",
+                            "startsAt": "2019-01-30T17:32:42.4394189Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "1167d99e-60dd-4576-b514-64cf03891be2",
-                                    "f70e2eae-1d71-497b-9dd1-3d83b30aaf63"
+                                    "a610b58d-4452-4c4c-963c-1c666c6751f2",
+                                    "90c42c9d-f106-4684-a848-96c31d88f5d1"
                                 ],
                                 "state": "suppressed"
                             }
@@ -259,11 +238,11 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-02-13T22:41:17.691429964Z",
+                            "startsAt": "2019-01-30T17:32:42.4394189Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "1167d99e-60dd-4576-b514-64cf03891be2"
+                                    "a610b58d-4452-4c4c-963c-1c666c6751f2"
                                 ],
                                 "state": "suppressed"
                             }
@@ -283,7 +262,28 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-02-13T22:41:17.691429964Z",
+                            "startsAt": "2019-01-30T17:32:42.4394189Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "fingerprint": "3bdb8b68bdce2ae0",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "prod",
+                                "instance": "server2",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:32:42.4394189Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -326,7 +326,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-02-13T22:41:17.691429964Z",
+                            "startsAt": "2019-01-30T17:32:42.4394189Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -369,7 +369,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-02-13T22:41:17.691429964Z",
+                            "startsAt": "2019-01-30T17:32:42.4394189Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -379,9 +379,9 @@
                     ],
                     "routeOpts": {
                         "groupBy": [
-                            "service",
                             "alertname",
-                            "cluster"
+                            "cluster",
+                            "service"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,
@@ -402,6 +402,27 @@
                     "alerts": [
                         {
                             "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "fingerprint": "5cb0dd95e7f3d9c0",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "HTTP_Probe_Failed",
+                                "cluster": "dev",
+                                "instance": "web2",
+                                "job": "node_exporter"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:32:42.4394189Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
                                 "help": "Example help annotation",
                                 "summary": "Example summary",
                                 "url": "http://localhost/example.html"
@@ -416,34 +437,13 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-02-13T22:41:17.691429964Z",
+                            "startsAt": "2019-01-30T17:32:42.4394189Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "9a32b09e-0c74-4f69-8ad9-600bdcc7b4cc"
+                                    "f447c3b3-51d7-4148-8674-c5cbc369c645"
                                 ],
                                 "state": "suppressed"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "fingerprint": "5cb0dd95e7f3d9c0",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "HTTP_Probe_Failed",
-                                "cluster": "dev",
-                                "instance": "web2",
-                                "job": "node_exporter"
-                            },
-                            "receivers": null,
-                            "startsAt": "2018-02-13T22:41:17.691429964Z",
-                            "status": {
-                                "inhibitedBy": [],
-                                "silencedBy": [],
-                                "state": "active"
                             }
                         }
                     ],
@@ -475,29 +475,6 @@
                                 "summary": "Example summary"
                             },
                             "endsAt": "0001-01-01T00:00:00Z",
-                            "fingerprint": "af9d8f2f0ccb3970",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "dev",
-                                "instance": "server8",
-                                "job": "node_ping"
-                            },
-                            "receivers": null,
-                            "startsAt": "2018-02-13T22:41:17.691429964Z",
-                            "status": {
-                                "inhibitedBy": null,
-                                "silencedBy": [
-                                    "1167d99e-60dd-4576-b514-64cf03891be2"
-                                ],
-                                "state": "suppressed"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
                             "fingerprint": "0967807e4073b606",
                             "generatorURL": "localhost/prometheus",
                             "labels": {
@@ -507,11 +484,11 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-02-13T22:41:17.691429964Z",
+                            "startsAt": "2019-01-30T17:32:42.4394189Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "1167d99e-60dd-4576-b514-64cf03891be2"
+                                    "a610b58d-4452-4c4c-963c-1c666c6751f2"
                                 ],
                                 "state": "suppressed"
                             }
@@ -530,12 +507,35 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-02-13T22:41:17.691429964Z",
+                            "startsAt": "2019-01-30T17:32:42.4394189Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "1167d99e-60dd-4576-b514-64cf03891be2",
-                                    "f70e2eae-1d71-497b-9dd1-3d83b30aaf63"
+                                    "a610b58d-4452-4c4c-963c-1c666c6751f2",
+                                    "90c42c9d-f106-4684-a848-96c31d88f5d1"
+                                ],
+                                "state": "suppressed"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "fingerprint": "af9d8f2f0ccb3970",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "dev",
+                                "instance": "server8",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:32:42.4394189Z",
+                            "status": {
+                                "inhibitedBy": null,
+                                "silencedBy": [
+                                    "a610b58d-4452-4c4c-963c-1c666c6751f2"
                                 ],
                                 "state": "suppressed"
                             }
@@ -543,9 +543,9 @@
                     ],
                     "routeOpts": {
                         "groupBy": [
+                            "alertname",
                             "cluster",
-                            "service",
-                            "alertname"
+                            "service"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,
@@ -579,7 +579,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-02-13T22:41:17.691429964Z",
+                            "startsAt": "2019-01-30T17:32:42.4394189Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -600,7 +600,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-02-13T22:41:17.691429964Z",
+                            "startsAt": "2019-01-30T17:32:42.4394189Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -610,9 +610,9 @@
                     ],
                     "routeOpts": {
                         "groupBy": [
-                            "alertname",
                             "cluster",
-                            "service"
+                            "service",
+                            "alertname"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,
@@ -645,7 +645,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-02-13T22:41:17.691429964Z",
+                            "startsAt": "2019-01-30T17:32:42.4394189Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -666,7 +666,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-02-13T22:41:17.691429964Z",
+                            "startsAt": "2019-01-30T17:32:42.4394189Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -687,7 +687,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-02-13T22:41:17.691429964Z",
+                            "startsAt": "2019-01-30T17:32:42.4394189Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -697,9 +697,9 @@
                     ],
                     "routeOpts": {
                         "groupBy": [
-                            "service",
                             "alertname",
-                            "cluster"
+                            "cluster",
+                            "service"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,
@@ -733,7 +733,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-02-13T22:41:17.691429964Z",
+                            "startsAt": "2019-01-30T17:32:42.4394189Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],

--- a/internal/mock/0.14.0/api/v1/silences
+++ b/internal/mock/0.14.0/api/v1/silences
@@ -1,10 +1,28 @@
 {
     "data": [
         {
+            "comment": "Silenced server7",
+            "createdBy": "john@example.com",
+            "endsAt": "2063-01-01T00:00:00Z",
+            "id": "90c42c9d-f106-4684-a848-96c31d88f5d1",
+            "matchers": [
+                {
+                    "isRegex": false,
+                    "name": "instance",
+                    "value": "server7"
+                }
+            ],
+            "startsAt": "2019-01-30T17:32:42.4340831Z",
+            "status": {
+                "state": "active"
+            },
+            "updatedAt": "2019-01-30T17:32:42.4341003Z"
+        },
+        {
             "comment": "Silenced instance",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "9a32b09e-0c74-4f69-8ad9-600bdcc7b4cc",
+            "id": "f447c3b3-51d7-4148-8674-c5cbc369c645",
             "matchers": [
                 {
                     "isRegex": false,
@@ -12,17 +30,17 @@
                     "value": "web1"
                 }
             ],
-            "startsAt": "2018-02-13T22:41:17.682678891Z",
+            "startsAt": "2019-01-30T17:32:42.4248399Z",
             "status": {
                 "state": "active"
             },
-            "updatedAt": "2018-02-13T22:41:17.682685244Z"
+            "updatedAt": "2019-01-30T17:32:42.424862Z"
         },
         {
             "comment": "Silenced Host_Down alerts in the dev cluster",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "1167d99e-60dd-4576-b514-64cf03891be2",
+            "id": "a610b58d-4452-4c4c-963c-1c666c6751f2",
             "matchers": [
                 {
                     "isRegex": false,
@@ -35,29 +53,11 @@
                     "value": "dev"
                 }
             ],
-            "startsAt": "2018-02-13T22:41:17.685938633Z",
+            "startsAt": "2019-01-30T17:32:42.4293615Z",
             "status": {
                 "state": "active"
             },
-            "updatedAt": "2018-02-13T22:41:17.685945586Z"
-        },
-        {
-            "comment": "Silenced server7",
-            "createdBy": "john@example.com",
-            "endsAt": "2063-01-01T00:00:00Z",
-            "id": "f70e2eae-1d71-497b-9dd1-3d83b30aaf63",
-            "matchers": [
-                {
-                    "isRegex": false,
-                    "name": "instance",
-                    "value": "server7"
-                }
-            ],
-            "startsAt": "2018-02-13T22:41:17.688769461Z",
-            "status": {
-                "state": "active"
-            },
-            "updatedAt": "2018-02-13T22:41:17.68877405Z"
+            "updatedAt": "2019-01-30T17:32:42.4293878Z"
         }
     ],
     "status": "success"

--- a/internal/mock/0.14.0/api/v1/status
+++ b/internal/mock/0.14.0/api/v1/status
@@ -75,16 +75,16 @@
         "meshStatus": {
             "connections": [],
             "name": "02:42:ac:11:00:02",
-            "nickName": "f5aa481fb869",
+            "nickName": "b60f655f9465",
             "peers": [
                 {
                     "name": "02:42:ac:11:00:02",
-                    "nickName": "f5aa481fb869",
-                    "uid": 10095986928128251540
+                    "nickName": "b60f655f9465",
+                    "uid": 11491249611199294248
                 }
             ]
         },
-        "uptime": "2018-02-13T22:41:02.274924341Z",
+        "uptime": "2019-01-30T17:32:27.2888212Z",
         "versionInfo": {
             "branch": "HEAD",
             "buildDate": "20180213-08:16:42",

--- a/internal/mock/0.14.0/metrics
+++ b/internal/mock/0.14.0/metrics
@@ -1,0 +1,464 @@
+# HELP alertmanager_alerts How many alerts by state.
+# TYPE alertmanager_alerts gauge
+alertmanager_alerts{state="active"} 8
+alertmanager_alerts{state="suppressed"} 4
+# HELP alertmanager_alerts_invalid_total The total number of received alerts that were invalid.
+# TYPE alertmanager_alerts_invalid_total counter
+alertmanager_alerts_invalid_total 0
+# HELP alertmanager_alerts_received_total The total number of received alerts.
+# TYPE alertmanager_alerts_received_total counter
+alertmanager_alerts_received_total{status="firing"} 60
+# HELP alertmanager_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which alertmanager was built.
+# TYPE alertmanager_build_info gauge
+alertmanager_build_info{branch="HEAD",goversion="go1.9.2",revision="30af4d051b37ce817ea7e35b56c57a0e2ec9dbb0",version="0.14.0"} 1
+# HELP alertmanager_config_hash Hash of the currently loaded alertmanager configuration.
+# TYPE alertmanager_config_hash gauge
+alertmanager_config_hash 6.2645753076152e+13
+# HELP alertmanager_config_last_reload_success_timestamp_seconds Timestamp of the last successful configuration reload.
+# TYPE alertmanager_config_last_reload_success_timestamp_seconds gauge
+alertmanager_config_last_reload_success_timestamp_seconds 1.548869547e+09
+# HELP alertmanager_config_last_reload_successful Whether the last configuration reload attempt was successful.
+# TYPE alertmanager_config_last_reload_successful gauge
+alertmanager_config_last_reload_successful 1
+# HELP alertmanager_nflog_gc_duration_seconds Duration of the last notification log garbage collection cycle.
+# TYPE alertmanager_nflog_gc_duration_seconds summary
+alertmanager_nflog_gc_duration_seconds{quantile="0.5"} NaN
+alertmanager_nflog_gc_duration_seconds{quantile="0.9"} NaN
+alertmanager_nflog_gc_duration_seconds{quantile="0.99"} NaN
+alertmanager_nflog_gc_duration_seconds_sum 0
+alertmanager_nflog_gc_duration_seconds_count 0
+# HELP alertmanager_nflog_queries_total Number of notification log queries were received.
+# TYPE alertmanager_nflog_queries_total counter
+alertmanager_nflog_queries_total 0
+# HELP alertmanager_nflog_query_duration_seconds Duration of notification log query evaluation.
+# TYPE alertmanager_nflog_query_duration_seconds histogram
+alertmanager_nflog_query_duration_seconds_bucket{le="0.005"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.01"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.025"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.05"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.1"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.25"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="1"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="2.5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="10"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="+Inf"} 0
+alertmanager_nflog_query_duration_seconds_sum 0
+alertmanager_nflog_query_duration_seconds_count 0
+# HELP alertmanager_nflog_query_errors_total Number notification log received queries that failed.
+# TYPE alertmanager_nflog_query_errors_total counter
+alertmanager_nflog_query_errors_total 0
+# HELP alertmanager_nflog_snapshot_duration_seconds Duration of the last notification log snapshot.
+# TYPE alertmanager_nflog_snapshot_duration_seconds summary
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.5"} NaN
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.9"} NaN
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.99"} NaN
+alertmanager_nflog_snapshot_duration_seconds_sum 0
+alertmanager_nflog_snapshot_duration_seconds_count 0
+# HELP alertmanager_notifications_failed_total The total number of failed notifications.
+# TYPE alertmanager_notifications_failed_total counter
+alertmanager_notifications_failed_total{integration="email"} 0
+alertmanager_notifications_failed_total{integration="hipchat"} 0
+alertmanager_notifications_failed_total{integration="opsgenie"} 0
+alertmanager_notifications_failed_total{integration="pagerduty"} 0
+alertmanager_notifications_failed_total{integration="pushover"} 0
+alertmanager_notifications_failed_total{integration="slack"} 0
+alertmanager_notifications_failed_total{integration="victorops"} 0
+alertmanager_notifications_failed_total{integration="webhook"} 0
+alertmanager_notifications_failed_total{integration="wechat"} 0
+# HELP alertmanager_notifications_total The total number of attempted notifications.
+# TYPE alertmanager_notifications_total counter
+alertmanager_notifications_total{integration="email"} 0
+alertmanager_notifications_total{integration="hipchat"} 0
+alertmanager_notifications_total{integration="opsgenie"} 0
+alertmanager_notifications_total{integration="pagerduty"} 0
+alertmanager_notifications_total{integration="pushover"} 0
+alertmanager_notifications_total{integration="slack"} 0
+alertmanager_notifications_total{integration="victorops"} 0
+alertmanager_notifications_total{integration="webhook"} 0
+alertmanager_notifications_total{integration="wechat"} 0
+# HELP alertmanager_peer_position Position the Alertmanager instance believes it's in. The position determines a peer's behavior in the cluster.
+# TYPE alertmanager_peer_position gauge
+alertmanager_peer_position 0
+# HELP alertmanager_peer_terminations_total Total number of terminated connections between the AlertManager and its peers.
+# TYPE alertmanager_peer_terminations_total gauge
+alertmanager_peer_terminations_total 0
+# HELP alertmanager_silences How many silences by state.
+# TYPE alertmanager_silences gauge
+alertmanager_silences{state="active"} 3
+alertmanager_silences{state="expired"} 0
+alertmanager_silences{state="pending"} 0
+# HELP alertmanager_silences_gc_duration_seconds Duration of the last silence garbage collection cycle.
+# TYPE alertmanager_silences_gc_duration_seconds summary
+alertmanager_silences_gc_duration_seconds{quantile="0.5"} NaN
+alertmanager_silences_gc_duration_seconds{quantile="0.9"} NaN
+alertmanager_silences_gc_duration_seconds{quantile="0.99"} NaN
+alertmanager_silences_gc_duration_seconds_sum 0
+alertmanager_silences_gc_duration_seconds_count 0
+# HELP alertmanager_silences_queries_total How many silence queries were received.
+# TYPE alertmanager_silences_queries_total counter
+alertmanager_silences_queries_total 49
+# HELP alertmanager_silences_query_duration_seconds Duration of silence query evaluation.
+# TYPE alertmanager_silences_query_duration_seconds histogram
+alertmanager_silences_query_duration_seconds_bucket{le="0.005"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.01"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.025"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.05"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.1"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.25"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.5"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="1"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="2.5"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="5"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="10"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="+Inf"} 48
+alertmanager_silences_query_duration_seconds_sum 0.0022524
+alertmanager_silences_query_duration_seconds_count 48
+# HELP alertmanager_silences_query_errors_total How many silence received queries did not succeed.
+# TYPE alertmanager_silences_query_errors_total counter
+alertmanager_silences_query_errors_total 0
+# HELP alertmanager_silences_snapshot_duration_seconds Duration of the last silence snapshot.
+# TYPE alertmanager_silences_snapshot_duration_seconds summary
+alertmanager_silences_snapshot_duration_seconds{quantile="0.5"} NaN
+alertmanager_silences_snapshot_duration_seconds{quantile="0.9"} NaN
+alertmanager_silences_snapshot_duration_seconds{quantile="0.99"} NaN
+alertmanager_silences_snapshot_duration_seconds_sum 0
+alertmanager_silences_snapshot_duration_seconds_count 0
+# HELP alertmanager_silences_snapshot_size_bytes Size of the last silence snapshot in bytes.
+# TYPE alertmanager_silences_snapshot_size_bytes gauge
+alertmanager_silences_snapshot_size_bytes 0
+# HELP go_gc_duration_seconds A summary of the GC invocation durations.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0"} 0.0001485
+go_gc_duration_seconds{quantile="0.25"} 0.0001485
+go_gc_duration_seconds{quantile="0.5"} 0.0007765
+go_gc_duration_seconds{quantile="0.75"} 0.0007765
+go_gc_duration_seconds{quantile="1"} 0.0007765
+go_gc_duration_seconds_sum 0.000925
+go_gc_duration_seconds_count 2
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 53
+# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+# TYPE go_memstats_alloc_bytes gauge
+go_memstats_alloc_bytes 4.716352e+06
+# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
+# TYPE go_memstats_alloc_bytes_total counter
+go_memstats_alloc_bytes_total 5.7454e+06
+# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
+# TYPE go_memstats_buck_hash_sys_bytes gauge
+go_memstats_buck_hash_sys_bytes 1.444499e+06
+# HELP go_memstats_frees_total Total number of frees.
+# TYPE go_memstats_frees_total counter
+go_memstats_frees_total 9655
+# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+# TYPE go_memstats_gc_sys_bytes gauge
+go_memstats_gc_sys_bytes 438272
+# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
+# TYPE go_memstats_heap_alloc_bytes gauge
+go_memstats_heap_alloc_bytes 4.716352e+06
+# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
+# TYPE go_memstats_heap_idle_bytes gauge
+go_memstats_heap_idle_bytes 1.048576e+06
+# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
+# TYPE go_memstats_heap_inuse_bytes gauge
+go_memstats_heap_inuse_bytes 5.668864e+06
+# HELP go_memstats_heap_objects Number of allocated objects.
+# TYPE go_memstats_heap_objects gauge
+go_memstats_heap_objects 15554
+# HELP go_memstats_heap_released_bytes_total Total number of heap bytes released to OS.
+# TYPE go_memstats_heap_released_bytes_total counter
+go_memstats_heap_released_bytes_total 0
+# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
+# TYPE go_memstats_heap_sys_bytes gauge
+go_memstats_heap_sys_bytes 6.71744e+06
+# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
+# TYPE go_memstats_last_gc_time_seconds gauge
+go_memstats_last_gc_time_seconds 1.5488695824573247e+09
+# HELP go_memstats_lookups_total Total number of pointer lookups.
+# TYPE go_memstats_lookups_total counter
+go_memstats_lookups_total 32
+# HELP go_memstats_mallocs_total Total number of mallocs.
+# TYPE go_memstats_mallocs_total counter
+go_memstats_mallocs_total 25209
+# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
+# TYPE go_memstats_mcache_inuse_bytes gauge
+go_memstats_mcache_inuse_bytes 3472
+# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
+# TYPE go_memstats_mcache_sys_bytes gauge
+go_memstats_mcache_sys_bytes 16384
+# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
+# TYPE go_memstats_mspan_inuse_bytes gauge
+go_memstats_mspan_inuse_bytes 62168
+# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
+# TYPE go_memstats_mspan_sys_bytes gauge
+go_memstats_mspan_sys_bytes 65536
+# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
+# TYPE go_memstats_next_gc_bytes gauge
+go_memstats_next_gc_bytes 8.9996e+06
+# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
+# TYPE go_memstats_other_sys_bytes gauge
+go_memstats_other_sys_bytes 761445
+# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
+# TYPE go_memstats_stack_inuse_bytes gauge
+go_memstats_stack_inuse_bytes 622592
+# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
+# TYPE go_memstats_stack_sys_bytes gauge
+go_memstats_stack_sys_bytes 622592
+# HELP go_memstats_sys_bytes Number of bytes obtained by system. Sum of all system allocations.
+# TYPE go_memstats_sys_bytes gauge
+go_memstats_sys_bytes 1.0066168e+07
+# HELP http_request_duration_microseconds The HTTP request latencies in microseconds.
+# TYPE http_request_duration_microseconds summary
+http_request_duration_microseconds{handler="add_alerts",quantile="0.5"} 754.2
+http_request_duration_microseconds{handler="add_alerts",quantile="0.9"} 1719.2
+http_request_duration_microseconds{handler="add_alerts",quantile="0.99"} 1719.2
+http_request_duration_microseconds_sum{handler="add_alerts"} 9112.900000000001
+http_request_duration_microseconds_count{handler="add_alerts"} 5
+http_request_duration_microseconds{handler="add_silence",quantile="0.5"} 281.2
+http_request_duration_microseconds{handler="add_silence",quantile="0.9"} 338.2
+http_request_duration_microseconds{handler="add_silence",quantile="0.99"} 338.2
+http_request_duration_microseconds_sum{handler="add_silence"} 1068.1
+http_request_duration_microseconds_count{handler="add_silence"} 3
+http_request_duration_microseconds{handler="alert_groups",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="alert_groups",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="alert_groups",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="alert_groups"} 0
+http_request_duration_microseconds_count{handler="alert_groups"} 0
+http_request_duration_microseconds{handler="app",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="app",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="app",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="app"} 0
+http_request_duration_microseconds_count{handler="app"} 0
+http_request_duration_microseconds{handler="del_silence",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="del_silence",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="del_silence",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="del_silence"} 0
+http_request_duration_microseconds_count{handler="del_silence"} 0
+http_request_duration_microseconds{handler="get_silence",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="get_silence",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="get_silence",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="get_silence"} 0
+http_request_duration_microseconds_count{handler="get_silence"} 0
+http_request_duration_microseconds{handler="index",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="index",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="index",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="index"} 0
+http_request_duration_microseconds_count{handler="index"} 0
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="legacy_add_alerts"} 0
+http_request_duration_microseconds_count{handler="legacy_add_alerts"} 0
+http_request_duration_microseconds{handler="lib_files",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="lib_files",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="lib_files",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="lib_files"} 0
+http_request_duration_microseconds_count{handler="lib_files"} 0
+http_request_duration_microseconds{handler="list_alerts",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="list_alerts",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="list_alerts",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="list_alerts"} 0
+http_request_duration_microseconds_count{handler="list_alerts"} 0
+http_request_duration_microseconds{handler="list_silences",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="list_silences",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="list_silences",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="list_silences"} 0
+http_request_duration_microseconds_count{handler="list_silences"} 0
+http_request_duration_microseconds{handler="options",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="options",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="options",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="options"} 0
+http_request_duration_microseconds_count{handler="options"} 0
+http_request_duration_microseconds{handler="prometheus",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="prometheus",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="prometheus",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="prometheus"} 0
+http_request_duration_microseconds_count{handler="prometheus"} 0
+http_request_duration_microseconds{handler="receivers",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="receivers",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="receivers",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="receivers"} 0
+http_request_duration_microseconds_count{handler="receivers"} 0
+http_request_duration_microseconds{handler="status",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="status",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="status",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="status"} 0
+http_request_duration_microseconds_count{handler="status"} 0
+# HELP http_request_size_bytes The HTTP request sizes in bytes.
+# TYPE http_request_size_bytes summary
+http_request_size_bytes{handler="add_alerts",quantile="0.5"} 2719
+http_request_size_bytes{handler="add_alerts",quantile="0.9"} 2719
+http_request_size_bytes{handler="add_alerts",quantile="0.99"} 2719
+http_request_size_bytes_sum{handler="add_alerts"} 13595
+http_request_size_bytes_count{handler="add_alerts"} 5
+http_request_size_bytes{handler="add_silence",quantile="0.5"} 358
+http_request_size_bytes{handler="add_silence",quantile="0.9"} 360
+http_request_size_bytes{handler="add_silence",quantile="0.99"} 360
+http_request_size_bytes_sum{handler="add_silence"} 1164
+http_request_size_bytes_count{handler="add_silence"} 3
+http_request_size_bytes{handler="alert_groups",quantile="0.5"} NaN
+http_request_size_bytes{handler="alert_groups",quantile="0.9"} NaN
+http_request_size_bytes{handler="alert_groups",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="alert_groups"} 0
+http_request_size_bytes_count{handler="alert_groups"} 0
+http_request_size_bytes{handler="app",quantile="0.5"} NaN
+http_request_size_bytes{handler="app",quantile="0.9"} NaN
+http_request_size_bytes{handler="app",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="app"} 0
+http_request_size_bytes_count{handler="app"} 0
+http_request_size_bytes{handler="del_silence",quantile="0.5"} NaN
+http_request_size_bytes{handler="del_silence",quantile="0.9"} NaN
+http_request_size_bytes{handler="del_silence",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="del_silence"} 0
+http_request_size_bytes_count{handler="del_silence"} 0
+http_request_size_bytes{handler="get_silence",quantile="0.5"} NaN
+http_request_size_bytes{handler="get_silence",quantile="0.9"} NaN
+http_request_size_bytes{handler="get_silence",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="get_silence"} 0
+http_request_size_bytes_count{handler="get_silence"} 0
+http_request_size_bytes{handler="index",quantile="0.5"} NaN
+http_request_size_bytes{handler="index",quantile="0.9"} NaN
+http_request_size_bytes{handler="index",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="index"} 0
+http_request_size_bytes_count{handler="index"} 0
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="legacy_add_alerts"} 0
+http_request_size_bytes_count{handler="legacy_add_alerts"} 0
+http_request_size_bytes{handler="lib_files",quantile="0.5"} NaN
+http_request_size_bytes{handler="lib_files",quantile="0.9"} NaN
+http_request_size_bytes{handler="lib_files",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="lib_files"} 0
+http_request_size_bytes_count{handler="lib_files"} 0
+http_request_size_bytes{handler="list_alerts",quantile="0.5"} NaN
+http_request_size_bytes{handler="list_alerts",quantile="0.9"} NaN
+http_request_size_bytes{handler="list_alerts",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="list_alerts"} 0
+http_request_size_bytes_count{handler="list_alerts"} 0
+http_request_size_bytes{handler="list_silences",quantile="0.5"} NaN
+http_request_size_bytes{handler="list_silences",quantile="0.9"} NaN
+http_request_size_bytes{handler="list_silences",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="list_silences"} 0
+http_request_size_bytes_count{handler="list_silences"} 0
+http_request_size_bytes{handler="options",quantile="0.5"} NaN
+http_request_size_bytes{handler="options",quantile="0.9"} NaN
+http_request_size_bytes{handler="options",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="options"} 0
+http_request_size_bytes_count{handler="options"} 0
+http_request_size_bytes{handler="prometheus",quantile="0.5"} NaN
+http_request_size_bytes{handler="prometheus",quantile="0.9"} NaN
+http_request_size_bytes{handler="prometheus",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="prometheus"} 0
+http_request_size_bytes_count{handler="prometheus"} 0
+http_request_size_bytes{handler="receivers",quantile="0.5"} NaN
+http_request_size_bytes{handler="receivers",quantile="0.9"} NaN
+http_request_size_bytes{handler="receivers",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="receivers"} 0
+http_request_size_bytes_count{handler="receivers"} 0
+http_request_size_bytes{handler="status",quantile="0.5"} NaN
+http_request_size_bytes{handler="status",quantile="0.9"} NaN
+http_request_size_bytes{handler="status",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="status"} 0
+http_request_size_bytes_count{handler="status"} 0
+# HELP http_requests_total Total number of HTTP requests made.
+# TYPE http_requests_total counter
+http_requests_total{code="200",handler="add_alerts",method="post"} 5
+http_requests_total{code="200",handler="add_silence",method="post"} 3
+# HELP http_response_size_bytes The HTTP response sizes in bytes.
+# TYPE http_response_size_bytes summary
+http_response_size_bytes{handler="add_alerts",quantile="0.5"} 20
+http_response_size_bytes{handler="add_alerts",quantile="0.9"} 20
+http_response_size_bytes{handler="add_alerts",quantile="0.99"} 20
+http_response_size_bytes_sum{handler="add_alerts"} 100
+http_response_size_bytes_count{handler="add_alerts"} 5
+http_response_size_bytes{handler="add_silence",quantile="0.5"} 80
+http_response_size_bytes{handler="add_silence",quantile="0.9"} 80
+http_response_size_bytes{handler="add_silence",quantile="0.99"} 80
+http_response_size_bytes_sum{handler="add_silence"} 240
+http_response_size_bytes_count{handler="add_silence"} 3
+http_response_size_bytes{handler="alert_groups",quantile="0.5"} NaN
+http_response_size_bytes{handler="alert_groups",quantile="0.9"} NaN
+http_response_size_bytes{handler="alert_groups",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="alert_groups"} 0
+http_response_size_bytes_count{handler="alert_groups"} 0
+http_response_size_bytes{handler="app",quantile="0.5"} NaN
+http_response_size_bytes{handler="app",quantile="0.9"} NaN
+http_response_size_bytes{handler="app",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="app"} 0
+http_response_size_bytes_count{handler="app"} 0
+http_response_size_bytes{handler="del_silence",quantile="0.5"} NaN
+http_response_size_bytes{handler="del_silence",quantile="0.9"} NaN
+http_response_size_bytes{handler="del_silence",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="del_silence"} 0
+http_response_size_bytes_count{handler="del_silence"} 0
+http_response_size_bytes{handler="get_silence",quantile="0.5"} NaN
+http_response_size_bytes{handler="get_silence",quantile="0.9"} NaN
+http_response_size_bytes{handler="get_silence",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="get_silence"} 0
+http_response_size_bytes_count{handler="get_silence"} 0
+http_response_size_bytes{handler="index",quantile="0.5"} NaN
+http_response_size_bytes{handler="index",quantile="0.9"} NaN
+http_response_size_bytes{handler="index",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="index"} 0
+http_response_size_bytes_count{handler="index"} 0
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="legacy_add_alerts"} 0
+http_response_size_bytes_count{handler="legacy_add_alerts"} 0
+http_response_size_bytes{handler="lib_files",quantile="0.5"} NaN
+http_response_size_bytes{handler="lib_files",quantile="0.9"} NaN
+http_response_size_bytes{handler="lib_files",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="lib_files"} 0
+http_response_size_bytes_count{handler="lib_files"} 0
+http_response_size_bytes{handler="list_alerts",quantile="0.5"} NaN
+http_response_size_bytes{handler="list_alerts",quantile="0.9"} NaN
+http_response_size_bytes{handler="list_alerts",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="list_alerts"} 0
+http_response_size_bytes_count{handler="list_alerts"} 0
+http_response_size_bytes{handler="list_silences",quantile="0.5"} NaN
+http_response_size_bytes{handler="list_silences",quantile="0.9"} NaN
+http_response_size_bytes{handler="list_silences",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="list_silences"} 0
+http_response_size_bytes_count{handler="list_silences"} 0
+http_response_size_bytes{handler="options",quantile="0.5"} NaN
+http_response_size_bytes{handler="options",quantile="0.9"} NaN
+http_response_size_bytes{handler="options",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="options"} 0
+http_response_size_bytes_count{handler="options"} 0
+http_response_size_bytes{handler="prometheus",quantile="0.5"} NaN
+http_response_size_bytes{handler="prometheus",quantile="0.9"} NaN
+http_response_size_bytes{handler="prometheus",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="prometheus"} 0
+http_response_size_bytes_count{handler="prometheus"} 0
+http_response_size_bytes{handler="receivers",quantile="0.5"} NaN
+http_response_size_bytes{handler="receivers",quantile="0.9"} NaN
+http_response_size_bytes{handler="receivers",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="receivers"} 0
+http_response_size_bytes_count{handler="receivers"} 0
+http_response_size_bytes{handler="status",quantile="0.5"} NaN
+http_response_size_bytes{handler="status",quantile="0.9"} NaN
+http_response_size_bytes{handler="status",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="status"} 0
+http_response_size_bytes_count{handler="status"} 0
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 0.15
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+process_max_fds 1.048576e+06
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+process_open_fds 8
+# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes 1.1300864e+07
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds 1.54886954616e+09
+# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE process_virtual_memory_bytes gauge
+process_virtual_memory_bytes 2.1241856e+07

--- a/internal/mock/0.15.0/api/v1/alerts/groups
+++ b/internal/mock/0.15.0/api/v1/alerts/groups
@@ -19,7 +19,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:05:37.2739239Z",
+                            "startsAt": "2019-01-30T17:33:53.847717Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -63,11 +63,11 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:05:37.2739239Z",
+                            "startsAt": "2019-01-30T17:33:53.847717Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "3ad97217-8100-46fa-bef1-b79efdb62304"
+                                    "ff7fa460-5b38-4c0c-a33b-b13d04bea1b7"
                                 ],
                                 "state": "suppressed"
                             }
@@ -86,7 +86,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:05:37.2739239Z",
+                            "startsAt": "2019-01-30T17:33:53.847717Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -116,28 +116,6 @@
                     "alerts": [
                         {
                             "annotations": {
-                                "summary": "Example summary",
-                                "url": "http://localhost/example.html"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "fingerprint": "d0aee2649e71388b",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "prod",
-                                "instance": "server1",
-                                "job": "node_ping"
-                            },
-                            "receivers": null,
-                            "startsAt": "2018-07-19T21:05:37.2739239Z",
-                            "status": {
-                                "inhibitedBy": [],
-                                "silencedBy": [],
-                                "state": "active"
-                            }
-                        },
-                        {
-                            "annotations": {
                                 "summary": "Example summary"
                             },
                             "endsAt": "0001-01-01T00:00:00Z",
@@ -150,7 +128,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:05:37.2739239Z",
+                            "startsAt": "2019-01-30T17:33:53.847717Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -171,7 +149,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:05:37.2739239Z",
+                            "startsAt": "2019-01-30T17:33:53.847717Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -192,7 +170,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:05:37.2739239Z",
+                            "startsAt": "2019-01-30T17:33:53.847717Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -213,7 +191,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:05:37.2739239Z",
+                            "startsAt": "2019-01-30T17:33:53.847717Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -234,11 +212,11 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:05:37.2739239Z",
+                            "startsAt": "2019-01-30T17:33:53.847717Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "042ea2db-c625-4210-86e5-51116414f290"
+                                    "40d02fa1-bbcb-4fa3-9bb1-ce3430b7a6c2"
                                 ],
                                 "state": "suppressed"
                             }
@@ -257,12 +235,12 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:05:37.2739239Z",
+                            "startsAt": "2019-01-30T17:33:53.847717Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "042ea2db-c625-4210-86e5-51116414f290",
-                                    "6d79cc47-7881-406f-97f2-3384dd95db40"
+                                    "40d02fa1-bbcb-4fa3-9bb1-ce3430b7a6c2",
+                                    "7665aebb-1b9a-42ee-aa42-4fbedac19daf"
                                 ],
                                 "state": "suppressed"
                             }
@@ -281,13 +259,35 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:05:37.2739239Z",
+                            "startsAt": "2019-01-30T17:33:53.847717Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "042ea2db-c625-4210-86e5-51116414f290"
+                                    "40d02fa1-bbcb-4fa3-9bb1-ce3430b7a6c2"
                                 ],
                                 "state": "suppressed"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary",
+                                "url": "http://localhost/example.html"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "fingerprint": "d0aee2649e71388b",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "prod",
+                                "instance": "server1",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:33:53.847717Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
                             }
                         }
                     ],
@@ -326,7 +326,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:05:37.2739239Z",
+                            "startsAt": "2019-01-30T17:33:53.847717Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -369,7 +369,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:05:37.2739239Z",
+                            "startsAt": "2019-01-30T17:33:53.847717Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -416,11 +416,11 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:05:37.2739239Z",
+                            "startsAt": "2019-01-30T17:33:53.847717Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "3ad97217-8100-46fa-bef1-b79efdb62304"
+                                    "ff7fa460-5b38-4c0c-a33b-b13d04bea1b7"
                                 ],
                                 "state": "suppressed"
                             }
@@ -439,7 +439,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:05:37.2739239Z",
+                            "startsAt": "2019-01-30T17:33:53.847717Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -475,6 +475,29 @@
                                 "summary": "Example summary"
                             },
                             "endsAt": "0001-01-01T00:00:00Z",
+                            "fingerprint": "0967807e4073b606",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "dev",
+                                "instance": "server6",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:33:53.847717Z",
+                            "status": {
+                                "inhibitedBy": null,
+                                "silencedBy": [
+                                    "40d02fa1-bbcb-4fa3-9bb1-ce3430b7a6c2"
+                                ],
+                                "state": "suppressed"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
                             "fingerprint": "44497481566cd3c7",
                             "generatorURL": "localhost/prometheus",
                             "labels": {
@@ -484,12 +507,12 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:05:37.2739239Z",
+                            "startsAt": "2019-01-30T17:33:53.847717Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "042ea2db-c625-4210-86e5-51116414f290",
-                                    "6d79cc47-7881-406f-97f2-3384dd95db40"
+                                    "40d02fa1-bbcb-4fa3-9bb1-ce3430b7a6c2",
+                                    "7665aebb-1b9a-42ee-aa42-4fbedac19daf"
                                 ],
                                 "state": "suppressed"
                             }
@@ -508,34 +531,11 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:05:37.2739239Z",
+                            "startsAt": "2019-01-30T17:33:53.847717Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "042ea2db-c625-4210-86e5-51116414f290"
-                                ],
-                                "state": "suppressed"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "fingerprint": "0967807e4073b606",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "dev",
-                                "instance": "server6",
-                                "job": "node_ping"
-                            },
-                            "receivers": null,
-                            "startsAt": "2018-07-19T21:05:37.2739239Z",
-                            "status": {
-                                "inhibitedBy": null,
-                                "silencedBy": [
-                                    "042ea2db-c625-4210-86e5-51116414f290"
+                                    "40d02fa1-bbcb-4fa3-9bb1-ce3430b7a6c2"
                                 ],
                                 "state": "suppressed"
                             }
@@ -543,9 +543,9 @@
                     ],
                     "routeOpts": {
                         "groupBy": [
+                            "alertname",
                             "cluster",
-                            "service",
-                            "alertname"
+                            "service"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,
@@ -566,27 +566,6 @@
                     "alerts": [
                         {
                             "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "fingerprint": "3bdb8b68bdce2ae0",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "prod",
-                                "instance": "server2",
-                                "job": "node_ping"
-                            },
-                            "receivers": null,
-                            "startsAt": "2018-07-19T21:05:37.2739239Z",
-                            "status": {
-                                "inhibitedBy": [],
-                                "silencedBy": [],
-                                "state": "active"
-                            }
-                        },
-                        {
-                            "annotations": {
                                 "summary": "Example summary",
                                 "url": "http://localhost/example.html"
                             },
@@ -600,7 +579,28 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:05:37.2739239Z",
+                            "startsAt": "2019-01-30T17:33:53.847717Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "fingerprint": "3bdb8b68bdce2ae0",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "prod",
+                                "instance": "server2",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:33:53.847717Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -610,9 +610,9 @@
                     ],
                     "routeOpts": {
                         "groupBy": [
+                            "alertname",
                             "cluster",
-                            "service",
-                            "alertname"
+                            "service"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,
@@ -645,7 +645,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:05:37.2739239Z",
+                            "startsAt": "2019-01-30T17:33:53.847717Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -666,7 +666,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:05:37.2739239Z",
+                            "startsAt": "2019-01-30T17:33:53.847717Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -687,7 +687,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:05:37.2739239Z",
+                            "startsAt": "2019-01-30T17:33:53.847717Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -733,7 +733,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:05:37.2739239Z",
+                            "startsAt": "2019-01-30T17:33:53.847717Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],

--- a/internal/mock/0.15.0/api/v1/silences
+++ b/internal/mock/0.15.0/api/v1/silences
@@ -1,28 +1,10 @@
 {
     "data": [
         {
-            "comment": "Silenced server7",
-            "createdBy": "john@example.com",
-            "endsAt": "2063-01-01T00:00:00Z",
-            "id": "6d79cc47-7881-406f-97f2-3384dd95db40",
-            "matchers": [
-                {
-                    "isRegex": false,
-                    "name": "instance",
-                    "value": "server7"
-                }
-            ],
-            "startsAt": "2018-07-19T21:05:37.2703994Z",
-            "status": {
-                "state": "active"
-            },
-            "updatedAt": "2018-07-19T21:05:37.2704157Z"
-        },
-        {
             "comment": "Silenced instance",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "3ad97217-8100-46fa-bef1-b79efdb62304",
+            "id": "ff7fa460-5b38-4c0c-a33b-b13d04bea1b7",
             "matchers": [
                 {
                     "isRegex": false,
@@ -30,17 +12,17 @@
                     "value": "web1"
                 }
             ],
-            "startsAt": "2018-07-19T21:05:37.2641482Z",
+            "startsAt": "2019-01-30T17:33:53.8335376Z",
             "status": {
                 "state": "active"
             },
-            "updatedAt": "2018-07-19T21:05:37.2641609Z"
+            "updatedAt": "2019-01-30T17:33:53.8335581Z"
         },
         {
             "comment": "Silenced Host_Down alerts in the dev cluster",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "042ea2db-c625-4210-86e5-51116414f290",
+            "id": "40d02fa1-bbcb-4fa3-9bb1-ce3430b7a6c2",
             "matchers": [
                 {
                     "isRegex": false,
@@ -53,11 +35,29 @@
                     "value": "dev"
                 }
             ],
-            "startsAt": "2018-07-19T21:05:37.2673937Z",
+            "startsAt": "2019-01-30T17:33:53.838072Z",
             "status": {
                 "state": "active"
             },
-            "updatedAt": "2018-07-19T21:05:37.2674058Z"
+            "updatedAt": "2019-01-30T17:33:53.8381795Z"
+        },
+        {
+            "comment": "Silenced server7",
+            "createdBy": "john@example.com",
+            "endsAt": "2063-01-01T00:00:00Z",
+            "id": "7665aebb-1b9a-42ee-aa42-4fbedac19daf",
+            "matchers": [
+                {
+                    "isRegex": false,
+                    "name": "instance",
+                    "value": "server7"
+                }
+            ],
+            "startsAt": "2019-01-30T17:33:53.8432721Z",
+            "status": {
+                "state": "active"
+            },
+            "updatedAt": "2019-01-30T17:33:53.8432908Z"
         }
     ],
     "status": "success"

--- a/internal/mock/0.15.0/api/v1/status
+++ b/internal/mock/0.15.0/api/v1/status
@@ -1,11 +1,11 @@
 {
     "data": {
         "clusterStatus": {
-            "name": "01CJT5S3PV6798FHGNW52B90NE",
+            "name": "01D2FX5K0TJ83HWP5C349P6BT9",
             "peers": [
                 {
                     "address": "172.17.0.2:9094",
-                    "name": "01CJT5S3PV6798FHGNW52B90NE"
+                    "name": "01D2FX5K0TJ83HWP5C349P6BT9"
                 }
             ],
             "status": "ready"
@@ -96,7 +96,7 @@
             "templates": null
         },
         "configYAML": "global:\n  resolve_timeout: 5m\n  http_config: {}\n  smtp_hello: localhost\n  smtp_require_tls: true\n  pagerduty_url: https://events.pagerduty.com/v2/enqueue\n  hipchat_api_url: https://api.hipchat.com/\n  opsgenie_api_url: https://api.opsgenie.com/\n  wechat_api_url: https://qyapi.weixin.qq.com/cgi-bin/\n  victorops_api_url: https://alert.victorops.com/integrations/generic/20131114/alert/\nroute:\n  receiver: default\n  group_by:\n  - alertname\n  routes:\n  - receiver: by-cluster-service\n    group_by:\n    - alertname\n    - cluster\n    - service\n    match_re:\n      alertname: ^(?:.*)$\n    continue: true\n  - receiver: by-name\n    group_by:\n    - alertname\n    match_re:\n      alertname: ^(?:.*)$\n    continue: true\n  group_wait: 15s\n  group_interval: 35s\n  repeat_interval: 999h\ninhibit_rules:\n- source_match:\n    severity: critical\n  target_match:\n    severity: warning\n  equal:\n  - alertname\n  - cluster\n  - service\nreceivers:\n- name: default\n- name: by-cluster-service\n- name: by-name\ntemplates: []\n",
-        "uptime": "2018-07-19T21:05:22.1422179Z",
+        "uptime": "2019-01-30T17:33:38.7323926Z",
         "versionInfo": {
             "branch": "HEAD",
             "buildDate": "20180622-11:58:41",

--- a/internal/mock/0.15.0/metrics
+++ b/internal/mock/0.15.0/metrics
@@ -1,0 +1,465 @@
+# HELP alertmanager_alerts How many alerts by state.
+# TYPE alertmanager_alerts gauge
+alertmanager_alerts{state="active"} 8
+alertmanager_alerts{state="suppressed"} 4
+# HELP alertmanager_alerts_invalid_total The total number of received alerts that were invalid.
+# TYPE alertmanager_alerts_invalid_total counter
+alertmanager_alerts_invalid_total 0
+# HELP alertmanager_alerts_received_total The total number of received alerts.
+# TYPE alertmanager_alerts_received_total counter
+alertmanager_alerts_received_total{status="firing"} 60
+alertmanager_alerts_received_total{status="resolved"} 0
+# HELP alertmanager_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which alertmanager was built.
+# TYPE alertmanager_build_info gauge
+alertmanager_build_info{branch="HEAD",goversion="go1.10.3",revision="462c969d85cf1a473587754d55e4a3c4a2abc63c",version="0.15.0"} 1
+# HELP alertmanager_cluster_failed_peers Number indicating the current number of failed peers in the cluster.
+# TYPE alertmanager_cluster_failed_peers gauge
+alertmanager_cluster_failed_peers 0
+# HELP alertmanager_cluster_health_score Health score of the cluster. Lower values are better and zero means 'totally healthy'.
+# TYPE alertmanager_cluster_health_score gauge
+alertmanager_cluster_health_score 0
+# HELP alertmanager_cluster_members Number indicating current number of members in cluster.
+# TYPE alertmanager_cluster_members gauge
+alertmanager_cluster_members 1
+# HELP alertmanager_cluster_messages_pruned_total Total number of cluster messsages pruned.
+# TYPE alertmanager_cluster_messages_pruned_total counter
+alertmanager_cluster_messages_pruned_total 0
+# HELP alertmanager_cluster_messages_queued Number of cluster messsages which are queued.
+# TYPE alertmanager_cluster_messages_queued gauge
+alertmanager_cluster_messages_queued 3
+# HELP alertmanager_cluster_messages_received_size_total Total size of cluster messages received.
+# TYPE alertmanager_cluster_messages_received_size_total counter
+alertmanager_cluster_messages_received_size_total{msg_type="full_state"} 0
+alertmanager_cluster_messages_received_size_total{msg_type="update"} 0
+# HELP alertmanager_cluster_messages_received_total Total number of cluster messsages received.
+# TYPE alertmanager_cluster_messages_received_total counter
+alertmanager_cluster_messages_received_total{msg_type="full_state"} 0
+alertmanager_cluster_messages_received_total{msg_type="update"} 0
+# HELP alertmanager_cluster_messages_sent_size_total Total size of cluster messages sent.
+# TYPE alertmanager_cluster_messages_sent_size_total counter
+alertmanager_cluster_messages_sent_size_total{msg_type="full_state"} 0
+alertmanager_cluster_messages_sent_size_total{msg_type="update"} 0
+# HELP alertmanager_cluster_messages_sent_total Total number of cluster messsages sent.
+# TYPE alertmanager_cluster_messages_sent_total counter
+alertmanager_cluster_messages_sent_total{msg_type="full_state"} 0
+alertmanager_cluster_messages_sent_total{msg_type="update"} 0
+# HELP alertmanager_cluster_peers_joined_total A counter of the number of peers that have joined.
+# TYPE alertmanager_cluster_peers_joined_total counter
+alertmanager_cluster_peers_joined_total 1
+# HELP alertmanager_cluster_peers_left_total A counter of the number of peers that have left.
+# TYPE alertmanager_cluster_peers_left_total counter
+alertmanager_cluster_peers_left_total 0
+# HELP alertmanager_cluster_peers_update_total A counter of the number of peers that have updated metadata.
+# TYPE alertmanager_cluster_peers_update_total counter
+alertmanager_cluster_peers_update_total 0
+# HELP alertmanager_cluster_reconnections_failed_total A counter of the number of failed cluster peer reconnection attempts.
+# TYPE alertmanager_cluster_reconnections_failed_total counter
+alertmanager_cluster_reconnections_failed_total 0
+# HELP alertmanager_cluster_reconnections_total A counter of the number of cluster peer reconnections.
+# TYPE alertmanager_cluster_reconnections_total counter
+alertmanager_cluster_reconnections_total 0
+# HELP alertmanager_config_hash Hash of the currently loaded alertmanager configuration.
+# TYPE alertmanager_config_hash gauge
+alertmanager_config_hash 6.2645753076152e+13
+# HELP alertmanager_config_last_reload_success_timestamp_seconds Timestamp of the last successful configuration reload.
+# TYPE alertmanager_config_last_reload_success_timestamp_seconds gauge
+alertmanager_config_last_reload_success_timestamp_seconds 1.548869618e+09
+# HELP alertmanager_config_last_reload_successful Whether the last configuration reload attempt was successful.
+# TYPE alertmanager_config_last_reload_successful gauge
+alertmanager_config_last_reload_successful 1
+# HELP alertmanager_http_request_duration_seconds Histogram of latencies for HTTP requests.
+# TYPE alertmanager_http_request_duration_seconds histogram
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="0.05"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="0.1"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="0.25"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="0.5"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="0.75"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="1"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="2"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="5"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="20"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="60"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="+Inf"} 5
+alertmanager_http_request_duration_seconds_sum{handler="/alerts",method="post"} 0.005485000000000001
+alertmanager_http_request_duration_seconds_count{handler="/alerts",method="post"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="0.05"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="0.1"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="0.25"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="0.5"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="0.75"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="1"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="2"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="5"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="20"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="60"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="+Inf"} 3
+alertmanager_http_request_duration_seconds_sum{handler="/silences",method="post"} 0.0013877
+alertmanager_http_request_duration_seconds_count{handler="/silences",method="post"} 3
+# HELP alertmanager_http_response_size_bytes Histogram of response size for HTTP requests.
+# TYPE alertmanager_http_response_size_bytes histogram
+alertmanager_http_response_size_bytes_bucket{handler="/alerts",method="post",le="100"} 5
+alertmanager_http_response_size_bytes_bucket{handler="/alerts",method="post",le="1000"} 5
+alertmanager_http_response_size_bytes_bucket{handler="/alerts",method="post",le="10000"} 5
+alertmanager_http_response_size_bytes_bucket{handler="/alerts",method="post",le="100000"} 5
+alertmanager_http_response_size_bytes_bucket{handler="/alerts",method="post",le="1e+06"} 5
+alertmanager_http_response_size_bytes_bucket{handler="/alerts",method="post",le="1e+07"} 5
+alertmanager_http_response_size_bytes_bucket{handler="/alerts",method="post",le="1e+08"} 5
+alertmanager_http_response_size_bytes_bucket{handler="/alerts",method="post",le="+Inf"} 5
+alertmanager_http_response_size_bytes_sum{handler="/alerts",method="post"} 100
+alertmanager_http_response_size_bytes_count{handler="/alerts",method="post"} 5
+alertmanager_http_response_size_bytes_bucket{handler="/silences",method="post",le="100"} 3
+alertmanager_http_response_size_bytes_bucket{handler="/silences",method="post",le="1000"} 3
+alertmanager_http_response_size_bytes_bucket{handler="/silences",method="post",le="10000"} 3
+alertmanager_http_response_size_bytes_bucket{handler="/silences",method="post",le="100000"} 3
+alertmanager_http_response_size_bytes_bucket{handler="/silences",method="post",le="1e+06"} 3
+alertmanager_http_response_size_bytes_bucket{handler="/silences",method="post",le="1e+07"} 3
+alertmanager_http_response_size_bytes_bucket{handler="/silences",method="post",le="1e+08"} 3
+alertmanager_http_response_size_bytes_bucket{handler="/silences",method="post",le="+Inf"} 3
+alertmanager_http_response_size_bytes_sum{handler="/silences",method="post"} 240
+alertmanager_http_response_size_bytes_count{handler="/silences",method="post"} 3
+# HELP alertmanager_nflog_gc_duration_seconds Duration of the last notification log garbage collection cycle.
+# TYPE alertmanager_nflog_gc_duration_seconds summary
+alertmanager_nflog_gc_duration_seconds{quantile="0.5"} NaN
+alertmanager_nflog_gc_duration_seconds{quantile="0.9"} NaN
+alertmanager_nflog_gc_duration_seconds{quantile="0.99"} NaN
+alertmanager_nflog_gc_duration_seconds_sum 0
+alertmanager_nflog_gc_duration_seconds_count 0
+# HELP alertmanager_nflog_gossip_messages_propagated_total Number of received gossip messages that have been further gossiped.
+# TYPE alertmanager_nflog_gossip_messages_propagated_total counter
+alertmanager_nflog_gossip_messages_propagated_total 0
+# HELP alertmanager_nflog_queries_total Number of notification log queries were received.
+# TYPE alertmanager_nflog_queries_total counter
+alertmanager_nflog_queries_total 0
+# HELP alertmanager_nflog_query_duration_seconds Duration of notification log query evaluation.
+# TYPE alertmanager_nflog_query_duration_seconds histogram
+alertmanager_nflog_query_duration_seconds_bucket{le="0.005"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.01"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.025"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.05"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.1"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.25"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="1"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="2.5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="10"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="+Inf"} 0
+alertmanager_nflog_query_duration_seconds_sum 0
+alertmanager_nflog_query_duration_seconds_count 0
+# HELP alertmanager_nflog_query_errors_total Number notification log received queries that failed.
+# TYPE alertmanager_nflog_query_errors_total counter
+alertmanager_nflog_query_errors_total 0
+# HELP alertmanager_nflog_snapshot_duration_seconds Duration of the last notification log snapshot.
+# TYPE alertmanager_nflog_snapshot_duration_seconds summary
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.5"} NaN
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.9"} NaN
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.99"} NaN
+alertmanager_nflog_snapshot_duration_seconds_sum 0
+alertmanager_nflog_snapshot_duration_seconds_count 0
+# HELP alertmanager_nflog_snapshot_size_bytes Size of the last notification log snapshot in bytes.
+# TYPE alertmanager_nflog_snapshot_size_bytes gauge
+alertmanager_nflog_snapshot_size_bytes 0
+# HELP alertmanager_notification_latency_seconds The latency of notifications in seconds.
+# TYPE alertmanager_notification_latency_seconds histogram
+alertmanager_notification_latency_seconds_bucket{integration="email",le="1"} 0
+alertmanager_notification_latency_seconds_bucket{integration="email",le="5"} 0
+alertmanager_notification_latency_seconds_bucket{integration="email",le="10"} 0
+alertmanager_notification_latency_seconds_bucket{integration="email",le="15"} 0
+alertmanager_notification_latency_seconds_bucket{integration="email",le="20"} 0
+alertmanager_notification_latency_seconds_bucket{integration="email",le="+Inf"} 0
+alertmanager_notification_latency_seconds_sum{integration="email"} 0
+alertmanager_notification_latency_seconds_count{integration="email"} 0
+alertmanager_notification_latency_seconds_bucket{integration="hipchat",le="1"} 0
+alertmanager_notification_latency_seconds_bucket{integration="hipchat",le="5"} 0
+alertmanager_notification_latency_seconds_bucket{integration="hipchat",le="10"} 0
+alertmanager_notification_latency_seconds_bucket{integration="hipchat",le="15"} 0
+alertmanager_notification_latency_seconds_bucket{integration="hipchat",le="20"} 0
+alertmanager_notification_latency_seconds_bucket{integration="hipchat",le="+Inf"} 0
+alertmanager_notification_latency_seconds_sum{integration="hipchat"} 0
+alertmanager_notification_latency_seconds_count{integration="hipchat"} 0
+alertmanager_notification_latency_seconds_bucket{integration="opsgenie",le="1"} 0
+alertmanager_notification_latency_seconds_bucket{integration="opsgenie",le="5"} 0
+alertmanager_notification_latency_seconds_bucket{integration="opsgenie",le="10"} 0
+alertmanager_notification_latency_seconds_bucket{integration="opsgenie",le="15"} 0
+alertmanager_notification_latency_seconds_bucket{integration="opsgenie",le="20"} 0
+alertmanager_notification_latency_seconds_bucket{integration="opsgenie",le="+Inf"} 0
+alertmanager_notification_latency_seconds_sum{integration="opsgenie"} 0
+alertmanager_notification_latency_seconds_count{integration="opsgenie"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pagerduty",le="1"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pagerduty",le="5"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pagerduty",le="10"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pagerduty",le="15"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pagerduty",le="20"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pagerduty",le="+Inf"} 0
+alertmanager_notification_latency_seconds_sum{integration="pagerduty"} 0
+alertmanager_notification_latency_seconds_count{integration="pagerduty"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pushover",le="1"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pushover",le="5"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pushover",le="10"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pushover",le="15"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pushover",le="20"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pushover",le="+Inf"} 0
+alertmanager_notification_latency_seconds_sum{integration="pushover"} 0
+alertmanager_notification_latency_seconds_count{integration="pushover"} 0
+alertmanager_notification_latency_seconds_bucket{integration="slack",le="1"} 0
+alertmanager_notification_latency_seconds_bucket{integration="slack",le="5"} 0
+alertmanager_notification_latency_seconds_bucket{integration="slack",le="10"} 0
+alertmanager_notification_latency_seconds_bucket{integration="slack",le="15"} 0
+alertmanager_notification_latency_seconds_bucket{integration="slack",le="20"} 0
+alertmanager_notification_latency_seconds_bucket{integration="slack",le="+Inf"} 0
+alertmanager_notification_latency_seconds_sum{integration="slack"} 0
+alertmanager_notification_latency_seconds_count{integration="slack"} 0
+alertmanager_notification_latency_seconds_bucket{integration="victorops",le="1"} 0
+alertmanager_notification_latency_seconds_bucket{integration="victorops",le="5"} 0
+alertmanager_notification_latency_seconds_bucket{integration="victorops",le="10"} 0
+alertmanager_notification_latency_seconds_bucket{integration="victorops",le="15"} 0
+alertmanager_notification_latency_seconds_bucket{integration="victorops",le="20"} 0
+alertmanager_notification_latency_seconds_bucket{integration="victorops",le="+Inf"} 0
+alertmanager_notification_latency_seconds_sum{integration="victorops"} 0
+alertmanager_notification_latency_seconds_count{integration="victorops"} 0
+alertmanager_notification_latency_seconds_bucket{integration="webhook",le="1"} 0
+alertmanager_notification_latency_seconds_bucket{integration="webhook",le="5"} 0
+alertmanager_notification_latency_seconds_bucket{integration="webhook",le="10"} 0
+alertmanager_notification_latency_seconds_bucket{integration="webhook",le="15"} 0
+alertmanager_notification_latency_seconds_bucket{integration="webhook",le="20"} 0
+alertmanager_notification_latency_seconds_bucket{integration="webhook",le="+Inf"} 0
+alertmanager_notification_latency_seconds_sum{integration="webhook"} 0
+alertmanager_notification_latency_seconds_count{integration="webhook"} 0
+alertmanager_notification_latency_seconds_bucket{integration="wechat",le="1"} 0
+alertmanager_notification_latency_seconds_bucket{integration="wechat",le="5"} 0
+alertmanager_notification_latency_seconds_bucket{integration="wechat",le="10"} 0
+alertmanager_notification_latency_seconds_bucket{integration="wechat",le="15"} 0
+alertmanager_notification_latency_seconds_bucket{integration="wechat",le="20"} 0
+alertmanager_notification_latency_seconds_bucket{integration="wechat",le="+Inf"} 0
+alertmanager_notification_latency_seconds_sum{integration="wechat"} 0
+alertmanager_notification_latency_seconds_count{integration="wechat"} 0
+# HELP alertmanager_notifications_failed_total The total number of failed notifications.
+# TYPE alertmanager_notifications_failed_total counter
+alertmanager_notifications_failed_total{integration="email"} 0
+alertmanager_notifications_failed_total{integration="hipchat"} 0
+alertmanager_notifications_failed_total{integration="opsgenie"} 0
+alertmanager_notifications_failed_total{integration="pagerduty"} 0
+alertmanager_notifications_failed_total{integration="pushover"} 0
+alertmanager_notifications_failed_total{integration="slack"} 0
+alertmanager_notifications_failed_total{integration="victorops"} 0
+alertmanager_notifications_failed_total{integration="webhook"} 0
+alertmanager_notifications_failed_total{integration="wechat"} 0
+# HELP alertmanager_notifications_total The total number of attempted notifications.
+# TYPE alertmanager_notifications_total counter
+alertmanager_notifications_total{integration="email"} 0
+alertmanager_notifications_total{integration="hipchat"} 0
+alertmanager_notifications_total{integration="opsgenie"} 0
+alertmanager_notifications_total{integration="pagerduty"} 0
+alertmanager_notifications_total{integration="pushover"} 0
+alertmanager_notifications_total{integration="slack"} 0
+alertmanager_notifications_total{integration="victorops"} 0
+alertmanager_notifications_total{integration="webhook"} 0
+alertmanager_notifications_total{integration="wechat"} 0
+# HELP alertmanager_oversize_gossip_message_duration_seconds Duration of oversized gossip message requests.
+# TYPE alertmanager_oversize_gossip_message_duration_seconds histogram
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="0.005"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="0.01"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="0.025"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="0.05"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="0.1"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="0.25"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="0.5"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="1"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="2.5"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="5"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="10"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="+Inf"} 0
+alertmanager_oversize_gossip_message_duration_seconds_sum{key="nfl"} 0
+alertmanager_oversize_gossip_message_duration_seconds_count{key="nfl"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="0.005"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="0.01"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="0.025"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="0.05"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="0.1"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="0.25"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="0.5"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="1"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="2.5"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="5"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="10"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="+Inf"} 0
+alertmanager_oversize_gossip_message_duration_seconds_sum{key="sil"} 0
+alertmanager_oversize_gossip_message_duration_seconds_count{key="sil"} 0
+# HELP alertmanager_oversized_gossip_message_dropped_total Number of oversized gossip messages that were dropped due to a full message queue.
+# TYPE alertmanager_oversized_gossip_message_dropped_total counter
+alertmanager_oversized_gossip_message_dropped_total{key="nfl"} 0
+alertmanager_oversized_gossip_message_dropped_total{key="sil"} 0
+# HELP alertmanager_oversized_gossip_message_failure_total Number of oversized gossip message sends that failed.
+# TYPE alertmanager_oversized_gossip_message_failure_total counter
+alertmanager_oversized_gossip_message_failure_total{key="nfl"} 0
+alertmanager_oversized_gossip_message_failure_total{key="sil"} 0
+# HELP alertmanager_oversized_gossip_message_sent_total Number of oversized gossip message sent.
+# TYPE alertmanager_oversized_gossip_message_sent_total counter
+alertmanager_oversized_gossip_message_sent_total{key="nfl"} 0
+alertmanager_oversized_gossip_message_sent_total{key="sil"} 0
+# HELP alertmanager_peer_position Position the Alertmanager instance believes it's in. The position determines a peer's behavior in the cluster.
+# TYPE alertmanager_peer_position gauge
+alertmanager_peer_position 0
+# HELP alertmanager_silences How many silences by state.
+# TYPE alertmanager_silences gauge
+alertmanager_silences{state="active"} 3
+alertmanager_silences{state="expired"} 0
+alertmanager_silences{state="pending"} 0
+# HELP alertmanager_silences_gc_duration_seconds Duration of the last silence garbage collection cycle.
+# TYPE alertmanager_silences_gc_duration_seconds summary
+alertmanager_silences_gc_duration_seconds{quantile="0.5"} NaN
+alertmanager_silences_gc_duration_seconds{quantile="0.9"} NaN
+alertmanager_silences_gc_duration_seconds{quantile="0.99"} NaN
+alertmanager_silences_gc_duration_seconds_sum 0
+alertmanager_silences_gc_duration_seconds_count 0
+# HELP alertmanager_silences_gossip_messages_propagated_total Number of received gossip messages that have been further gossiped.
+# TYPE alertmanager_silences_gossip_messages_propagated_total counter
+alertmanager_silences_gossip_messages_propagated_total 0
+# HELP alertmanager_silences_queries_total How many silence queries were received.
+# TYPE alertmanager_silences_queries_total counter
+alertmanager_silences_queries_total 51
+# HELP alertmanager_silences_query_duration_seconds Duration of silence query evaluation.
+# TYPE alertmanager_silences_query_duration_seconds histogram
+alertmanager_silences_query_duration_seconds_bucket{le="0.005"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="0.01"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="0.025"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="0.05"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="0.1"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="0.25"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="0.5"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="1"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="2.5"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="5"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="10"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="+Inf"} 49
+alertmanager_silences_query_duration_seconds_sum 0.0044380999999999995
+alertmanager_silences_query_duration_seconds_count 49
+# HELP alertmanager_silences_query_errors_total How many silence received queries did not succeed.
+# TYPE alertmanager_silences_query_errors_total counter
+alertmanager_silences_query_errors_total 0
+# HELP alertmanager_silences_snapshot_duration_seconds Duration of the last silence snapshot.
+# TYPE alertmanager_silences_snapshot_duration_seconds summary
+alertmanager_silences_snapshot_duration_seconds{quantile="0.5"} NaN
+alertmanager_silences_snapshot_duration_seconds{quantile="0.9"} NaN
+alertmanager_silences_snapshot_duration_seconds{quantile="0.99"} NaN
+alertmanager_silences_snapshot_duration_seconds_sum 0
+alertmanager_silences_snapshot_duration_seconds_count 0
+# HELP alertmanager_silences_snapshot_size_bytes Size of the last silence snapshot in bytes.
+# TYPE alertmanager_silences_snapshot_size_bytes gauge
+alertmanager_silences_snapshot_size_bytes 0
+# HELP go_gc_duration_seconds A summary of the GC invocation durations.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0"} 0.0001937
+go_gc_duration_seconds{quantile="0.25"} 0.0001937
+go_gc_duration_seconds{quantile="0.5"} 0.0002411
+go_gc_duration_seconds{quantile="0.75"} 0.0010619
+go_gc_duration_seconds{quantile="1"} 0.0010619
+go_gc_duration_seconds_sum 0.0014967
+go_gc_duration_seconds_count 3
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 43
+# HELP go_info Information about the Go environment.
+# TYPE go_info gauge
+go_info{version="go1.10.3"} 1
+# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+# TYPE go_memstats_alloc_bytes gauge
+go_memstats_alloc_bytes 2.306136e+06
+# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
+# TYPE go_memstats_alloc_bytes_total counter
+go_memstats_alloc_bytes_total 1.1416864e+07
+# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
+# TYPE go_memstats_buck_hash_sys_bytes gauge
+go_memstats_buck_hash_sys_bytes 1.447707e+06
+# HELP go_memstats_frees_total Total number of frees.
+# TYPE go_memstats_frees_total counter
+go_memstats_frees_total 8060
+# HELP go_memstats_gc_cpu_fraction The fraction of this program's available CPU time used by the GC since the program started.
+# TYPE go_memstats_gc_cpu_fraction gauge
+go_memstats_gc_cpu_fraction 0.1144035079163822
+# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+# TYPE go_memstats_gc_sys_bytes gauge
+go_memstats_gc_sys_bytes 405504
+# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
+# TYPE go_memstats_heap_alloc_bytes gauge
+go_memstats_heap_alloc_bytes 2.306136e+06
+# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
+# TYPE go_memstats_heap_idle_bytes gauge
+go_memstats_heap_idle_bytes 2.400256e+06
+# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
+# TYPE go_memstats_heap_inuse_bytes gauge
+go_memstats_heap_inuse_bytes 3.203072e+06
+# HELP go_memstats_heap_objects Number of allocated objects.
+# TYPE go_memstats_heap_objects gauge
+go_memstats_heap_objects 20967
+# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS.
+# TYPE go_memstats_heap_released_bytes gauge
+go_memstats_heap_released_bytes 0
+# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
+# TYPE go_memstats_heap_sys_bytes gauge
+go_memstats_heap_sys_bytes 5.603328e+06
+# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
+# TYPE go_memstats_last_gc_time_seconds gauge
+go_memstats_last_gc_time_seconds 1.5488696187286808e+09
+# HELP go_memstats_lookups_total Total number of pointer lookups.
+# TYPE go_memstats_lookups_total counter
+go_memstats_lookups_total 33
+# HELP go_memstats_mallocs_total Total number of mallocs.
+# TYPE go_memstats_mallocs_total counter
+go_memstats_mallocs_total 29027
+# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
+# TYPE go_memstats_mcache_inuse_bytes gauge
+go_memstats_mcache_inuse_bytes 3472
+# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
+# TYPE go_memstats_mcache_sys_bytes gauge
+go_memstats_mcache_sys_bytes 16384
+# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
+# TYPE go_memstats_mspan_inuse_bytes gauge
+go_memstats_mspan_inuse_bytes 46968
+# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
+# TYPE go_memstats_mspan_sys_bytes gauge
+go_memstats_mspan_sys_bytes 49152
+# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
+# TYPE go_memstats_next_gc_bytes gauge
+go_memstats_next_gc_bytes 4.194304e+06
+# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
+# TYPE go_memstats_other_sys_bytes gauge
+go_memstats_other_sys_bytes 774621
+# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
+# TYPE go_memstats_stack_inuse_bytes gauge
+go_memstats_stack_inuse_bytes 688128
+# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
+# TYPE go_memstats_stack_sys_bytes gauge
+go_memstats_stack_sys_bytes 688128
+# HELP go_memstats_sys_bytes Number of bytes obtained from system.
+# TYPE go_memstats_sys_bytes gauge
+go_memstats_sys_bytes 8.984824e+06
+# HELP go_threads Number of OS threads created.
+# TYPE go_threads gauge
+go_threads 9
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 0.34
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+process_max_fds 1.048576e+06
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+process_open_fds 9
+# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes 1.4692352e+07
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds 1.54886961776e+09
+# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE process_virtual_memory_bytes gauge
+process_virtual_memory_bytes 2.2224896e+07
+# HELP promhttp_metric_handler_requests_in_flight Current number of scrapes being served.
+# TYPE promhttp_metric_handler_requests_in_flight gauge
+promhttp_metric_handler_requests_in_flight 1
+# HELP promhttp_metric_handler_requests_total Total number of scrapes by HTTP status code.
+# TYPE promhttp_metric_handler_requests_total counter
+promhttp_metric_handler_requests_total{code="200"} 0
+promhttp_metric_handler_requests_total{code="500"} 0
+promhttp_metric_handler_requests_total{code="503"} 0

--- a/internal/mock/0.15.1/api/v1/alerts/groups
+++ b/internal/mock/0.15.1/api/v1/alerts/groups
@@ -19,7 +19,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:06:46.9659343Z",
+                            "startsAt": "2019-01-30T17:35:04.6526595Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -63,11 +63,11 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:06:46.9659343Z",
+                            "startsAt": "2019-01-30T17:35:04.6526595Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "d1487fc4-bff7-4ad8-9f80-99ce2b3a73a1"
+                                    "c01391b1-1bd8-4ae6-b891-f5b1eb4aa4d1"
                                 ],
                                 "state": "suppressed"
                             }
@@ -86,7 +86,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:06:46.9659343Z",
+                            "startsAt": "2019-01-30T17:35:04.6526595Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -119,48 +119,6 @@
                                 "summary": "Example summary"
                             },
                             "endsAt": "0001-01-01T00:00:00Z",
-                            "fingerprint": "24e4121619386f95",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "staging",
-                                "instance": "server3",
-                                "job": "node_ping"
-                            },
-                            "receivers": null,
-                            "startsAt": "2018-07-19T21:06:46.9659343Z",
-                            "status": {
-                                "inhibitedBy": [],
-                                "silencedBy": [],
-                                "state": "active"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "fingerprint": "d9067fcc9686d942",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "staging",
-                                "instance": "server4",
-                                "job": "node_ping"
-                            },
-                            "receivers": null,
-                            "startsAt": "2018-07-19T21:06:46.9659343Z",
-                            "status": {
-                                "inhibitedBy": [],
-                                "silencedBy": [],
-                                "state": "active"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
                             "fingerprint": "5f1306dab6671183",
                             "generatorURL": "localhost/prometheus",
                             "labels": {
@@ -170,7 +128,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:06:46.9659343Z",
+                            "startsAt": "2019-01-30T17:35:04.6526595Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -191,11 +149,11 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:06:46.9659343Z",
+                            "startsAt": "2019-01-30T17:35:04.6526595Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "9ba82d53-825c-4d92-9c03-570368be09d9"
+                                    "fc2e3583-f060-4073-a2bc-19e86b64038f"
                                 ],
                                 "state": "suppressed"
                             }
@@ -214,12 +172,12 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:06:46.9659343Z",
+                            "startsAt": "2019-01-30T17:35:04.6526595Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "9ba82d53-825c-4d92-9c03-570368be09d9",
-                                    "03fca656-dc3b-4cb5-adda-9a1893af90ac"
+                                    "fc2e3583-f060-4073-a2bc-19e86b64038f",
+                                    "46c0cc90-27cf-4322-805e-cd16e30e19f3"
                                 ],
                                 "state": "suppressed"
                             }
@@ -238,11 +196,11 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:06:46.9659343Z",
+                            "startsAt": "2019-01-30T17:35:04.6526595Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "9ba82d53-825c-4d92-9c03-570368be09d9"
+                                    "fc2e3583-f060-4073-a2bc-19e86b64038f"
                                 ],
                                 "state": "suppressed"
                             }
@@ -262,7 +220,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:06:46.9659343Z",
+                            "startsAt": "2019-01-30T17:35:04.6526595Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -283,7 +241,49 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:06:46.9659343Z",
+                            "startsAt": "2019-01-30T17:35:04.6526595Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "fingerprint": "24e4121619386f95",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "staging",
+                                "instance": "server3",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:35:04.6526595Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "fingerprint": "d9067fcc9686d942",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "staging",
+                                "instance": "server4",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:35:04.6526595Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -326,7 +326,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:06:46.9659343Z",
+                            "startsAt": "2019-01-30T17:35:04.6526595Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -369,7 +369,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:06:46.9659343Z",
+                            "startsAt": "2019-01-30T17:35:04.6526595Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -379,9 +379,9 @@
                     ],
                     "routeOpts": {
                         "groupBy": [
+                            "alertname",
                             "cluster",
-                            "service",
-                            "alertname"
+                            "service"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,
@@ -416,11 +416,11 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:06:46.9659343Z",
+                            "startsAt": "2019-01-30T17:35:04.6526595Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "d1487fc4-bff7-4ad8-9f80-99ce2b3a73a1"
+                                    "c01391b1-1bd8-4ae6-b891-f5b1eb4aa4d1"
                                 ],
                                 "state": "suppressed"
                             }
@@ -439,7 +439,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:06:46.9659343Z",
+                            "startsAt": "2019-01-30T17:35:04.6526595Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -484,11 +484,11 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:06:46.9659343Z",
+                            "startsAt": "2019-01-30T17:35:04.6526595Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "9ba82d53-825c-4d92-9c03-570368be09d9"
+                                    "fc2e3583-f060-4073-a2bc-19e86b64038f"
                                 ],
                                 "state": "suppressed"
                             }
@@ -507,12 +507,12 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:06:46.9659343Z",
+                            "startsAt": "2019-01-30T17:35:04.6526595Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "9ba82d53-825c-4d92-9c03-570368be09d9",
-                                    "03fca656-dc3b-4cb5-adda-9a1893af90ac"
+                                    "fc2e3583-f060-4073-a2bc-19e86b64038f",
+                                    "46c0cc90-27cf-4322-805e-cd16e30e19f3"
                                 ],
                                 "state": "suppressed"
                             }
@@ -531,11 +531,11 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:06:46.9659343Z",
+                            "startsAt": "2019-01-30T17:35:04.6526595Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "9ba82d53-825c-4d92-9c03-570368be09d9"
+                                    "fc2e3583-f060-4073-a2bc-19e86b64038f"
                                 ],
                                 "state": "suppressed"
                             }
@@ -579,7 +579,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:06:46.9659343Z",
+                            "startsAt": "2019-01-30T17:35:04.6526595Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -600,7 +600,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:06:46.9659343Z",
+                            "startsAt": "2019-01-30T17:35:04.6526595Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -645,7 +645,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:06:46.9659343Z",
+                            "startsAt": "2019-01-30T17:35:04.6526595Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -666,7 +666,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:06:46.9659343Z",
+                            "startsAt": "2019-01-30T17:35:04.6526595Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -687,7 +687,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:06:46.9659343Z",
+                            "startsAt": "2019-01-30T17:35:04.6526595Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -733,7 +733,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-07-19T21:06:46.9659343Z",
+                            "startsAt": "2019-01-30T17:35:04.6526595Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -743,9 +743,9 @@
                     ],
                     "routeOpts": {
                         "groupBy": [
-                            "service",
                             "alertname",
-                            "cluster"
+                            "cluster",
+                            "service"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,

--- a/internal/mock/0.15.1/api/v1/silences
+++ b/internal/mock/0.15.1/api/v1/silences
@@ -4,7 +4,7 @@
             "comment": "Silenced instance",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "d1487fc4-bff7-4ad8-9f80-99ce2b3a73a1",
+            "id": "c01391b1-1bd8-4ae6-b891-f5b1eb4aa4d1",
             "matchers": [
                 {
                     "isRegex": false,
@@ -12,17 +12,17 @@
                     "value": "web1"
                 }
             ],
-            "startsAt": "2018-07-19T21:06:46.9561055Z",
+            "startsAt": "2019-01-30T17:35:04.638948Z",
             "status": {
                 "state": "active"
             },
-            "updatedAt": "2018-07-19T21:06:46.9561819Z"
+            "updatedAt": "2019-01-30T17:35:04.638968Z"
         },
         {
             "comment": "Silenced Host_Down alerts in the dev cluster",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "9ba82d53-825c-4d92-9c03-570368be09d9",
+            "id": "fc2e3583-f060-4073-a2bc-19e86b64038f",
             "matchers": [
                 {
                     "isRegex": false,
@@ -35,17 +35,17 @@
                     "value": "dev"
                 }
             ],
-            "startsAt": "2018-07-19T21:06:46.9594753Z",
+            "startsAt": "2019-01-30T17:35:04.6451078Z",
             "status": {
                 "state": "active"
             },
-            "updatedAt": "2018-07-19T21:06:46.9594876Z"
+            "updatedAt": "2019-01-30T17:35:04.6452295Z"
         },
         {
             "comment": "Silenced server7",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "03fca656-dc3b-4cb5-adda-9a1893af90ac",
+            "id": "46c0cc90-27cf-4322-805e-cd16e30e19f3",
             "matchers": [
                 {
                     "isRegex": false,
@@ -53,11 +53,11 @@
                     "value": "server7"
                 }
             ],
-            "startsAt": "2018-07-19T21:06:46.9624246Z",
+            "startsAt": "2019-01-30T17:35:04.6490005Z",
             "status": {
                 "state": "active"
             },
-            "updatedAt": "2018-07-19T21:06:46.9624375Z"
+            "updatedAt": "2019-01-30T17:35:04.6490252Z"
         }
     ],
     "status": "success"

--- a/internal/mock/0.15.1/api/v1/status
+++ b/internal/mock/0.15.1/api/v1/status
@@ -1,11 +1,11 @@
 {
     "data": {
         "clusterStatus": {
-            "name": "01CJT5V7RNNYAYDW8Z3VVT4EPP",
+            "name": "01D2FX7R4F13HSG50VXH882MH6",
             "peers": [
                 {
                     "address": "172.17.0.2:9094",
-                    "name": "01CJT5V7RNNYAYDW8Z3VVT4EPP"
+                    "name": "01D2FX7R4F13HSG50VXH882MH6"
                 }
             ],
             "status": "ready"
@@ -96,7 +96,7 @@
             "templates": null
         },
         "configYAML": "global:\n  resolve_timeout: 5m\n  http_config: {}\n  smtp_hello: localhost\n  smtp_require_tls: true\n  pagerduty_url: https://events.pagerduty.com/v2/enqueue\n  hipchat_api_url: https://api.hipchat.com/\n  opsgenie_api_url: https://api.opsgenie.com/\n  wechat_api_url: https://qyapi.weixin.qq.com/cgi-bin/\n  victorops_api_url: https://alert.victorops.com/integrations/generic/20131114/alert/\nroute:\n  receiver: default\n  group_by:\n  - alertname\n  routes:\n  - receiver: by-cluster-service\n    group_by:\n    - alertname\n    - cluster\n    - service\n    match_re:\n      alertname: ^(?:.*)$\n    continue: true\n  - receiver: by-name\n    group_by:\n    - alertname\n    match_re:\n      alertname: ^(?:.*)$\n    continue: true\n  group_wait: 15s\n  group_interval: 35s\n  repeat_interval: 999h\ninhibit_rules:\n- source_match:\n    severity: critical\n  target_match:\n    severity: warning\n  equal:\n  - alertname\n  - cluster\n  - service\nreceivers:\n- name: default\n- name: by-cluster-service\n- name: by-name\ntemplates: []\n",
-        "uptime": "2018-07-19T21:06:31.8325528Z",
+        "uptime": "2019-01-30T17:34:49.5136829Z",
         "versionInfo": {
             "branch": "HEAD",
             "buildDate": "20180712-18:25:27",

--- a/internal/mock/0.15.1/metrics
+++ b/internal/mock/0.15.1/metrics
@@ -1,0 +1,465 @@
+# HELP alertmanager_alerts How many alerts by state.
+# TYPE alertmanager_alerts gauge
+alertmanager_alerts{state="active"} 8
+alertmanager_alerts{state="suppressed"} 4
+# HELP alertmanager_alerts_invalid_total The total number of received alerts that were invalid.
+# TYPE alertmanager_alerts_invalid_total counter
+alertmanager_alerts_invalid_total 0
+# HELP alertmanager_alerts_received_total The total number of received alerts.
+# TYPE alertmanager_alerts_received_total counter
+alertmanager_alerts_received_total{status="firing"} 60
+alertmanager_alerts_received_total{status="resolved"} 0
+# HELP alertmanager_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which alertmanager was built.
+# TYPE alertmanager_build_info gauge
+alertmanager_build_info{branch="HEAD",goversion="go1.10.3",revision="8397de1830f154535a31150f9262da0072d8725d",version="0.15.1"} 1
+# HELP alertmanager_cluster_failed_peers Number indicating the current number of failed peers in the cluster.
+# TYPE alertmanager_cluster_failed_peers gauge
+alertmanager_cluster_failed_peers 0
+# HELP alertmanager_cluster_health_score Health score of the cluster. Lower values are better and zero means 'totally healthy'.
+# TYPE alertmanager_cluster_health_score gauge
+alertmanager_cluster_health_score 0
+# HELP alertmanager_cluster_members Number indicating current number of members in cluster.
+# TYPE alertmanager_cluster_members gauge
+alertmanager_cluster_members 1
+# HELP alertmanager_cluster_messages_pruned_total Total number of cluster messsages pruned.
+# TYPE alertmanager_cluster_messages_pruned_total counter
+alertmanager_cluster_messages_pruned_total 0
+# HELP alertmanager_cluster_messages_queued Number of cluster messsages which are queued.
+# TYPE alertmanager_cluster_messages_queued gauge
+alertmanager_cluster_messages_queued 3
+# HELP alertmanager_cluster_messages_received_size_total Total size of cluster messages received.
+# TYPE alertmanager_cluster_messages_received_size_total counter
+alertmanager_cluster_messages_received_size_total{msg_type="full_state"} 0
+alertmanager_cluster_messages_received_size_total{msg_type="update"} 0
+# HELP alertmanager_cluster_messages_received_total Total number of cluster messsages received.
+# TYPE alertmanager_cluster_messages_received_total counter
+alertmanager_cluster_messages_received_total{msg_type="full_state"} 0
+alertmanager_cluster_messages_received_total{msg_type="update"} 0
+# HELP alertmanager_cluster_messages_sent_size_total Total size of cluster messages sent.
+# TYPE alertmanager_cluster_messages_sent_size_total counter
+alertmanager_cluster_messages_sent_size_total{msg_type="full_state"} 0
+alertmanager_cluster_messages_sent_size_total{msg_type="update"} 0
+# HELP alertmanager_cluster_messages_sent_total Total number of cluster messsages sent.
+# TYPE alertmanager_cluster_messages_sent_total counter
+alertmanager_cluster_messages_sent_total{msg_type="full_state"} 0
+alertmanager_cluster_messages_sent_total{msg_type="update"} 0
+# HELP alertmanager_cluster_peers_joined_total A counter of the number of peers that have joined.
+# TYPE alertmanager_cluster_peers_joined_total counter
+alertmanager_cluster_peers_joined_total 1
+# HELP alertmanager_cluster_peers_left_total A counter of the number of peers that have left.
+# TYPE alertmanager_cluster_peers_left_total counter
+alertmanager_cluster_peers_left_total 0
+# HELP alertmanager_cluster_peers_update_total A counter of the number of peers that have updated metadata.
+# TYPE alertmanager_cluster_peers_update_total counter
+alertmanager_cluster_peers_update_total 0
+# HELP alertmanager_cluster_reconnections_failed_total A counter of the number of failed cluster peer reconnection attempts.
+# TYPE alertmanager_cluster_reconnections_failed_total counter
+alertmanager_cluster_reconnections_failed_total 0
+# HELP alertmanager_cluster_reconnections_total A counter of the number of cluster peer reconnections.
+# TYPE alertmanager_cluster_reconnections_total counter
+alertmanager_cluster_reconnections_total 0
+# HELP alertmanager_config_hash Hash of the currently loaded alertmanager configuration.
+# TYPE alertmanager_config_hash gauge
+alertmanager_config_hash 6.2645753076152e+13
+# HELP alertmanager_config_last_reload_success_timestamp_seconds Timestamp of the last successful configuration reload.
+# TYPE alertmanager_config_last_reload_success_timestamp_seconds gauge
+alertmanager_config_last_reload_success_timestamp_seconds 1.548869689e+09
+# HELP alertmanager_config_last_reload_successful Whether the last configuration reload attempt was successful.
+# TYPE alertmanager_config_last_reload_successful gauge
+alertmanager_config_last_reload_successful 1
+# HELP alertmanager_http_request_duration_seconds Histogram of latencies for HTTP requests.
+# TYPE alertmanager_http_request_duration_seconds histogram
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="0.05"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="0.1"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="0.25"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="0.5"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="0.75"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="1"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="2"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="5"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="20"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="60"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="+Inf"} 5
+alertmanager_http_request_duration_seconds_sum{handler="/alerts",method="post"} 0.0036248
+alertmanager_http_request_duration_seconds_count{handler="/alerts",method="post"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="0.05"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="0.1"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="0.25"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="0.5"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="0.75"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="1"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="2"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="5"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="20"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="60"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="+Inf"} 3
+alertmanager_http_request_duration_seconds_sum{handler="/silences",method="post"} 0.0018133000000000001
+alertmanager_http_request_duration_seconds_count{handler="/silences",method="post"} 3
+# HELP alertmanager_http_response_size_bytes Histogram of response size for HTTP requests.
+# TYPE alertmanager_http_response_size_bytes histogram
+alertmanager_http_response_size_bytes_bucket{handler="/alerts",method="post",le="100"} 5
+alertmanager_http_response_size_bytes_bucket{handler="/alerts",method="post",le="1000"} 5
+alertmanager_http_response_size_bytes_bucket{handler="/alerts",method="post",le="10000"} 5
+alertmanager_http_response_size_bytes_bucket{handler="/alerts",method="post",le="100000"} 5
+alertmanager_http_response_size_bytes_bucket{handler="/alerts",method="post",le="1e+06"} 5
+alertmanager_http_response_size_bytes_bucket{handler="/alerts",method="post",le="1e+07"} 5
+alertmanager_http_response_size_bytes_bucket{handler="/alerts",method="post",le="1e+08"} 5
+alertmanager_http_response_size_bytes_bucket{handler="/alerts",method="post",le="+Inf"} 5
+alertmanager_http_response_size_bytes_sum{handler="/alerts",method="post"} 100
+alertmanager_http_response_size_bytes_count{handler="/alerts",method="post"} 5
+alertmanager_http_response_size_bytes_bucket{handler="/silences",method="post",le="100"} 3
+alertmanager_http_response_size_bytes_bucket{handler="/silences",method="post",le="1000"} 3
+alertmanager_http_response_size_bytes_bucket{handler="/silences",method="post",le="10000"} 3
+alertmanager_http_response_size_bytes_bucket{handler="/silences",method="post",le="100000"} 3
+alertmanager_http_response_size_bytes_bucket{handler="/silences",method="post",le="1e+06"} 3
+alertmanager_http_response_size_bytes_bucket{handler="/silences",method="post",le="1e+07"} 3
+alertmanager_http_response_size_bytes_bucket{handler="/silences",method="post",le="1e+08"} 3
+alertmanager_http_response_size_bytes_bucket{handler="/silences",method="post",le="+Inf"} 3
+alertmanager_http_response_size_bytes_sum{handler="/silences",method="post"} 240
+alertmanager_http_response_size_bytes_count{handler="/silences",method="post"} 3
+# HELP alertmanager_nflog_gc_duration_seconds Duration of the last notification log garbage collection cycle.
+# TYPE alertmanager_nflog_gc_duration_seconds summary
+alertmanager_nflog_gc_duration_seconds{quantile="0.5"} NaN
+alertmanager_nflog_gc_duration_seconds{quantile="0.9"} NaN
+alertmanager_nflog_gc_duration_seconds{quantile="0.99"} NaN
+alertmanager_nflog_gc_duration_seconds_sum 0
+alertmanager_nflog_gc_duration_seconds_count 0
+# HELP alertmanager_nflog_gossip_messages_propagated_total Number of received gossip messages that have been further gossiped.
+# TYPE alertmanager_nflog_gossip_messages_propagated_total counter
+alertmanager_nflog_gossip_messages_propagated_total 0
+# HELP alertmanager_nflog_queries_total Number of notification log queries were received.
+# TYPE alertmanager_nflog_queries_total counter
+alertmanager_nflog_queries_total 0
+# HELP alertmanager_nflog_query_duration_seconds Duration of notification log query evaluation.
+# TYPE alertmanager_nflog_query_duration_seconds histogram
+alertmanager_nflog_query_duration_seconds_bucket{le="0.005"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.01"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.025"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.05"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.1"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.25"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="1"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="2.5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="10"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="+Inf"} 0
+alertmanager_nflog_query_duration_seconds_sum 0
+alertmanager_nflog_query_duration_seconds_count 0
+# HELP alertmanager_nflog_query_errors_total Number notification log received queries that failed.
+# TYPE alertmanager_nflog_query_errors_total counter
+alertmanager_nflog_query_errors_total 0
+# HELP alertmanager_nflog_snapshot_duration_seconds Duration of the last notification log snapshot.
+# TYPE alertmanager_nflog_snapshot_duration_seconds summary
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.5"} NaN
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.9"} NaN
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.99"} NaN
+alertmanager_nflog_snapshot_duration_seconds_sum 0
+alertmanager_nflog_snapshot_duration_seconds_count 0
+# HELP alertmanager_nflog_snapshot_size_bytes Size of the last notification log snapshot in bytes.
+# TYPE alertmanager_nflog_snapshot_size_bytes gauge
+alertmanager_nflog_snapshot_size_bytes 0
+# HELP alertmanager_notification_latency_seconds The latency of notifications in seconds.
+# TYPE alertmanager_notification_latency_seconds histogram
+alertmanager_notification_latency_seconds_bucket{integration="email",le="1"} 0
+alertmanager_notification_latency_seconds_bucket{integration="email",le="5"} 0
+alertmanager_notification_latency_seconds_bucket{integration="email",le="10"} 0
+alertmanager_notification_latency_seconds_bucket{integration="email",le="15"} 0
+alertmanager_notification_latency_seconds_bucket{integration="email",le="20"} 0
+alertmanager_notification_latency_seconds_bucket{integration="email",le="+Inf"} 0
+alertmanager_notification_latency_seconds_sum{integration="email"} 0
+alertmanager_notification_latency_seconds_count{integration="email"} 0
+alertmanager_notification_latency_seconds_bucket{integration="hipchat",le="1"} 0
+alertmanager_notification_latency_seconds_bucket{integration="hipchat",le="5"} 0
+alertmanager_notification_latency_seconds_bucket{integration="hipchat",le="10"} 0
+alertmanager_notification_latency_seconds_bucket{integration="hipchat",le="15"} 0
+alertmanager_notification_latency_seconds_bucket{integration="hipchat",le="20"} 0
+alertmanager_notification_latency_seconds_bucket{integration="hipchat",le="+Inf"} 0
+alertmanager_notification_latency_seconds_sum{integration="hipchat"} 0
+alertmanager_notification_latency_seconds_count{integration="hipchat"} 0
+alertmanager_notification_latency_seconds_bucket{integration="opsgenie",le="1"} 0
+alertmanager_notification_latency_seconds_bucket{integration="opsgenie",le="5"} 0
+alertmanager_notification_latency_seconds_bucket{integration="opsgenie",le="10"} 0
+alertmanager_notification_latency_seconds_bucket{integration="opsgenie",le="15"} 0
+alertmanager_notification_latency_seconds_bucket{integration="opsgenie",le="20"} 0
+alertmanager_notification_latency_seconds_bucket{integration="opsgenie",le="+Inf"} 0
+alertmanager_notification_latency_seconds_sum{integration="opsgenie"} 0
+alertmanager_notification_latency_seconds_count{integration="opsgenie"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pagerduty",le="1"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pagerduty",le="5"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pagerduty",le="10"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pagerduty",le="15"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pagerduty",le="20"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pagerduty",le="+Inf"} 0
+alertmanager_notification_latency_seconds_sum{integration="pagerduty"} 0
+alertmanager_notification_latency_seconds_count{integration="pagerduty"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pushover",le="1"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pushover",le="5"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pushover",le="10"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pushover",le="15"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pushover",le="20"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pushover",le="+Inf"} 0
+alertmanager_notification_latency_seconds_sum{integration="pushover"} 0
+alertmanager_notification_latency_seconds_count{integration="pushover"} 0
+alertmanager_notification_latency_seconds_bucket{integration="slack",le="1"} 0
+alertmanager_notification_latency_seconds_bucket{integration="slack",le="5"} 0
+alertmanager_notification_latency_seconds_bucket{integration="slack",le="10"} 0
+alertmanager_notification_latency_seconds_bucket{integration="slack",le="15"} 0
+alertmanager_notification_latency_seconds_bucket{integration="slack",le="20"} 0
+alertmanager_notification_latency_seconds_bucket{integration="slack",le="+Inf"} 0
+alertmanager_notification_latency_seconds_sum{integration="slack"} 0
+alertmanager_notification_latency_seconds_count{integration="slack"} 0
+alertmanager_notification_latency_seconds_bucket{integration="victorops",le="1"} 0
+alertmanager_notification_latency_seconds_bucket{integration="victorops",le="5"} 0
+alertmanager_notification_latency_seconds_bucket{integration="victorops",le="10"} 0
+alertmanager_notification_latency_seconds_bucket{integration="victorops",le="15"} 0
+alertmanager_notification_latency_seconds_bucket{integration="victorops",le="20"} 0
+alertmanager_notification_latency_seconds_bucket{integration="victorops",le="+Inf"} 0
+alertmanager_notification_latency_seconds_sum{integration="victorops"} 0
+alertmanager_notification_latency_seconds_count{integration="victorops"} 0
+alertmanager_notification_latency_seconds_bucket{integration="webhook",le="1"} 0
+alertmanager_notification_latency_seconds_bucket{integration="webhook",le="5"} 0
+alertmanager_notification_latency_seconds_bucket{integration="webhook",le="10"} 0
+alertmanager_notification_latency_seconds_bucket{integration="webhook",le="15"} 0
+alertmanager_notification_latency_seconds_bucket{integration="webhook",le="20"} 0
+alertmanager_notification_latency_seconds_bucket{integration="webhook",le="+Inf"} 0
+alertmanager_notification_latency_seconds_sum{integration="webhook"} 0
+alertmanager_notification_latency_seconds_count{integration="webhook"} 0
+alertmanager_notification_latency_seconds_bucket{integration="wechat",le="1"} 0
+alertmanager_notification_latency_seconds_bucket{integration="wechat",le="5"} 0
+alertmanager_notification_latency_seconds_bucket{integration="wechat",le="10"} 0
+alertmanager_notification_latency_seconds_bucket{integration="wechat",le="15"} 0
+alertmanager_notification_latency_seconds_bucket{integration="wechat",le="20"} 0
+alertmanager_notification_latency_seconds_bucket{integration="wechat",le="+Inf"} 0
+alertmanager_notification_latency_seconds_sum{integration="wechat"} 0
+alertmanager_notification_latency_seconds_count{integration="wechat"} 0
+# HELP alertmanager_notifications_failed_total The total number of failed notifications.
+# TYPE alertmanager_notifications_failed_total counter
+alertmanager_notifications_failed_total{integration="email"} 0
+alertmanager_notifications_failed_total{integration="hipchat"} 0
+alertmanager_notifications_failed_total{integration="opsgenie"} 0
+alertmanager_notifications_failed_total{integration="pagerduty"} 0
+alertmanager_notifications_failed_total{integration="pushover"} 0
+alertmanager_notifications_failed_total{integration="slack"} 0
+alertmanager_notifications_failed_total{integration="victorops"} 0
+alertmanager_notifications_failed_total{integration="webhook"} 0
+alertmanager_notifications_failed_total{integration="wechat"} 0
+# HELP alertmanager_notifications_total The total number of attempted notifications.
+# TYPE alertmanager_notifications_total counter
+alertmanager_notifications_total{integration="email"} 0
+alertmanager_notifications_total{integration="hipchat"} 0
+alertmanager_notifications_total{integration="opsgenie"} 0
+alertmanager_notifications_total{integration="pagerduty"} 0
+alertmanager_notifications_total{integration="pushover"} 0
+alertmanager_notifications_total{integration="slack"} 0
+alertmanager_notifications_total{integration="victorops"} 0
+alertmanager_notifications_total{integration="webhook"} 0
+alertmanager_notifications_total{integration="wechat"} 0
+# HELP alertmanager_oversize_gossip_message_duration_seconds Duration of oversized gossip message requests.
+# TYPE alertmanager_oversize_gossip_message_duration_seconds histogram
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="0.005"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="0.01"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="0.025"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="0.05"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="0.1"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="0.25"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="0.5"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="1"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="2.5"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="5"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="10"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="+Inf"} 0
+alertmanager_oversize_gossip_message_duration_seconds_sum{key="nfl"} 0
+alertmanager_oversize_gossip_message_duration_seconds_count{key="nfl"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="0.005"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="0.01"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="0.025"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="0.05"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="0.1"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="0.25"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="0.5"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="1"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="2.5"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="5"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="10"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="+Inf"} 0
+alertmanager_oversize_gossip_message_duration_seconds_sum{key="sil"} 0
+alertmanager_oversize_gossip_message_duration_seconds_count{key="sil"} 0
+# HELP alertmanager_oversized_gossip_message_dropped_total Number of oversized gossip messages that were dropped due to a full message queue.
+# TYPE alertmanager_oversized_gossip_message_dropped_total counter
+alertmanager_oversized_gossip_message_dropped_total{key="nfl"} 0
+alertmanager_oversized_gossip_message_dropped_total{key="sil"} 0
+# HELP alertmanager_oversized_gossip_message_failure_total Number of oversized gossip message sends that failed.
+# TYPE alertmanager_oversized_gossip_message_failure_total counter
+alertmanager_oversized_gossip_message_failure_total{key="nfl"} 0
+alertmanager_oversized_gossip_message_failure_total{key="sil"} 0
+# HELP alertmanager_oversized_gossip_message_sent_total Number of oversized gossip message sent.
+# TYPE alertmanager_oversized_gossip_message_sent_total counter
+alertmanager_oversized_gossip_message_sent_total{key="nfl"} 0
+alertmanager_oversized_gossip_message_sent_total{key="sil"} 0
+# HELP alertmanager_peer_position Position the Alertmanager instance believes it's in. The position determines a peer's behavior in the cluster.
+# TYPE alertmanager_peer_position gauge
+alertmanager_peer_position 0
+# HELP alertmanager_silences How many silences by state.
+# TYPE alertmanager_silences gauge
+alertmanager_silences{state="active"} 3
+alertmanager_silences{state="expired"} 0
+alertmanager_silences{state="pending"} 0
+# HELP alertmanager_silences_gc_duration_seconds Duration of the last silence garbage collection cycle.
+# TYPE alertmanager_silences_gc_duration_seconds summary
+alertmanager_silences_gc_duration_seconds{quantile="0.5"} NaN
+alertmanager_silences_gc_duration_seconds{quantile="0.9"} NaN
+alertmanager_silences_gc_duration_seconds{quantile="0.99"} NaN
+alertmanager_silences_gc_duration_seconds_sum 0
+alertmanager_silences_gc_duration_seconds_count 0
+# HELP alertmanager_silences_gossip_messages_propagated_total Number of received gossip messages that have been further gossiped.
+# TYPE alertmanager_silences_gossip_messages_propagated_total counter
+alertmanager_silences_gossip_messages_propagated_total 0
+# HELP alertmanager_silences_queries_total How many silence queries were received.
+# TYPE alertmanager_silences_queries_total counter
+alertmanager_silences_queries_total 51
+# HELP alertmanager_silences_query_duration_seconds Duration of silence query evaluation.
+# TYPE alertmanager_silences_query_duration_seconds histogram
+alertmanager_silences_query_duration_seconds_bucket{le="0.005"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.01"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.025"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.05"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.1"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.25"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.5"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="1"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="2.5"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="5"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="10"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="+Inf"} 48
+alertmanager_silences_query_duration_seconds_sum 0.0022549
+alertmanager_silences_query_duration_seconds_count 48
+# HELP alertmanager_silences_query_errors_total How many silence received queries did not succeed.
+# TYPE alertmanager_silences_query_errors_total counter
+alertmanager_silences_query_errors_total 0
+# HELP alertmanager_silences_snapshot_duration_seconds Duration of the last silence snapshot.
+# TYPE alertmanager_silences_snapshot_duration_seconds summary
+alertmanager_silences_snapshot_duration_seconds{quantile="0.5"} NaN
+alertmanager_silences_snapshot_duration_seconds{quantile="0.9"} NaN
+alertmanager_silences_snapshot_duration_seconds{quantile="0.99"} NaN
+alertmanager_silences_snapshot_duration_seconds_sum 0
+alertmanager_silences_snapshot_duration_seconds_count 0
+# HELP alertmanager_silences_snapshot_size_bytes Size of the last silence snapshot in bytes.
+# TYPE alertmanager_silences_snapshot_size_bytes gauge
+alertmanager_silences_snapshot_size_bytes 0
+# HELP go_gc_duration_seconds A summary of the GC invocation durations.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0"} 0.0021457
+go_gc_duration_seconds{quantile="0.25"} 0.0021457
+go_gc_duration_seconds{quantile="0.5"} 0.0079945
+go_gc_duration_seconds{quantile="0.75"} 0.0133754
+go_gc_duration_seconds{quantile="1"} 0.0133754
+go_gc_duration_seconds_sum 0.0235156
+go_gc_duration_seconds_count 3
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 43
+# HELP go_info Information about the Go environment.
+# TYPE go_info gauge
+go_info{version="go1.10.3"} 1
+# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+# TYPE go_memstats_alloc_bytes gauge
+go_memstats_alloc_bytes 2.285848e+06
+# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
+# TYPE go_memstats_alloc_bytes_total counter
+go_memstats_alloc_bytes_total 1.1488664e+07
+# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
+# TYPE go_memstats_buck_hash_sys_bytes gauge
+go_memstats_buck_hash_sys_bytes 1.448171e+06
+# HELP go_memstats_frees_total Total number of frees.
+# TYPE go_memstats_frees_total counter
+go_memstats_frees_total 8497
+# HELP go_memstats_gc_cpu_fraction The fraction of this program's available CPU time used by the GC since the program started.
+# TYPE go_memstats_gc_cpu_fraction gauge
+go_memstats_gc_cpu_fraction 0.5738161019376657
+# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+# TYPE go_memstats_gc_sys_bytes gauge
+go_memstats_gc_sys_bytes 438272
+# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
+# TYPE go_memstats_heap_alloc_bytes gauge
+go_memstats_heap_alloc_bytes 2.285848e+06
+# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
+# TYPE go_memstats_heap_idle_bytes gauge
+go_memstats_heap_idle_bytes 3.4816e+06
+# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
+# TYPE go_memstats_heap_inuse_bytes gauge
+go_memstats_heap_inuse_bytes 3.203072e+06
+# HELP go_memstats_heap_objects Number of allocated objects.
+# TYPE go_memstats_heap_objects gauge
+go_memstats_heap_objects 20856
+# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS.
+# TYPE go_memstats_heap_released_bytes gauge
+go_memstats_heap_released_bytes 0
+# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
+# TYPE go_memstats_heap_sys_bytes gauge
+go_memstats_heap_sys_bytes 6.684672e+06
+# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
+# TYPE go_memstats_last_gc_time_seconds gauge
+go_memstats_last_gc_time_seconds 1.54886968951065e+09
+# HELP go_memstats_lookups_total Total number of pointer lookups.
+# TYPE go_memstats_lookups_total counter
+go_memstats_lookups_total 41
+# HELP go_memstats_mallocs_total Total number of mallocs.
+# TYPE go_memstats_mallocs_total counter
+go_memstats_mallocs_total 29353
+# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
+# TYPE go_memstats_mcache_inuse_bytes gauge
+go_memstats_mcache_inuse_bytes 3472
+# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
+# TYPE go_memstats_mcache_sys_bytes gauge
+go_memstats_mcache_sys_bytes 16384
+# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
+# TYPE go_memstats_mspan_inuse_bytes gauge
+go_memstats_mspan_inuse_bytes 47424
+# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
+# TYPE go_memstats_mspan_sys_bytes gauge
+go_memstats_mspan_sys_bytes 65536
+# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
+# TYPE go_memstats_next_gc_bytes gauge
+go_memstats_next_gc_bytes 4.194304e+06
+# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
+# TYPE go_memstats_other_sys_bytes gauge
+go_memstats_other_sys_bytes 757773
+# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
+# TYPE go_memstats_stack_inuse_bytes gauge
+go_memstats_stack_inuse_bytes 655360
+# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
+# TYPE go_memstats_stack_sys_bytes gauge
+go_memstats_stack_sys_bytes 655360
+# HELP go_memstats_sys_bytes Number of bytes obtained from system.
+# TYPE go_memstats_sys_bytes gauge
+go_memstats_sys_bytes 1.0066168e+07
+# HELP go_threads Number of OS threads created.
+# TYPE go_threads gauge
+go_threads 9
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 0.34
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+process_max_fds 1.048576e+06
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+process_open_fds 9
+# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes 1.5663104e+07
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds 1.54886968849e+09
+# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE process_virtual_memory_bytes gauge
+process_virtual_memory_bytes 2.3310336e+07
+# HELP promhttp_metric_handler_requests_in_flight Current number of scrapes being served.
+# TYPE promhttp_metric_handler_requests_in_flight gauge
+promhttp_metric_handler_requests_in_flight 1
+# HELP promhttp_metric_handler_requests_total Total number of scrapes by HTTP status code.
+# TYPE promhttp_metric_handler_requests_total counter
+promhttp_metric_handler_requests_total{code="200"} 0
+promhttp_metric_handler_requests_total{code="500"} 0
+promhttp_metric_handler_requests_total{code="503"} 0

--- a/internal/mock/0.15.2/api/v1/alerts/groups
+++ b/internal/mock/0.15.2/api/v1/alerts/groups
@@ -19,7 +19,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-08-14T17:36:40.017867056Z",
+                            "startsAt": "2019-01-30T17:36:16.8038819Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -49,6 +49,27 @@
                     "alerts": [
                         {
                             "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "fingerprint": "5cb0dd95e7f3d9c0",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "HTTP_Probe_Failed",
+                                "cluster": "dev",
+                                "instance": "web2",
+                                "job": "node_exporter"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:36:16.8038819Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
                                 "help": "Example help annotation",
                                 "summary": "Example summary",
                                 "url": "http://localhost/example.html"
@@ -63,34 +84,13 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-08-14T17:36:40.017867056Z",
+                            "startsAt": "2019-01-30T17:36:16.8038819Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "53b23b18-eb32-492c-816d-0db910bdafb1"
+                                    "2eb9a975-eab5-461b-80ae-0d0d6d2055fa"
                                 ],
                                 "state": "suppressed"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "fingerprint": "5cb0dd95e7f3d9c0",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "HTTP_Probe_Failed",
-                                "cluster": "dev",
-                                "instance": "web2",
-                                "job": "node_exporter"
-                            },
-                            "receivers": null,
-                            "startsAt": "2018-08-14T17:36:40.017867056Z",
-                            "status": {
-                                "inhibitedBy": [],
-                                "silencedBy": [],
-                                "state": "active"
                             }
                         }
                     ],
@@ -119,6 +119,27 @@
                                 "summary": "Example summary"
                             },
                             "endsAt": "0001-01-01T00:00:00Z",
+                            "fingerprint": "3bdb8b68bdce2ae0",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "prod",
+                                "instance": "server2",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:36:16.8038819Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
                             "fingerprint": "24e4121619386f95",
                             "generatorURL": "localhost/prometheus",
                             "labels": {
@@ -128,7 +149,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-08-14T17:36:40.017867056Z",
+                            "startsAt": "2019-01-30T17:36:16.8038819Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -149,7 +170,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-08-14T17:36:40.017867056Z",
+                            "startsAt": "2019-01-30T17:36:16.8038819Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -170,7 +191,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-08-14T17:36:40.017867056Z",
+                            "startsAt": "2019-01-30T17:36:16.8038819Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -191,11 +212,11 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-08-14T17:36:40.017867056Z",
+                            "startsAt": "2019-01-30T17:36:16.8038819Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "4cf5fd82-1edd-4169-99d1-ff8415e72179"
+                                    "47d19c8a-6fde-4272-9f20-0f9d56054353"
                                 ],
                                 "state": "suppressed"
                             }
@@ -214,12 +235,12 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-08-14T17:36:40.017867056Z",
+                            "startsAt": "2019-01-30T17:36:16.8038819Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "4cf5fd82-1edd-4169-99d1-ff8415e72179",
-                                    "5d988cf7-c076-43c9-8c98-7724bc07894d"
+                                    "47d19c8a-6fde-4272-9f20-0f9d56054353",
+                                    "c7dc7c20-cee6-44ba-9ecc-ad354a602bbb"
                                 ],
                                 "state": "suppressed"
                             }
@@ -238,11 +259,11 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-08-14T17:36:40.017867056Z",
+                            "startsAt": "2019-01-30T17:36:16.8038819Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "4cf5fd82-1edd-4169-99d1-ff8415e72179"
+                                    "47d19c8a-6fde-4272-9f20-0f9d56054353"
                                 ],
                                 "state": "suppressed"
                             }
@@ -262,28 +283,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-08-14T17:36:40.017867056Z",
-                            "status": {
-                                "inhibitedBy": [],
-                                "silencedBy": [],
-                                "state": "active"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "fingerprint": "3bdb8b68bdce2ae0",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "prod",
-                                "instance": "server2",
-                                "job": "node_ping"
-                            },
-                            "receivers": null,
-                            "startsAt": "2018-08-14T17:36:40.017867056Z",
+                            "startsAt": "2019-01-30T17:36:16.8038819Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -326,7 +326,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-08-14T17:36:40.017867056Z",
+                            "startsAt": "2019-01-30T17:36:16.8038819Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -369,7 +369,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-08-14T17:36:40.017867056Z",
+                            "startsAt": "2019-01-30T17:36:16.8038819Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -379,9 +379,9 @@
                     ],
                     "routeOpts": {
                         "groupBy": [
-                            "alertname",
                             "cluster",
-                            "service"
+                            "service",
+                            "alertname"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,
@@ -416,11 +416,11 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-08-14T17:36:40.017867056Z",
+                            "startsAt": "2019-01-30T17:36:16.8038819Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "53b23b18-eb32-492c-816d-0db910bdafb1"
+                                    "2eb9a975-eab5-461b-80ae-0d0d6d2055fa"
                                 ],
                                 "state": "suppressed"
                             }
@@ -439,7 +439,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-08-14T17:36:40.017867056Z",
+                            "startsAt": "2019-01-30T17:36:16.8038819Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -449,9 +449,9 @@
                     ],
                     "routeOpts": {
                         "groupBy": [
+                            "alertname",
                             "cluster",
-                            "service",
-                            "alertname"
+                            "service"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,
@@ -484,11 +484,11 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-08-14T17:36:40.017867056Z",
+                            "startsAt": "2019-01-30T17:36:16.8038819Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "4cf5fd82-1edd-4169-99d1-ff8415e72179"
+                                    "47d19c8a-6fde-4272-9f20-0f9d56054353"
                                 ],
                                 "state": "suppressed"
                             }
@@ -507,12 +507,12 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-08-14T17:36:40.017867056Z",
+                            "startsAt": "2019-01-30T17:36:16.8038819Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "4cf5fd82-1edd-4169-99d1-ff8415e72179",
-                                    "5d988cf7-c076-43c9-8c98-7724bc07894d"
+                                    "47d19c8a-6fde-4272-9f20-0f9d56054353",
+                                    "c7dc7c20-cee6-44ba-9ecc-ad354a602bbb"
                                 ],
                                 "state": "suppressed"
                             }
@@ -531,11 +531,11 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-08-14T17:36:40.017867056Z",
+                            "startsAt": "2019-01-30T17:36:16.8038819Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "4cf5fd82-1edd-4169-99d1-ff8415e72179"
+                                    "47d19c8a-6fde-4272-9f20-0f9d56054353"
                                 ],
                                 "state": "suppressed"
                             }
@@ -579,7 +579,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-08-14T17:36:40.017867056Z",
+                            "startsAt": "2019-01-30T17:36:16.8038819Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -600,7 +600,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-08-14T17:36:40.017867056Z",
+                            "startsAt": "2019-01-30T17:36:16.8038819Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -636,6 +636,27 @@
                                 "summary": "Example summary"
                             },
                             "endsAt": "0001-01-01T00:00:00Z",
+                            "fingerprint": "24e4121619386f95",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "staging",
+                                "instance": "server3",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:36:16.8038819Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
                             "fingerprint": "d9067fcc9686d942",
                             "generatorURL": "localhost/prometheus",
                             "labels": {
@@ -645,7 +666,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-08-14T17:36:40.017867056Z",
+                            "startsAt": "2019-01-30T17:36:16.8038819Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -666,28 +687,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-08-14T17:36:40.017867056Z",
-                            "status": {
-                                "inhibitedBy": [],
-                                "silencedBy": [],
-                                "state": "active"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "fingerprint": "24e4121619386f95",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "staging",
-                                "instance": "server3",
-                                "job": "node_ping"
-                            },
-                            "receivers": null,
-                            "startsAt": "2018-08-14T17:36:40.017867056Z",
+                            "startsAt": "2019-01-30T17:36:16.8038819Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -733,7 +733,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-08-14T17:36:40.017867056Z",
+                            "startsAt": "2019-01-30T17:36:16.8038819Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],

--- a/internal/mock/0.15.2/api/v1/silences
+++ b/internal/mock/0.15.2/api/v1/silences
@@ -4,7 +4,7 @@
             "comment": "Silenced instance",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "53b23b18-eb32-492c-816d-0db910bdafb1",
+            "id": "2eb9a975-eab5-461b-80ae-0d0d6d2055fa",
             "matchers": [
                 {
                     "isRegex": false,
@@ -12,17 +12,17 @@
                     "value": "web1"
                 }
             ],
-            "startsAt": "2018-08-14T17:36:40.003722418Z",
+            "startsAt": "2019-01-30T17:36:16.7824412Z",
             "status": {
                 "state": "active"
             },
-            "updatedAt": "2018-08-14T17:36:40.0037313Z"
+            "updatedAt": "2019-01-30T17:36:16.7824664Z"
         },
         {
             "comment": "Silenced Host_Down alerts in the dev cluster",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "4cf5fd82-1edd-4169-99d1-ff8415e72179",
+            "id": "47d19c8a-6fde-4272-9f20-0f9d56054353",
             "matchers": [
                 {
                     "isRegex": false,
@@ -35,17 +35,17 @@
                     "value": "dev"
                 }
             ],
-            "startsAt": "2018-08-14T17:36:40.007903563Z",
+            "startsAt": "2019-01-30T17:36:16.7867719Z",
             "status": {
                 "state": "active"
             },
-            "updatedAt": "2018-08-14T17:36:40.007909561Z"
+            "updatedAt": "2019-01-30T17:36:16.7867875Z"
         },
         {
             "comment": "Silenced server7",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "5d988cf7-c076-43c9-8c98-7724bc07894d",
+            "id": "c7dc7c20-cee6-44ba-9ecc-ad354a602bbb",
             "matchers": [
                 {
                     "isRegex": false,
@@ -53,11 +53,11 @@
                     "value": "server7"
                 }
             ],
-            "startsAt": "2018-08-14T17:36:40.013397062Z",
+            "startsAt": "2019-01-30T17:36:16.7905069Z",
             "status": {
                 "state": "active"
             },
-            "updatedAt": "2018-08-14T17:36:40.013404352Z"
+            "updatedAt": "2019-01-30T17:36:16.7905274Z"
         }
     ],
     "status": "success"

--- a/internal/mock/0.15.2/api/v1/status
+++ b/internal/mock/0.15.2/api/v1/status
@@ -1,11 +1,11 @@
 {
     "data": {
         "clusterStatus": {
-            "name": "01CMWR563B2AQ4SBJT0G15MY2Q",
+            "name": "01D2FX9YG493TX9CTV2GHJEFD2",
             "peers": [
                 {
                     "address": "172.17.0.2:9094",
-                    "name": "01CMWR563B2AQ4SBJT0G15MY2Q"
+                    "name": "01D2FX9YG493TX9CTV2GHJEFD2"
                 }
             ],
             "status": "ready"
@@ -96,7 +96,7 @@
             "templates": null
         },
         "configYAML": "global:\n  resolve_timeout: 5m\n  http_config: {}\n  smtp_hello: localhost\n  smtp_require_tls: true\n  pagerduty_url: https://events.pagerduty.com/v2/enqueue\n  hipchat_api_url: https://api.hipchat.com/\n  opsgenie_api_url: https://api.opsgenie.com/\n  wechat_api_url: https://qyapi.weixin.qq.com/cgi-bin/\n  victorops_api_url: https://alert.victorops.com/integrations/generic/20131114/alert/\nroute:\n  receiver: default\n  group_by:\n  - alertname\n  routes:\n  - receiver: by-cluster-service\n    group_by:\n    - alertname\n    - cluster\n    - service\n    match_re:\n      alertname: ^(?:.*)$\n    continue: true\n  - receiver: by-name\n    group_by:\n    - alertname\n    match_re:\n      alertname: ^(?:.*)$\n    continue: true\n  group_wait: 15s\n  group_interval: 35s\n  repeat_interval: 999h\ninhibit_rules:\n- source_match:\n    severity: critical\n  target_match:\n    severity: warning\n  equal:\n  - alertname\n  - cluster\n  - service\nreceivers:\n- name: default\n- name: by-cluster-service\n- name: by-name\ntemplates: []\n",
-        "uptime": "2018-08-14T17:36:24.688050101Z",
+        "uptime": "2019-01-30T17:36:01.545557Z",
         "versionInfo": {
             "branch": "HEAD",
             "buildDate": "20180814-10:53:39",

--- a/internal/mock/0.15.2/metrics
+++ b/internal/mock/0.15.2/metrics
@@ -1,0 +1,465 @@
+# HELP alertmanager_alerts How many alerts by state.
+# TYPE alertmanager_alerts gauge
+alertmanager_alerts{state="active"} 8
+alertmanager_alerts{state="suppressed"} 4
+# HELP alertmanager_alerts_invalid_total The total number of received alerts that were invalid.
+# TYPE alertmanager_alerts_invalid_total counter
+alertmanager_alerts_invalid_total 0
+# HELP alertmanager_alerts_received_total The total number of received alerts.
+# TYPE alertmanager_alerts_received_total counter
+alertmanager_alerts_received_total{status="firing"} 60
+alertmanager_alerts_received_total{status="resolved"} 0
+# HELP alertmanager_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which alertmanager was built.
+# TYPE alertmanager_build_info gauge
+alertmanager_build_info{branch="HEAD",goversion="go1.10.3",revision="d19fae3bae451940b8470abb680cfdd59bfa7cfa",version="0.15.2"} 1
+# HELP alertmanager_cluster_failed_peers Number indicating the current number of failed peers in the cluster.
+# TYPE alertmanager_cluster_failed_peers gauge
+alertmanager_cluster_failed_peers 0
+# HELP alertmanager_cluster_health_score Health score of the cluster. Lower values are better and zero means 'totally healthy'.
+# TYPE alertmanager_cluster_health_score gauge
+alertmanager_cluster_health_score 0
+# HELP alertmanager_cluster_members Number indicating current number of members in cluster.
+# TYPE alertmanager_cluster_members gauge
+alertmanager_cluster_members 1
+# HELP alertmanager_cluster_messages_pruned_total Total number of cluster messsages pruned.
+# TYPE alertmanager_cluster_messages_pruned_total counter
+alertmanager_cluster_messages_pruned_total 0
+# HELP alertmanager_cluster_messages_queued Number of cluster messsages which are queued.
+# TYPE alertmanager_cluster_messages_queued gauge
+alertmanager_cluster_messages_queued 3
+# HELP alertmanager_cluster_messages_received_size_total Total size of cluster messages received.
+# TYPE alertmanager_cluster_messages_received_size_total counter
+alertmanager_cluster_messages_received_size_total{msg_type="full_state"} 0
+alertmanager_cluster_messages_received_size_total{msg_type="update"} 0
+# HELP alertmanager_cluster_messages_received_total Total number of cluster messsages received.
+# TYPE alertmanager_cluster_messages_received_total counter
+alertmanager_cluster_messages_received_total{msg_type="full_state"} 0
+alertmanager_cluster_messages_received_total{msg_type="update"} 0
+# HELP alertmanager_cluster_messages_sent_size_total Total size of cluster messages sent.
+# TYPE alertmanager_cluster_messages_sent_size_total counter
+alertmanager_cluster_messages_sent_size_total{msg_type="full_state"} 0
+alertmanager_cluster_messages_sent_size_total{msg_type="update"} 0
+# HELP alertmanager_cluster_messages_sent_total Total number of cluster messsages sent.
+# TYPE alertmanager_cluster_messages_sent_total counter
+alertmanager_cluster_messages_sent_total{msg_type="full_state"} 0
+alertmanager_cluster_messages_sent_total{msg_type="update"} 0
+# HELP alertmanager_cluster_peers_joined_total A counter of the number of peers that have joined.
+# TYPE alertmanager_cluster_peers_joined_total counter
+alertmanager_cluster_peers_joined_total 1
+# HELP alertmanager_cluster_peers_left_total A counter of the number of peers that have left.
+# TYPE alertmanager_cluster_peers_left_total counter
+alertmanager_cluster_peers_left_total 0
+# HELP alertmanager_cluster_peers_update_total A counter of the number of peers that have updated metadata.
+# TYPE alertmanager_cluster_peers_update_total counter
+alertmanager_cluster_peers_update_total 0
+# HELP alertmanager_cluster_reconnections_failed_total A counter of the number of failed cluster peer reconnection attempts.
+# TYPE alertmanager_cluster_reconnections_failed_total counter
+alertmanager_cluster_reconnections_failed_total 0
+# HELP alertmanager_cluster_reconnections_total A counter of the number of cluster peer reconnections.
+# TYPE alertmanager_cluster_reconnections_total counter
+alertmanager_cluster_reconnections_total 0
+# HELP alertmanager_config_hash Hash of the currently loaded alertmanager configuration.
+# TYPE alertmanager_config_hash gauge
+alertmanager_config_hash 6.2645753076152e+13
+# HELP alertmanager_config_last_reload_success_timestamp_seconds Timestamp of the last successful configuration reload.
+# TYPE alertmanager_config_last_reload_success_timestamp_seconds gauge
+alertmanager_config_last_reload_success_timestamp_seconds 1.548869761e+09
+# HELP alertmanager_config_last_reload_successful Whether the last configuration reload attempt was successful.
+# TYPE alertmanager_config_last_reload_successful gauge
+alertmanager_config_last_reload_successful 1
+# HELP alertmanager_http_request_duration_seconds Histogram of latencies for HTTP requests.
+# TYPE alertmanager_http_request_duration_seconds histogram
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="0.05"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="0.1"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="0.25"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="0.5"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="0.75"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="1"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="2"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="5"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="20"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="60"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="+Inf"} 5
+alertmanager_http_request_duration_seconds_sum{handler="/alerts",method="post"} 0.004571499999999999
+alertmanager_http_request_duration_seconds_count{handler="/alerts",method="post"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="0.05"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="0.1"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="0.25"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="0.5"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="0.75"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="1"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="2"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="5"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="20"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="60"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="+Inf"} 3
+alertmanager_http_request_duration_seconds_sum{handler="/silences",method="post"} 0.0010368999999999999
+alertmanager_http_request_duration_seconds_count{handler="/silences",method="post"} 3
+# HELP alertmanager_http_response_size_bytes Histogram of response size for HTTP requests.
+# TYPE alertmanager_http_response_size_bytes histogram
+alertmanager_http_response_size_bytes_bucket{handler="/alerts",method="post",le="100"} 5
+alertmanager_http_response_size_bytes_bucket{handler="/alerts",method="post",le="1000"} 5
+alertmanager_http_response_size_bytes_bucket{handler="/alerts",method="post",le="10000"} 5
+alertmanager_http_response_size_bytes_bucket{handler="/alerts",method="post",le="100000"} 5
+alertmanager_http_response_size_bytes_bucket{handler="/alerts",method="post",le="1e+06"} 5
+alertmanager_http_response_size_bytes_bucket{handler="/alerts",method="post",le="1e+07"} 5
+alertmanager_http_response_size_bytes_bucket{handler="/alerts",method="post",le="1e+08"} 5
+alertmanager_http_response_size_bytes_bucket{handler="/alerts",method="post",le="+Inf"} 5
+alertmanager_http_response_size_bytes_sum{handler="/alerts",method="post"} 100
+alertmanager_http_response_size_bytes_count{handler="/alerts",method="post"} 5
+alertmanager_http_response_size_bytes_bucket{handler="/silences",method="post",le="100"} 3
+alertmanager_http_response_size_bytes_bucket{handler="/silences",method="post",le="1000"} 3
+alertmanager_http_response_size_bytes_bucket{handler="/silences",method="post",le="10000"} 3
+alertmanager_http_response_size_bytes_bucket{handler="/silences",method="post",le="100000"} 3
+alertmanager_http_response_size_bytes_bucket{handler="/silences",method="post",le="1e+06"} 3
+alertmanager_http_response_size_bytes_bucket{handler="/silences",method="post",le="1e+07"} 3
+alertmanager_http_response_size_bytes_bucket{handler="/silences",method="post",le="1e+08"} 3
+alertmanager_http_response_size_bytes_bucket{handler="/silences",method="post",le="+Inf"} 3
+alertmanager_http_response_size_bytes_sum{handler="/silences",method="post"} 240
+alertmanager_http_response_size_bytes_count{handler="/silences",method="post"} 3
+# HELP alertmanager_nflog_gc_duration_seconds Duration of the last notification log garbage collection cycle.
+# TYPE alertmanager_nflog_gc_duration_seconds summary
+alertmanager_nflog_gc_duration_seconds{quantile="0.5"} NaN
+alertmanager_nflog_gc_duration_seconds{quantile="0.9"} NaN
+alertmanager_nflog_gc_duration_seconds{quantile="0.99"} NaN
+alertmanager_nflog_gc_duration_seconds_sum 0
+alertmanager_nflog_gc_duration_seconds_count 0
+# HELP alertmanager_nflog_gossip_messages_propagated_total Number of received gossip messages that have been further gossiped.
+# TYPE alertmanager_nflog_gossip_messages_propagated_total counter
+alertmanager_nflog_gossip_messages_propagated_total 0
+# HELP alertmanager_nflog_queries_total Number of notification log queries were received.
+# TYPE alertmanager_nflog_queries_total counter
+alertmanager_nflog_queries_total 0
+# HELP alertmanager_nflog_query_duration_seconds Duration of notification log query evaluation.
+# TYPE alertmanager_nflog_query_duration_seconds histogram
+alertmanager_nflog_query_duration_seconds_bucket{le="0.005"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.01"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.025"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.05"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.1"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.25"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="1"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="2.5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="10"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="+Inf"} 0
+alertmanager_nflog_query_duration_seconds_sum 0
+alertmanager_nflog_query_duration_seconds_count 0
+# HELP alertmanager_nflog_query_errors_total Number notification log received queries that failed.
+# TYPE alertmanager_nflog_query_errors_total counter
+alertmanager_nflog_query_errors_total 0
+# HELP alertmanager_nflog_snapshot_duration_seconds Duration of the last notification log snapshot.
+# TYPE alertmanager_nflog_snapshot_duration_seconds summary
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.5"} NaN
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.9"} NaN
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.99"} NaN
+alertmanager_nflog_snapshot_duration_seconds_sum 0
+alertmanager_nflog_snapshot_duration_seconds_count 0
+# HELP alertmanager_nflog_snapshot_size_bytes Size of the last notification log snapshot in bytes.
+# TYPE alertmanager_nflog_snapshot_size_bytes gauge
+alertmanager_nflog_snapshot_size_bytes 0
+# HELP alertmanager_notification_latency_seconds The latency of notifications in seconds.
+# TYPE alertmanager_notification_latency_seconds histogram
+alertmanager_notification_latency_seconds_bucket{integration="email",le="1"} 0
+alertmanager_notification_latency_seconds_bucket{integration="email",le="5"} 0
+alertmanager_notification_latency_seconds_bucket{integration="email",le="10"} 0
+alertmanager_notification_latency_seconds_bucket{integration="email",le="15"} 0
+alertmanager_notification_latency_seconds_bucket{integration="email",le="20"} 0
+alertmanager_notification_latency_seconds_bucket{integration="email",le="+Inf"} 0
+alertmanager_notification_latency_seconds_sum{integration="email"} 0
+alertmanager_notification_latency_seconds_count{integration="email"} 0
+alertmanager_notification_latency_seconds_bucket{integration="hipchat",le="1"} 0
+alertmanager_notification_latency_seconds_bucket{integration="hipchat",le="5"} 0
+alertmanager_notification_latency_seconds_bucket{integration="hipchat",le="10"} 0
+alertmanager_notification_latency_seconds_bucket{integration="hipchat",le="15"} 0
+alertmanager_notification_latency_seconds_bucket{integration="hipchat",le="20"} 0
+alertmanager_notification_latency_seconds_bucket{integration="hipchat",le="+Inf"} 0
+alertmanager_notification_latency_seconds_sum{integration="hipchat"} 0
+alertmanager_notification_latency_seconds_count{integration="hipchat"} 0
+alertmanager_notification_latency_seconds_bucket{integration="opsgenie",le="1"} 0
+alertmanager_notification_latency_seconds_bucket{integration="opsgenie",le="5"} 0
+alertmanager_notification_latency_seconds_bucket{integration="opsgenie",le="10"} 0
+alertmanager_notification_latency_seconds_bucket{integration="opsgenie",le="15"} 0
+alertmanager_notification_latency_seconds_bucket{integration="opsgenie",le="20"} 0
+alertmanager_notification_latency_seconds_bucket{integration="opsgenie",le="+Inf"} 0
+alertmanager_notification_latency_seconds_sum{integration="opsgenie"} 0
+alertmanager_notification_latency_seconds_count{integration="opsgenie"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pagerduty",le="1"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pagerduty",le="5"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pagerduty",le="10"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pagerduty",le="15"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pagerduty",le="20"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pagerduty",le="+Inf"} 0
+alertmanager_notification_latency_seconds_sum{integration="pagerduty"} 0
+alertmanager_notification_latency_seconds_count{integration="pagerduty"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pushover",le="1"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pushover",le="5"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pushover",le="10"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pushover",le="15"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pushover",le="20"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pushover",le="+Inf"} 0
+alertmanager_notification_latency_seconds_sum{integration="pushover"} 0
+alertmanager_notification_latency_seconds_count{integration="pushover"} 0
+alertmanager_notification_latency_seconds_bucket{integration="slack",le="1"} 0
+alertmanager_notification_latency_seconds_bucket{integration="slack",le="5"} 0
+alertmanager_notification_latency_seconds_bucket{integration="slack",le="10"} 0
+alertmanager_notification_latency_seconds_bucket{integration="slack",le="15"} 0
+alertmanager_notification_latency_seconds_bucket{integration="slack",le="20"} 0
+alertmanager_notification_latency_seconds_bucket{integration="slack",le="+Inf"} 0
+alertmanager_notification_latency_seconds_sum{integration="slack"} 0
+alertmanager_notification_latency_seconds_count{integration="slack"} 0
+alertmanager_notification_latency_seconds_bucket{integration="victorops",le="1"} 0
+alertmanager_notification_latency_seconds_bucket{integration="victorops",le="5"} 0
+alertmanager_notification_latency_seconds_bucket{integration="victorops",le="10"} 0
+alertmanager_notification_latency_seconds_bucket{integration="victorops",le="15"} 0
+alertmanager_notification_latency_seconds_bucket{integration="victorops",le="20"} 0
+alertmanager_notification_latency_seconds_bucket{integration="victorops",le="+Inf"} 0
+alertmanager_notification_latency_seconds_sum{integration="victorops"} 0
+alertmanager_notification_latency_seconds_count{integration="victorops"} 0
+alertmanager_notification_latency_seconds_bucket{integration="webhook",le="1"} 0
+alertmanager_notification_latency_seconds_bucket{integration="webhook",le="5"} 0
+alertmanager_notification_latency_seconds_bucket{integration="webhook",le="10"} 0
+alertmanager_notification_latency_seconds_bucket{integration="webhook",le="15"} 0
+alertmanager_notification_latency_seconds_bucket{integration="webhook",le="20"} 0
+alertmanager_notification_latency_seconds_bucket{integration="webhook",le="+Inf"} 0
+alertmanager_notification_latency_seconds_sum{integration="webhook"} 0
+alertmanager_notification_latency_seconds_count{integration="webhook"} 0
+alertmanager_notification_latency_seconds_bucket{integration="wechat",le="1"} 0
+alertmanager_notification_latency_seconds_bucket{integration="wechat",le="5"} 0
+alertmanager_notification_latency_seconds_bucket{integration="wechat",le="10"} 0
+alertmanager_notification_latency_seconds_bucket{integration="wechat",le="15"} 0
+alertmanager_notification_latency_seconds_bucket{integration="wechat",le="20"} 0
+alertmanager_notification_latency_seconds_bucket{integration="wechat",le="+Inf"} 0
+alertmanager_notification_latency_seconds_sum{integration="wechat"} 0
+alertmanager_notification_latency_seconds_count{integration="wechat"} 0
+# HELP alertmanager_notifications_failed_total The total number of failed notifications.
+# TYPE alertmanager_notifications_failed_total counter
+alertmanager_notifications_failed_total{integration="email"} 0
+alertmanager_notifications_failed_total{integration="hipchat"} 0
+alertmanager_notifications_failed_total{integration="opsgenie"} 0
+alertmanager_notifications_failed_total{integration="pagerduty"} 0
+alertmanager_notifications_failed_total{integration="pushover"} 0
+alertmanager_notifications_failed_total{integration="slack"} 0
+alertmanager_notifications_failed_total{integration="victorops"} 0
+alertmanager_notifications_failed_total{integration="webhook"} 0
+alertmanager_notifications_failed_total{integration="wechat"} 0
+# HELP alertmanager_notifications_total The total number of attempted notifications.
+# TYPE alertmanager_notifications_total counter
+alertmanager_notifications_total{integration="email"} 0
+alertmanager_notifications_total{integration="hipchat"} 0
+alertmanager_notifications_total{integration="opsgenie"} 0
+alertmanager_notifications_total{integration="pagerduty"} 0
+alertmanager_notifications_total{integration="pushover"} 0
+alertmanager_notifications_total{integration="slack"} 0
+alertmanager_notifications_total{integration="victorops"} 0
+alertmanager_notifications_total{integration="webhook"} 0
+alertmanager_notifications_total{integration="wechat"} 0
+# HELP alertmanager_oversize_gossip_message_duration_seconds Duration of oversized gossip message requests.
+# TYPE alertmanager_oversize_gossip_message_duration_seconds histogram
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="0.005"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="0.01"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="0.025"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="0.05"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="0.1"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="0.25"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="0.5"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="1"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="2.5"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="5"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="10"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="+Inf"} 0
+alertmanager_oversize_gossip_message_duration_seconds_sum{key="nfl"} 0
+alertmanager_oversize_gossip_message_duration_seconds_count{key="nfl"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="0.005"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="0.01"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="0.025"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="0.05"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="0.1"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="0.25"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="0.5"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="1"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="2.5"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="5"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="10"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="+Inf"} 0
+alertmanager_oversize_gossip_message_duration_seconds_sum{key="sil"} 0
+alertmanager_oversize_gossip_message_duration_seconds_count{key="sil"} 0
+# HELP alertmanager_oversized_gossip_message_dropped_total Number of oversized gossip messages that were dropped due to a full message queue.
+# TYPE alertmanager_oversized_gossip_message_dropped_total counter
+alertmanager_oversized_gossip_message_dropped_total{key="nfl"} 0
+alertmanager_oversized_gossip_message_dropped_total{key="sil"} 0
+# HELP alertmanager_oversized_gossip_message_failure_total Number of oversized gossip message sends that failed.
+# TYPE alertmanager_oversized_gossip_message_failure_total counter
+alertmanager_oversized_gossip_message_failure_total{key="nfl"} 0
+alertmanager_oversized_gossip_message_failure_total{key="sil"} 0
+# HELP alertmanager_oversized_gossip_message_sent_total Number of oversized gossip message sent.
+# TYPE alertmanager_oversized_gossip_message_sent_total counter
+alertmanager_oversized_gossip_message_sent_total{key="nfl"} 0
+alertmanager_oversized_gossip_message_sent_total{key="sil"} 0
+# HELP alertmanager_peer_position Position the Alertmanager instance believes it's in. The position determines a peer's behavior in the cluster.
+# TYPE alertmanager_peer_position gauge
+alertmanager_peer_position 0
+# HELP alertmanager_silences How many silences by state.
+# TYPE alertmanager_silences gauge
+alertmanager_silences{state="active"} 3
+alertmanager_silences{state="expired"} 0
+alertmanager_silences{state="pending"} 0
+# HELP alertmanager_silences_gc_duration_seconds Duration of the last silence garbage collection cycle.
+# TYPE alertmanager_silences_gc_duration_seconds summary
+alertmanager_silences_gc_duration_seconds{quantile="0.5"} NaN
+alertmanager_silences_gc_duration_seconds{quantile="0.9"} NaN
+alertmanager_silences_gc_duration_seconds{quantile="0.99"} NaN
+alertmanager_silences_gc_duration_seconds_sum 0
+alertmanager_silences_gc_duration_seconds_count 0
+# HELP alertmanager_silences_gossip_messages_propagated_total Number of received gossip messages that have been further gossiped.
+# TYPE alertmanager_silences_gossip_messages_propagated_total counter
+alertmanager_silences_gossip_messages_propagated_total 0
+# HELP alertmanager_silences_queries_total How many silence queries were received.
+# TYPE alertmanager_silences_queries_total counter
+alertmanager_silences_queries_total 50
+# HELP alertmanager_silences_query_duration_seconds Duration of silence query evaluation.
+# TYPE alertmanager_silences_query_duration_seconds histogram
+alertmanager_silences_query_duration_seconds_bucket{le="0.005"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="0.01"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="0.025"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="0.05"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="0.1"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="0.25"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="0.5"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="1"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="2.5"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="5"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="10"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="+Inf"} 49
+alertmanager_silences_query_duration_seconds_sum 0.0017641000000000002
+alertmanager_silences_query_duration_seconds_count 49
+# HELP alertmanager_silences_query_errors_total How many silence received queries did not succeed.
+# TYPE alertmanager_silences_query_errors_total counter
+alertmanager_silences_query_errors_total 0
+# HELP alertmanager_silences_snapshot_duration_seconds Duration of the last silence snapshot.
+# TYPE alertmanager_silences_snapshot_duration_seconds summary
+alertmanager_silences_snapshot_duration_seconds{quantile="0.5"} NaN
+alertmanager_silences_snapshot_duration_seconds{quantile="0.9"} NaN
+alertmanager_silences_snapshot_duration_seconds{quantile="0.99"} NaN
+alertmanager_silences_snapshot_duration_seconds_sum 0
+alertmanager_silences_snapshot_duration_seconds_count 0
+# HELP alertmanager_silences_snapshot_size_bytes Size of the last silence snapshot in bytes.
+# TYPE alertmanager_silences_snapshot_size_bytes gauge
+alertmanager_silences_snapshot_size_bytes 0
+# HELP go_gc_duration_seconds A summary of the GC invocation durations.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0"} 0.0001245
+go_gc_duration_seconds{quantile="0.25"} 0.0001245
+go_gc_duration_seconds{quantile="0.5"} 0.0005443
+go_gc_duration_seconds{quantile="0.75"} 0.002426
+go_gc_duration_seconds{quantile="1"} 0.002426
+go_gc_duration_seconds_sum 0.0030948
+go_gc_duration_seconds_count 3
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 43
+# HELP go_info Information about the Go environment.
+# TYPE go_info gauge
+go_info{version="go1.10.3"} 1
+# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+# TYPE go_memstats_alloc_bytes gauge
+go_memstats_alloc_bytes 2.241376e+06
+# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
+# TYPE go_memstats_alloc_bytes_total counter
+go_memstats_alloc_bytes_total 1.1443272e+07
+# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
+# TYPE go_memstats_buck_hash_sys_bytes gauge
+go_memstats_buck_hash_sys_bytes 1.446818e+06
+# HELP go_memstats_frees_total Total number of frees.
+# TYPE go_memstats_frees_total counter
+go_memstats_frees_total 8476
+# HELP go_memstats_gc_cpu_fraction The fraction of this program's available CPU time used by the GC since the program started.
+# TYPE go_memstats_gc_cpu_fraction gauge
+go_memstats_gc_cpu_fraction 0.14217617465320667
+# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+# TYPE go_memstats_gc_sys_bytes gauge
+go_memstats_gc_sys_bytes 405504
+# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
+# TYPE go_memstats_heap_alloc_bytes gauge
+go_memstats_heap_alloc_bytes 2.241376e+06
+# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
+# TYPE go_memstats_heap_idle_bytes gauge
+go_memstats_heap_idle_bytes 2.408448e+06
+# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
+# TYPE go_memstats_heap_inuse_bytes gauge
+go_memstats_heap_inuse_bytes 3.129344e+06
+# HELP go_memstats_heap_objects Number of allocated objects.
+# TYPE go_memstats_heap_objects gauge
+go_memstats_heap_objects 20748
+# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS.
+# TYPE go_memstats_heap_released_bytes gauge
+go_memstats_heap_released_bytes 0
+# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
+# TYPE go_memstats_heap_sys_bytes gauge
+go_memstats_heap_sys_bytes 5.537792e+06
+# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
+# TYPE go_memstats_last_gc_time_seconds gauge
+go_memstats_last_gc_time_seconds 1.5488697615467532e+09
+# HELP go_memstats_lookups_total Total number of pointer lookups.
+# TYPE go_memstats_lookups_total counter
+go_memstats_lookups_total 39
+# HELP go_memstats_mallocs_total Total number of mallocs.
+# TYPE go_memstats_mallocs_total counter
+go_memstats_mallocs_total 29224
+# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
+# TYPE go_memstats_mcache_inuse_bytes gauge
+go_memstats_mcache_inuse_bytes 3472
+# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
+# TYPE go_memstats_mcache_sys_bytes gauge
+go_memstats_mcache_sys_bytes 16384
+# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
+# TYPE go_memstats_mspan_inuse_bytes gauge
+go_memstats_mspan_inuse_bytes 47120
+# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
+# TYPE go_memstats_mspan_sys_bytes gauge
+go_memstats_mspan_sys_bytes 65536
+# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
+# TYPE go_memstats_next_gc_bytes gauge
+go_memstats_next_gc_bytes 4.194304e+06
+# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
+# TYPE go_memstats_other_sys_bytes gauge
+go_memstats_other_sys_bytes 759126
+# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
+# TYPE go_memstats_stack_inuse_bytes gauge
+go_memstats_stack_inuse_bytes 753664
+# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
+# TYPE go_memstats_stack_sys_bytes gauge
+go_memstats_stack_sys_bytes 753664
+# HELP go_memstats_sys_bytes Number of bytes obtained from system.
+# TYPE go_memstats_sys_bytes gauge
+go_memstats_sys_bytes 8.984824e+06
+# HELP go_threads Number of OS threads created.
+# TYPE go_threads gauge
+go_threads 11
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 0.35
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+process_max_fds 1.048576e+06
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+process_open_fds 9
+# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes 1.5843328e+07
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds 1.54886976068e+09
+# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE process_virtual_memory_bytes gauge
+process_virtual_memory_bytes 2.2249472e+07
+# HELP promhttp_metric_handler_requests_in_flight Current number of scrapes being served.
+# TYPE promhttp_metric_handler_requests_in_flight gauge
+promhttp_metric_handler_requests_in_flight 1
+# HELP promhttp_metric_handler_requests_total Total number of scrapes by HTTP status code.
+# TYPE promhttp_metric_handler_requests_total counter
+promhttp_metric_handler_requests_total{code="200"} 0
+promhttp_metric_handler_requests_total{code="500"} 0
+promhttp_metric_handler_requests_total{code="503"} 0

--- a/internal/mock/0.15.3/api/v1/alerts/groups
+++ b/internal/mock/0.15.3/api/v1/alerts/groups
@@ -19,7 +19,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-11-10T12:48:10.73047806Z",
+                            "startsAt": "2019-01-30T17:39:12.7605052Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -63,11 +63,11 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-11-10T12:48:10.73047806Z",
+                            "startsAt": "2019-01-30T17:39:12.7605052Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "16ee9fd6-612e-47b0-bbfe-e3b22dfa5b7b"
+                                    "21f78a8a-18da-4190-ad23-45efa75bf50e"
                                 ],
                                 "state": "suppressed"
                             }
@@ -86,7 +86,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-11-10T12:48:10.73047806Z",
+                            "startsAt": "2019-01-30T17:39:12.7605052Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -119,6 +119,75 @@
                                 "summary": "Example summary"
                             },
                             "endsAt": "0001-01-01T00:00:00Z",
+                            "fingerprint": "44497481566cd3c7",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "dev",
+                                "instance": "server7",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:39:12.7605052Z",
+                            "status": {
+                                "inhibitedBy": null,
+                                "silencedBy": [
+                                    "3fe0ad5b-01d1-4d0a-912d-5a4842daf51d",
+                                    "79adc702-1ef0-4449-8b62-d9dc01cb760b"
+                                ],
+                                "state": "suppressed"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "fingerprint": "af9d8f2f0ccb3970",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "dev",
+                                "instance": "server8",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:39:12.7605052Z",
+                            "status": {
+                                "inhibitedBy": null,
+                                "silencedBy": [
+                                    "3fe0ad5b-01d1-4d0a-912d-5a4842daf51d"
+                                ],
+                                "state": "suppressed"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary",
+                                "url": "http://localhost/example.html"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "fingerprint": "d0aee2649e71388b",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "prod",
+                                "instance": "server1",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:39:12.7605052Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
                             "fingerprint": "3bdb8b68bdce2ae0",
                             "generatorURL": "localhost/prometheus",
                             "labels": {
@@ -128,7 +197,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-11-10T12:48:10.73047806Z",
+                            "startsAt": "2019-01-30T17:39:12.7605052Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -149,7 +218,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-11-10T12:48:10.73047806Z",
+                            "startsAt": "2019-01-30T17:39:12.7605052Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -170,7 +239,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-11-10T12:48:10.73047806Z",
+                            "startsAt": "2019-01-30T17:39:12.7605052Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -191,7 +260,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-11-10T12:48:10.73047806Z",
+                            "startsAt": "2019-01-30T17:39:12.7605052Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -212,82 +281,13 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-11-10T12:48:10.73047806Z",
+                            "startsAt": "2019-01-30T17:39:12.7605052Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "7d0e6d8c-3eb8-4693-bb8f-5917ddd14708"
+                                    "3fe0ad5b-01d1-4d0a-912d-5a4842daf51d"
                                 ],
                                 "state": "suppressed"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "fingerprint": "44497481566cd3c7",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "dev",
-                                "instance": "server7",
-                                "job": "node_ping"
-                            },
-                            "receivers": null,
-                            "startsAt": "2018-11-10T12:48:10.73047806Z",
-                            "status": {
-                                "inhibitedBy": null,
-                                "silencedBy": [
-                                    "7d0e6d8c-3eb8-4693-bb8f-5917ddd14708",
-                                    "74105d8c-e858-4a2e-ae2b-1f8953a3ad82"
-                                ],
-                                "state": "suppressed"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "fingerprint": "af9d8f2f0ccb3970",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "dev",
-                                "instance": "server8",
-                                "job": "node_ping"
-                            },
-                            "receivers": null,
-                            "startsAt": "2018-11-10T12:48:10.73047806Z",
-                            "status": {
-                                "inhibitedBy": null,
-                                "silencedBy": [
-                                    "7d0e6d8c-3eb8-4693-bb8f-5917ddd14708"
-                                ],
-                                "state": "suppressed"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary",
-                                "url": "http://localhost/example.html"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "fingerprint": "d0aee2649e71388b",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "prod",
-                                "instance": "server1",
-                                "job": "node_ping"
-                            },
-                            "receivers": null,
-                            "startsAt": "2018-11-10T12:48:10.73047806Z",
-                            "status": {
-                                "inhibitedBy": [],
-                                "silencedBy": [],
-                                "state": "active"
                             }
                         }
                     ],
@@ -326,7 +326,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-11-10T12:48:10.73047806Z",
+                            "startsAt": "2019-01-30T17:39:12.7605052Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -369,7 +369,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-11-10T12:48:10.73047806Z",
+                            "startsAt": "2019-01-30T17:39:12.7605052Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -416,11 +416,11 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-11-10T12:48:10.73047806Z",
+                            "startsAt": "2019-01-30T17:39:12.7605052Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "16ee9fd6-612e-47b0-bbfe-e3b22dfa5b7b"
+                                    "21f78a8a-18da-4190-ad23-45efa75bf50e"
                                 ],
                                 "state": "suppressed"
                             }
@@ -439,7 +439,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-11-10T12:48:10.73047806Z",
+                            "startsAt": "2019-01-30T17:39:12.7605052Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -449,9 +449,9 @@
                     ],
                     "routeOpts": {
                         "groupBy": [
+                            "alertname",
                             "cluster",
-                            "service",
-                            "alertname"
+                            "service"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,
@@ -484,11 +484,11 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-11-10T12:48:10.73047806Z",
+                            "startsAt": "2019-01-30T17:39:12.7605052Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "7d0e6d8c-3eb8-4693-bb8f-5917ddd14708"
+                                    "3fe0ad5b-01d1-4d0a-912d-5a4842daf51d"
                                 ],
                                 "state": "suppressed"
                             }
@@ -507,12 +507,12 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-11-10T12:48:10.73047806Z",
+                            "startsAt": "2019-01-30T17:39:12.7605052Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "7d0e6d8c-3eb8-4693-bb8f-5917ddd14708",
-                                    "74105d8c-e858-4a2e-ae2b-1f8953a3ad82"
+                                    "3fe0ad5b-01d1-4d0a-912d-5a4842daf51d",
+                                    "79adc702-1ef0-4449-8b62-d9dc01cb760b"
                                 ],
                                 "state": "suppressed"
                             }
@@ -531,11 +531,11 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-11-10T12:48:10.73047806Z",
+                            "startsAt": "2019-01-30T17:39:12.7605052Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "7d0e6d8c-3eb8-4693-bb8f-5917ddd14708"
+                                    "3fe0ad5b-01d1-4d0a-912d-5a4842daf51d"
                                 ],
                                 "state": "suppressed"
                             }
@@ -543,9 +543,9 @@
                     ],
                     "routeOpts": {
                         "groupBy": [
-                            "service",
                             "alertname",
-                            "cluster"
+                            "cluster",
+                            "service"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,
@@ -579,7 +579,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-11-10T12:48:10.73047806Z",
+                            "startsAt": "2019-01-30T17:39:12.7605052Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -600,7 +600,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-11-10T12:48:10.73047806Z",
+                            "startsAt": "2019-01-30T17:39:12.7605052Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -636,6 +636,27 @@
                                 "summary": "Example summary"
                             },
                             "endsAt": "0001-01-01T00:00:00Z",
+                            "fingerprint": "5f1306dab6671183",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "staging",
+                                "instance": "server5",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:39:12.7605052Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
                             "fingerprint": "24e4121619386f95",
                             "generatorURL": "localhost/prometheus",
                             "labels": {
@@ -645,7 +666,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-11-10T12:48:10.73047806Z",
+                            "startsAt": "2019-01-30T17:39:12.7605052Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -666,28 +687,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2018-11-10T12:48:10.73047806Z",
-                            "status": {
-                                "inhibitedBy": [],
-                                "silencedBy": [],
-                                "state": "active"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "fingerprint": "5f1306dab6671183",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "staging",
-                                "instance": "server5",
-                                "job": "node_ping"
-                            },
-                            "receivers": null,
-                            "startsAt": "2018-11-10T12:48:10.73047806Z",
+                            "startsAt": "2019-01-30T17:39:12.7605052Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -733,7 +733,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2018-11-10T12:48:10.73047806Z",
+                            "startsAt": "2019-01-30T17:39:12.7605052Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -743,9 +743,9 @@
                     ],
                     "routeOpts": {
                         "groupBy": [
-                            "alertname",
                             "cluster",
-                            "service"
+                            "service",
+                            "alertname"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,

--- a/internal/mock/0.15.3/api/v1/silences
+++ b/internal/mock/0.15.3/api/v1/silences
@@ -1,10 +1,28 @@
 {
     "data": [
         {
+            "comment": "Silenced server7",
+            "createdBy": "john@example.com",
+            "endsAt": "2063-01-01T00:00:00Z",
+            "id": "79adc702-1ef0-4449-8b62-d9dc01cb760b",
+            "matchers": [
+                {
+                    "isRegex": false,
+                    "name": "instance",
+                    "value": "server7"
+                }
+            ],
+            "startsAt": "2019-01-30T17:39:12.7525183Z",
+            "status": {
+                "state": "active"
+            },
+            "updatedAt": "2019-01-30T17:39:12.7525426Z"
+        },
+        {
             "comment": "Silenced instance",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "16ee9fd6-612e-47b0-bbfe-e3b22dfa5b7b",
+            "id": "21f78a8a-18da-4190-ad23-45efa75bf50e",
             "matchers": [
                 {
                     "isRegex": false,
@@ -12,17 +30,17 @@
                     "value": "web1"
                 }
             ],
-            "startsAt": "2018-11-10T12:48:10.715060277Z",
+            "startsAt": "2019-01-30T17:39:12.7448906Z",
             "status": {
                 "state": "active"
             },
-            "updatedAt": "2018-11-10T12:48:10.715066837Z"
+            "updatedAt": "2019-01-30T17:39:12.7449075Z"
         },
         {
             "comment": "Silenced Host_Down alerts in the dev cluster",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "7d0e6d8c-3eb8-4693-bb8f-5917ddd14708",
+            "id": "3fe0ad5b-01d1-4d0a-912d-5a4842daf51d",
             "matchers": [
                 {
                     "isRegex": false,
@@ -35,29 +53,11 @@
                     "value": "dev"
                 }
             ],
-            "startsAt": "2018-11-10T12:48:10.719460001Z",
+            "startsAt": "2019-01-30T17:39:12.7485402Z",
             "status": {
                 "state": "active"
             },
-            "updatedAt": "2018-11-10T12:48:10.719467625Z"
-        },
-        {
-            "comment": "Silenced server7",
-            "createdBy": "john@example.com",
-            "endsAt": "2063-01-01T00:00:00Z",
-            "id": "74105d8c-e858-4a2e-ae2b-1f8953a3ad82",
-            "matchers": [
-                {
-                    "isRegex": false,
-                    "name": "instance",
-                    "value": "server7"
-                }
-            ],
-            "startsAt": "2018-11-10T12:48:10.725571792Z",
-            "status": {
-                "state": "active"
-            },
-            "updatedAt": "2018-11-10T12:48:10.725579329Z"
+            "updatedAt": "2019-01-30T17:39:12.748559Z"
         }
     ],
     "status": "success"

--- a/internal/mock/0.15.3/api/v1/status
+++ b/internal/mock/0.15.3/api/v1/status
@@ -1,11 +1,11 @@
 {
     "data": {
         "clusterStatus": {
-            "name": "01CVYTM6GBACGKQND75VV0W8WP",
+            "name": "01D2FXFAC43WVBGPS2PQ0TRZY0",
             "peers": [
                 {
                     "address": "172.17.0.2:9094",
-                    "name": "01CVYTM6GBACGKQND75VV0W8WP"
+                    "name": "01D2FXFAC43WVBGPS2PQ0TRZY0"
                 }
             ],
             "status": "ready"
@@ -96,7 +96,7 @@
             "templates": null
         },
         "configYAML": "global:\n  resolve_timeout: 5m\n  http_config: {}\n  smtp_hello: localhost\n  smtp_require_tls: true\n  pagerduty_url: https://events.pagerduty.com/v2/enqueue\n  hipchat_api_url: https://api.hipchat.com/\n  opsgenie_api_url: https://api.opsgenie.com/\n  wechat_api_url: https://qyapi.weixin.qq.com/cgi-bin/\n  victorops_api_url: https://alert.victorops.com/integrations/generic/20131114/alert/\nroute:\n  receiver: default\n  group_by:\n  - alertname\n  routes:\n  - receiver: by-cluster-service\n    group_by:\n    - alertname\n    - cluster\n    - service\n    match_re:\n      alertname: ^(?:.*)$\n    continue: true\n  - receiver: by-name\n    group_by:\n    - alertname\n    match_re:\n      alertname: ^(?:.*)$\n    continue: true\n  group_wait: 15s\n  group_interval: 35s\n  repeat_interval: 999h\ninhibit_rules:\n- source_match:\n    severity: critical\n  target_match:\n    severity: warning\n  equal:\n  - alertname\n  - cluster\n  - service\nreceivers:\n- name: default\n- name: by-cluster-service\n- name: by-name\ntemplates: []\n",
-        "uptime": "2018-11-10T12:47:55.404398788Z",
+        "uptime": "2019-01-30T17:38:57.5483712Z",
         "versionInfo": {
             "branch": "HEAD",
             "buildDate": "20181109-15:40:48",

--- a/internal/mock/0.15.3/metrics
+++ b/internal/mock/0.15.3/metrics
@@ -1,0 +1,465 @@
+# HELP alertmanager_alerts How many alerts by state.
+# TYPE alertmanager_alerts gauge
+alertmanager_alerts{state="active"} 8
+alertmanager_alerts{state="suppressed"} 4
+# HELP alertmanager_alerts_invalid_total The total number of received alerts that were invalid.
+# TYPE alertmanager_alerts_invalid_total counter
+alertmanager_alerts_invalid_total 0
+# HELP alertmanager_alerts_received_total The total number of received alerts.
+# TYPE alertmanager_alerts_received_total counter
+alertmanager_alerts_received_total{status="firing"} 60
+alertmanager_alerts_received_total{status="resolved"} 0
+# HELP alertmanager_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which alertmanager was built.
+# TYPE alertmanager_build_info gauge
+alertmanager_build_info{branch="HEAD",goversion="go1.11.2",revision="d4a7697cc90f8bce62efe7c44b63b542578ec0a1",version="0.15.3"} 1
+# HELP alertmanager_cluster_failed_peers Number indicating the current number of failed peers in the cluster.
+# TYPE alertmanager_cluster_failed_peers gauge
+alertmanager_cluster_failed_peers 0
+# HELP alertmanager_cluster_health_score Health score of the cluster. Lower values are better and zero means 'totally healthy'.
+# TYPE alertmanager_cluster_health_score gauge
+alertmanager_cluster_health_score 0
+# HELP alertmanager_cluster_members Number indicating current number of members in cluster.
+# TYPE alertmanager_cluster_members gauge
+alertmanager_cluster_members 1
+# HELP alertmanager_cluster_messages_pruned_total Total number of cluster messsages pruned.
+# TYPE alertmanager_cluster_messages_pruned_total counter
+alertmanager_cluster_messages_pruned_total 0
+# HELP alertmanager_cluster_messages_queued Number of cluster messsages which are queued.
+# TYPE alertmanager_cluster_messages_queued gauge
+alertmanager_cluster_messages_queued 3
+# HELP alertmanager_cluster_messages_received_size_total Total size of cluster messages received.
+# TYPE alertmanager_cluster_messages_received_size_total counter
+alertmanager_cluster_messages_received_size_total{msg_type="full_state"} 0
+alertmanager_cluster_messages_received_size_total{msg_type="update"} 0
+# HELP alertmanager_cluster_messages_received_total Total number of cluster messsages received.
+# TYPE alertmanager_cluster_messages_received_total counter
+alertmanager_cluster_messages_received_total{msg_type="full_state"} 0
+alertmanager_cluster_messages_received_total{msg_type="update"} 0
+# HELP alertmanager_cluster_messages_sent_size_total Total size of cluster messages sent.
+# TYPE alertmanager_cluster_messages_sent_size_total counter
+alertmanager_cluster_messages_sent_size_total{msg_type="full_state"} 0
+alertmanager_cluster_messages_sent_size_total{msg_type="update"} 0
+# HELP alertmanager_cluster_messages_sent_total Total number of cluster messsages sent.
+# TYPE alertmanager_cluster_messages_sent_total counter
+alertmanager_cluster_messages_sent_total{msg_type="full_state"} 0
+alertmanager_cluster_messages_sent_total{msg_type="update"} 0
+# HELP alertmanager_cluster_peers_joined_total A counter of the number of peers that have joined.
+# TYPE alertmanager_cluster_peers_joined_total counter
+alertmanager_cluster_peers_joined_total 1
+# HELP alertmanager_cluster_peers_left_total A counter of the number of peers that have left.
+# TYPE alertmanager_cluster_peers_left_total counter
+alertmanager_cluster_peers_left_total 0
+# HELP alertmanager_cluster_peers_update_total A counter of the number of peers that have updated metadata.
+# TYPE alertmanager_cluster_peers_update_total counter
+alertmanager_cluster_peers_update_total 0
+# HELP alertmanager_cluster_reconnections_failed_total A counter of the number of failed cluster peer reconnection attempts.
+# TYPE alertmanager_cluster_reconnections_failed_total counter
+alertmanager_cluster_reconnections_failed_total 0
+# HELP alertmanager_cluster_reconnections_total A counter of the number of cluster peer reconnections.
+# TYPE alertmanager_cluster_reconnections_total counter
+alertmanager_cluster_reconnections_total 0
+# HELP alertmanager_config_hash Hash of the currently loaded alertmanager configuration.
+# TYPE alertmanager_config_hash gauge
+alertmanager_config_hash 6.2645753076152e+13
+# HELP alertmanager_config_last_reload_success_timestamp_seconds Timestamp of the last successful configuration reload.
+# TYPE alertmanager_config_last_reload_success_timestamp_seconds gauge
+alertmanager_config_last_reload_success_timestamp_seconds 1.548869937e+09
+# HELP alertmanager_config_last_reload_successful Whether the last configuration reload attempt was successful.
+# TYPE alertmanager_config_last_reload_successful gauge
+alertmanager_config_last_reload_successful 1
+# HELP alertmanager_http_request_duration_seconds Histogram of latencies for HTTP requests.
+# TYPE alertmanager_http_request_duration_seconds histogram
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="0.05"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="0.1"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="0.25"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="0.5"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="0.75"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="1"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="2"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="5"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="20"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="60"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/alerts",method="post",le="+Inf"} 5
+alertmanager_http_request_duration_seconds_sum{handler="/alerts",method="post"} 0.0056600999999999995
+alertmanager_http_request_duration_seconds_count{handler="/alerts",method="post"} 5
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="0.05"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="0.1"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="0.25"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="0.5"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="0.75"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="1"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="2"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="5"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="20"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="60"} 3
+alertmanager_http_request_duration_seconds_bucket{handler="/silences",method="post",le="+Inf"} 3
+alertmanager_http_request_duration_seconds_sum{handler="/silences",method="post"} 0.0008343
+alertmanager_http_request_duration_seconds_count{handler="/silences",method="post"} 3
+# HELP alertmanager_http_response_size_bytes Histogram of response size for HTTP requests.
+# TYPE alertmanager_http_response_size_bytes histogram
+alertmanager_http_response_size_bytes_bucket{handler="/alerts",method="post",le="100"} 5
+alertmanager_http_response_size_bytes_bucket{handler="/alerts",method="post",le="1000"} 5
+alertmanager_http_response_size_bytes_bucket{handler="/alerts",method="post",le="10000"} 5
+alertmanager_http_response_size_bytes_bucket{handler="/alerts",method="post",le="100000"} 5
+alertmanager_http_response_size_bytes_bucket{handler="/alerts",method="post",le="1e+06"} 5
+alertmanager_http_response_size_bytes_bucket{handler="/alerts",method="post",le="1e+07"} 5
+alertmanager_http_response_size_bytes_bucket{handler="/alerts",method="post",le="1e+08"} 5
+alertmanager_http_response_size_bytes_bucket{handler="/alerts",method="post",le="+Inf"} 5
+alertmanager_http_response_size_bytes_sum{handler="/alerts",method="post"} 100
+alertmanager_http_response_size_bytes_count{handler="/alerts",method="post"} 5
+alertmanager_http_response_size_bytes_bucket{handler="/silences",method="post",le="100"} 3
+alertmanager_http_response_size_bytes_bucket{handler="/silences",method="post",le="1000"} 3
+alertmanager_http_response_size_bytes_bucket{handler="/silences",method="post",le="10000"} 3
+alertmanager_http_response_size_bytes_bucket{handler="/silences",method="post",le="100000"} 3
+alertmanager_http_response_size_bytes_bucket{handler="/silences",method="post",le="1e+06"} 3
+alertmanager_http_response_size_bytes_bucket{handler="/silences",method="post",le="1e+07"} 3
+alertmanager_http_response_size_bytes_bucket{handler="/silences",method="post",le="1e+08"} 3
+alertmanager_http_response_size_bytes_bucket{handler="/silences",method="post",le="+Inf"} 3
+alertmanager_http_response_size_bytes_sum{handler="/silences",method="post"} 240
+alertmanager_http_response_size_bytes_count{handler="/silences",method="post"} 3
+# HELP alertmanager_nflog_gc_duration_seconds Duration of the last notification log garbage collection cycle.
+# TYPE alertmanager_nflog_gc_duration_seconds summary
+alertmanager_nflog_gc_duration_seconds{quantile="0.5"} NaN
+alertmanager_nflog_gc_duration_seconds{quantile="0.9"} NaN
+alertmanager_nflog_gc_duration_seconds{quantile="0.99"} NaN
+alertmanager_nflog_gc_duration_seconds_sum 0
+alertmanager_nflog_gc_duration_seconds_count 0
+# HELP alertmanager_nflog_gossip_messages_propagated_total Number of received gossip messages that have been further gossiped.
+# TYPE alertmanager_nflog_gossip_messages_propagated_total counter
+alertmanager_nflog_gossip_messages_propagated_total 0
+# HELP alertmanager_nflog_queries_total Number of notification log queries were received.
+# TYPE alertmanager_nflog_queries_total counter
+alertmanager_nflog_queries_total 0
+# HELP alertmanager_nflog_query_duration_seconds Duration of notification log query evaluation.
+# TYPE alertmanager_nflog_query_duration_seconds histogram
+alertmanager_nflog_query_duration_seconds_bucket{le="0.005"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.01"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.025"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.05"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.1"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.25"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="1"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="2.5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="10"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="+Inf"} 0
+alertmanager_nflog_query_duration_seconds_sum 0
+alertmanager_nflog_query_duration_seconds_count 0
+# HELP alertmanager_nflog_query_errors_total Number notification log received queries that failed.
+# TYPE alertmanager_nflog_query_errors_total counter
+alertmanager_nflog_query_errors_total 0
+# HELP alertmanager_nflog_snapshot_duration_seconds Duration of the last notification log snapshot.
+# TYPE alertmanager_nflog_snapshot_duration_seconds summary
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.5"} NaN
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.9"} NaN
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.99"} NaN
+alertmanager_nflog_snapshot_duration_seconds_sum 0
+alertmanager_nflog_snapshot_duration_seconds_count 0
+# HELP alertmanager_nflog_snapshot_size_bytes Size of the last notification log snapshot in bytes.
+# TYPE alertmanager_nflog_snapshot_size_bytes gauge
+alertmanager_nflog_snapshot_size_bytes 0
+# HELP alertmanager_notification_latency_seconds The latency of notifications in seconds.
+# TYPE alertmanager_notification_latency_seconds histogram
+alertmanager_notification_latency_seconds_bucket{integration="email",le="1"} 0
+alertmanager_notification_latency_seconds_bucket{integration="email",le="5"} 0
+alertmanager_notification_latency_seconds_bucket{integration="email",le="10"} 0
+alertmanager_notification_latency_seconds_bucket{integration="email",le="15"} 0
+alertmanager_notification_latency_seconds_bucket{integration="email",le="20"} 0
+alertmanager_notification_latency_seconds_bucket{integration="email",le="+Inf"} 0
+alertmanager_notification_latency_seconds_sum{integration="email"} 0
+alertmanager_notification_latency_seconds_count{integration="email"} 0
+alertmanager_notification_latency_seconds_bucket{integration="hipchat",le="1"} 0
+alertmanager_notification_latency_seconds_bucket{integration="hipchat",le="5"} 0
+alertmanager_notification_latency_seconds_bucket{integration="hipchat",le="10"} 0
+alertmanager_notification_latency_seconds_bucket{integration="hipchat",le="15"} 0
+alertmanager_notification_latency_seconds_bucket{integration="hipchat",le="20"} 0
+alertmanager_notification_latency_seconds_bucket{integration="hipchat",le="+Inf"} 0
+alertmanager_notification_latency_seconds_sum{integration="hipchat"} 0
+alertmanager_notification_latency_seconds_count{integration="hipchat"} 0
+alertmanager_notification_latency_seconds_bucket{integration="opsgenie",le="1"} 0
+alertmanager_notification_latency_seconds_bucket{integration="opsgenie",le="5"} 0
+alertmanager_notification_latency_seconds_bucket{integration="opsgenie",le="10"} 0
+alertmanager_notification_latency_seconds_bucket{integration="opsgenie",le="15"} 0
+alertmanager_notification_latency_seconds_bucket{integration="opsgenie",le="20"} 0
+alertmanager_notification_latency_seconds_bucket{integration="opsgenie",le="+Inf"} 0
+alertmanager_notification_latency_seconds_sum{integration="opsgenie"} 0
+alertmanager_notification_latency_seconds_count{integration="opsgenie"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pagerduty",le="1"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pagerduty",le="5"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pagerduty",le="10"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pagerduty",le="15"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pagerduty",le="20"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pagerduty",le="+Inf"} 0
+alertmanager_notification_latency_seconds_sum{integration="pagerduty"} 0
+alertmanager_notification_latency_seconds_count{integration="pagerduty"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pushover",le="1"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pushover",le="5"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pushover",le="10"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pushover",le="15"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pushover",le="20"} 0
+alertmanager_notification_latency_seconds_bucket{integration="pushover",le="+Inf"} 0
+alertmanager_notification_latency_seconds_sum{integration="pushover"} 0
+alertmanager_notification_latency_seconds_count{integration="pushover"} 0
+alertmanager_notification_latency_seconds_bucket{integration="slack",le="1"} 0
+alertmanager_notification_latency_seconds_bucket{integration="slack",le="5"} 0
+alertmanager_notification_latency_seconds_bucket{integration="slack",le="10"} 0
+alertmanager_notification_latency_seconds_bucket{integration="slack",le="15"} 0
+alertmanager_notification_latency_seconds_bucket{integration="slack",le="20"} 0
+alertmanager_notification_latency_seconds_bucket{integration="slack",le="+Inf"} 0
+alertmanager_notification_latency_seconds_sum{integration="slack"} 0
+alertmanager_notification_latency_seconds_count{integration="slack"} 0
+alertmanager_notification_latency_seconds_bucket{integration="victorops",le="1"} 0
+alertmanager_notification_latency_seconds_bucket{integration="victorops",le="5"} 0
+alertmanager_notification_latency_seconds_bucket{integration="victorops",le="10"} 0
+alertmanager_notification_latency_seconds_bucket{integration="victorops",le="15"} 0
+alertmanager_notification_latency_seconds_bucket{integration="victorops",le="20"} 0
+alertmanager_notification_latency_seconds_bucket{integration="victorops",le="+Inf"} 0
+alertmanager_notification_latency_seconds_sum{integration="victorops"} 0
+alertmanager_notification_latency_seconds_count{integration="victorops"} 0
+alertmanager_notification_latency_seconds_bucket{integration="webhook",le="1"} 0
+alertmanager_notification_latency_seconds_bucket{integration="webhook",le="5"} 0
+alertmanager_notification_latency_seconds_bucket{integration="webhook",le="10"} 0
+alertmanager_notification_latency_seconds_bucket{integration="webhook",le="15"} 0
+alertmanager_notification_latency_seconds_bucket{integration="webhook",le="20"} 0
+alertmanager_notification_latency_seconds_bucket{integration="webhook",le="+Inf"} 0
+alertmanager_notification_latency_seconds_sum{integration="webhook"} 0
+alertmanager_notification_latency_seconds_count{integration="webhook"} 0
+alertmanager_notification_latency_seconds_bucket{integration="wechat",le="1"} 0
+alertmanager_notification_latency_seconds_bucket{integration="wechat",le="5"} 0
+alertmanager_notification_latency_seconds_bucket{integration="wechat",le="10"} 0
+alertmanager_notification_latency_seconds_bucket{integration="wechat",le="15"} 0
+alertmanager_notification_latency_seconds_bucket{integration="wechat",le="20"} 0
+alertmanager_notification_latency_seconds_bucket{integration="wechat",le="+Inf"} 0
+alertmanager_notification_latency_seconds_sum{integration="wechat"} 0
+alertmanager_notification_latency_seconds_count{integration="wechat"} 0
+# HELP alertmanager_notifications_failed_total The total number of failed notifications.
+# TYPE alertmanager_notifications_failed_total counter
+alertmanager_notifications_failed_total{integration="email"} 0
+alertmanager_notifications_failed_total{integration="hipchat"} 0
+alertmanager_notifications_failed_total{integration="opsgenie"} 0
+alertmanager_notifications_failed_total{integration="pagerduty"} 0
+alertmanager_notifications_failed_total{integration="pushover"} 0
+alertmanager_notifications_failed_total{integration="slack"} 0
+alertmanager_notifications_failed_total{integration="victorops"} 0
+alertmanager_notifications_failed_total{integration="webhook"} 0
+alertmanager_notifications_failed_total{integration="wechat"} 0
+# HELP alertmanager_notifications_total The total number of attempted notifications.
+# TYPE alertmanager_notifications_total counter
+alertmanager_notifications_total{integration="email"} 0
+alertmanager_notifications_total{integration="hipchat"} 0
+alertmanager_notifications_total{integration="opsgenie"} 0
+alertmanager_notifications_total{integration="pagerduty"} 0
+alertmanager_notifications_total{integration="pushover"} 0
+alertmanager_notifications_total{integration="slack"} 0
+alertmanager_notifications_total{integration="victorops"} 0
+alertmanager_notifications_total{integration="webhook"} 0
+alertmanager_notifications_total{integration="wechat"} 0
+# HELP alertmanager_oversize_gossip_message_duration_seconds Duration of oversized gossip message requests.
+# TYPE alertmanager_oversize_gossip_message_duration_seconds histogram
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="0.005"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="0.01"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="0.025"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="0.05"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="0.1"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="0.25"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="0.5"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="1"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="2.5"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="5"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="10"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="nfl",le="+Inf"} 0
+alertmanager_oversize_gossip_message_duration_seconds_sum{key="nfl"} 0
+alertmanager_oversize_gossip_message_duration_seconds_count{key="nfl"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="0.005"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="0.01"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="0.025"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="0.05"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="0.1"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="0.25"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="0.5"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="1"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="2.5"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="5"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="10"} 0
+alertmanager_oversize_gossip_message_duration_seconds_bucket{key="sil",le="+Inf"} 0
+alertmanager_oversize_gossip_message_duration_seconds_sum{key="sil"} 0
+alertmanager_oversize_gossip_message_duration_seconds_count{key="sil"} 0
+# HELP alertmanager_oversized_gossip_message_dropped_total Number of oversized gossip messages that were dropped due to a full message queue.
+# TYPE alertmanager_oversized_gossip_message_dropped_total counter
+alertmanager_oversized_gossip_message_dropped_total{key="nfl"} 0
+alertmanager_oversized_gossip_message_dropped_total{key="sil"} 0
+# HELP alertmanager_oversized_gossip_message_failure_total Number of oversized gossip message sends that failed.
+# TYPE alertmanager_oversized_gossip_message_failure_total counter
+alertmanager_oversized_gossip_message_failure_total{key="nfl"} 0
+alertmanager_oversized_gossip_message_failure_total{key="sil"} 0
+# HELP alertmanager_oversized_gossip_message_sent_total Number of oversized gossip message sent.
+# TYPE alertmanager_oversized_gossip_message_sent_total counter
+alertmanager_oversized_gossip_message_sent_total{key="nfl"} 0
+alertmanager_oversized_gossip_message_sent_total{key="sil"} 0
+# HELP alertmanager_peer_position Position the Alertmanager instance believes it's in. The position determines a peer's behavior in the cluster.
+# TYPE alertmanager_peer_position gauge
+alertmanager_peer_position 0
+# HELP alertmanager_silences How many silences by state.
+# TYPE alertmanager_silences gauge
+alertmanager_silences{state="active"} 3
+alertmanager_silences{state="expired"} 0
+alertmanager_silences{state="pending"} 0
+# HELP alertmanager_silences_gc_duration_seconds Duration of the last silence garbage collection cycle.
+# TYPE alertmanager_silences_gc_duration_seconds summary
+alertmanager_silences_gc_duration_seconds{quantile="0.5"} NaN
+alertmanager_silences_gc_duration_seconds{quantile="0.9"} NaN
+alertmanager_silences_gc_duration_seconds{quantile="0.99"} NaN
+alertmanager_silences_gc_duration_seconds_sum 0
+alertmanager_silences_gc_duration_seconds_count 0
+# HELP alertmanager_silences_gossip_messages_propagated_total Number of received gossip messages that have been further gossiped.
+# TYPE alertmanager_silences_gossip_messages_propagated_total counter
+alertmanager_silences_gossip_messages_propagated_total 0
+# HELP alertmanager_silences_queries_total How many silence queries were received.
+# TYPE alertmanager_silences_queries_total counter
+alertmanager_silences_queries_total 49
+# HELP alertmanager_silences_query_duration_seconds Duration of silence query evaluation.
+# TYPE alertmanager_silences_query_duration_seconds histogram
+alertmanager_silences_query_duration_seconds_bucket{le="0.005"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="0.01"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="0.025"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="0.05"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="0.1"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="0.25"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="0.5"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="1"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="2.5"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="5"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="10"} 49
+alertmanager_silences_query_duration_seconds_bucket{le="+Inf"} 49
+alertmanager_silences_query_duration_seconds_sum 0.0020767000000000003
+alertmanager_silences_query_duration_seconds_count 49
+# HELP alertmanager_silences_query_errors_total How many silence received queries did not succeed.
+# TYPE alertmanager_silences_query_errors_total counter
+alertmanager_silences_query_errors_total 0
+# HELP alertmanager_silences_snapshot_duration_seconds Duration of the last silence snapshot.
+# TYPE alertmanager_silences_snapshot_duration_seconds summary
+alertmanager_silences_snapshot_duration_seconds{quantile="0.5"} NaN
+alertmanager_silences_snapshot_duration_seconds{quantile="0.9"} NaN
+alertmanager_silences_snapshot_duration_seconds{quantile="0.99"} NaN
+alertmanager_silences_snapshot_duration_seconds_sum 0
+alertmanager_silences_snapshot_duration_seconds_count 0
+# HELP alertmanager_silences_snapshot_size_bytes Size of the last silence snapshot in bytes.
+# TYPE alertmanager_silences_snapshot_size_bytes gauge
+alertmanager_silences_snapshot_size_bytes 0
+# HELP go_gc_duration_seconds A summary of the GC invocation durations.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0"} 0.0004534
+go_gc_duration_seconds{quantile="0.25"} 0.0004534
+go_gc_duration_seconds{quantile="0.5"} 0.0030033
+go_gc_duration_seconds{quantile="0.75"} 0.0038476
+go_gc_duration_seconds{quantile="1"} 0.0038476
+go_gc_duration_seconds_sum 0.0073043
+go_gc_duration_seconds_count 3
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 42
+# HELP go_info Information about the Go environment.
+# TYPE go_info gauge
+go_info{version="go1.11.2"} 1
+# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+# TYPE go_memstats_alloc_bytes gauge
+go_memstats_alloc_bytes 1.894456e+06
+# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
+# TYPE go_memstats_alloc_bytes_total counter
+go_memstats_alloc_bytes_total 1.1161424e+07
+# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
+# TYPE go_memstats_buck_hash_sys_bytes gauge
+go_memstats_buck_hash_sys_bytes 1.447612e+06
+# HELP go_memstats_frees_total Total number of frees.
+# TYPE go_memstats_frees_total counter
+go_memstats_frees_total 9213
+# HELP go_memstats_gc_cpu_fraction The fraction of this program's available CPU time used by the GC since the program started.
+# TYPE go_memstats_gc_cpu_fraction gauge
+go_memstats_gc_cpu_fraction 0.1335256203038043
+# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+# TYPE go_memstats_gc_sys_bytes gauge
+go_memstats_gc_sys_bytes 2.371584e+06
+# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
+# TYPE go_memstats_heap_alloc_bytes gauge
+go_memstats_heap_alloc_bytes 1.894456e+06
+# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
+# TYPE go_memstats_heap_idle_bytes gauge
+go_memstats_heap_idle_bytes 6.3578112e+07
+# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
+# TYPE go_memstats_heap_inuse_bytes gauge
+go_memstats_heap_inuse_bytes 2.809856e+06
+# HELP go_memstats_heap_objects Number of allocated objects.
+# TYPE go_memstats_heap_objects gauge
+go_memstats_heap_objects 16071
+# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS.
+# TYPE go_memstats_heap_released_bytes gauge
+go_memstats_heap_released_bytes 0
+# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
+# TYPE go_memstats_heap_sys_bytes gauge
+go_memstats_heap_sys_bytes 6.6387968e+07
+# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
+# TYPE go_memstats_last_gc_time_seconds gauge
+go_memstats_last_gc_time_seconds 1.5488699375647414e+09
+# HELP go_memstats_lookups_total Total number of pointer lookups.
+# TYPE go_memstats_lookups_total counter
+go_memstats_lookups_total 0
+# HELP go_memstats_mallocs_total Total number of mallocs.
+# TYPE go_memstats_mallocs_total counter
+go_memstats_mallocs_total 25284
+# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
+# TYPE go_memstats_mcache_inuse_bytes gauge
+go_memstats_mcache_inuse_bytes 3456
+# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
+# TYPE go_memstats_mcache_sys_bytes gauge
+go_memstats_mcache_sys_bytes 16384
+# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
+# TYPE go_memstats_mspan_inuse_bytes gauge
+go_memstats_mspan_inuse_bytes 41648
+# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
+# TYPE go_memstats_mspan_sys_bytes gauge
+go_memstats_mspan_sys_bytes 49152
+# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
+# TYPE go_memstats_next_gc_bytes gauge
+go_memstats_next_gc_bytes 4.194304e+06
+# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
+# TYPE go_memstats_other_sys_bytes gauge
+go_memstats_other_sys_bytes 766524
+# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
+# TYPE go_memstats_stack_inuse_bytes gauge
+go_memstats_stack_inuse_bytes 720896
+# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
+# TYPE go_memstats_stack_sys_bytes gauge
+go_memstats_stack_sys_bytes 720896
+# HELP go_memstats_sys_bytes Number of bytes obtained from system.
+# TYPE go_memstats_sys_bytes gauge
+go_memstats_sys_bytes 7.176012e+07
+# HELP go_threads Number of OS threads created.
+# TYPE go_threads gauge
+go_threads 10
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 0.36
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+process_max_fds 1.048576e+06
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+process_open_fds 9
+# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes 1.579008e+07
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds 1.54886993683e+09
+# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE process_virtual_memory_bytes gauge
+process_virtual_memory_bytes 1.2056576e+08
+# HELP promhttp_metric_handler_requests_in_flight Current number of scrapes being served.
+# TYPE promhttp_metric_handler_requests_in_flight gauge
+promhttp_metric_handler_requests_in_flight 1
+# HELP promhttp_metric_handler_requests_total Total number of scrapes by HTTP status code.
+# TYPE promhttp_metric_handler_requests_total counter
+promhttp_metric_handler_requests_total{code="200"} 0
+promhttp_metric_handler_requests_total{code="500"} 0
+promhttp_metric_handler_requests_total{code="503"} 0

--- a/internal/mock/0.4.0/api/v1/alerts/groups
+++ b/internal/mock/0.4.0/api/v1/alerts/groups
@@ -18,7 +18,7 @@
                                 "instance": "server5",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:48:22.042998664Z"
+                            "startsAt": "2019-01-30T17:13:26.8858002Z"
                         }
                     ],
                     "routeOpts": {
@@ -56,7 +56,7 @@
                                 "job": "node_exporter"
                             },
                             "silenced": 1,
-                            "startsAt": "2017-06-21T19:48:22.042998664Z"
+                            "startsAt": "2019-01-30T17:13:26.8858002Z"
                         },
                         {
                             "annotations": {
@@ -71,7 +71,7 @@
                                 "instance": "web2",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:48:22.042998664Z"
+                            "startsAt": "2019-01-30T17:13:26.8858002Z"
                         }
                     ],
                     "routeOpts": {
@@ -95,6 +95,22 @@
                     "alerts": [
                         {
                             "annotations": {
+                                "summary": "Example summary",
+                                "url": "http://localhost/example.html"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "inhibited": false,
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "prod",
+                                "instance": "server1",
+                                "job": "node_ping"
+                            },
+                            "startsAt": "2019-01-30T17:13:26.8858002Z"
+                        },
+                        {
+                            "annotations": {
                                 "summary": "Example summary"
                             },
                             "endsAt": "0001-01-01T00:00:00Z",
@@ -106,7 +122,7 @@
                                 "instance": "server2",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:48:22.042998664Z"
+                            "startsAt": "2019-01-30T17:13:26.8858002Z"
                         },
                         {
                             "annotations": {
@@ -121,7 +137,7 @@
                                 "instance": "server3",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:48:22.042998664Z"
+                            "startsAt": "2019-01-30T17:13:26.8858002Z"
                         },
                         {
                             "annotations": {
@@ -136,7 +152,7 @@
                                 "instance": "server4",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:48:22.042998664Z"
+                            "startsAt": "2019-01-30T17:13:26.8858002Z"
                         },
                         {
                             "annotations": {
@@ -151,7 +167,7 @@
                                 "instance": "server5",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:48:22.042998664Z"
+                            "startsAt": "2019-01-30T17:13:26.8858002Z"
                         },
                         {
                             "annotations": {
@@ -167,7 +183,7 @@
                                 "job": "node_ping"
                             },
                             "silenced": 2,
-                            "startsAt": "2017-06-21T19:48:22.042998664Z"
+                            "startsAt": "2019-01-30T17:13:26.8858002Z"
                         },
                         {
                             "annotations": {
@@ -183,7 +199,7 @@
                                 "job": "node_ping"
                             },
                             "silenced": 2,
-                            "startsAt": "2017-06-21T19:48:22.042998664Z"
+                            "startsAt": "2019-01-30T17:13:26.8858002Z"
                         },
                         {
                             "annotations": {
@@ -199,23 +215,7 @@
                                 "job": "node_ping"
                             },
                             "silenced": 2,
-                            "startsAt": "2017-06-21T19:48:22.042998664Z"
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary",
-                                "url": "http://localhost/example.html"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "generatorURL": "localhost/prometheus",
-                            "inhibited": false,
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "prod",
-                                "instance": "server1",
-                                "job": "node_ping"
-                            },
-                            "startsAt": "2017-06-21T19:48:22.042998664Z"
+                            "startsAt": "2019-01-30T17:13:26.8858002Z"
                         }
                     ],
                     "routeOpts": {
@@ -251,7 +251,7 @@
                                 "instance": "server2",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:48:22.042998664Z"
+                            "startsAt": "2019-01-30T17:13:26.8858002Z"
                         }
                     ],
                     "routeOpts": {
@@ -287,7 +287,7 @@
                                 "instance": "server5",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:48:22.042998664Z"
+                            "startsAt": "2019-01-30T17:13:26.8858002Z"
                         }
                     ],
                     "routeOpts": {
@@ -328,7 +328,7 @@
                                 "job": "node_exporter"
                             },
                             "silenced": 1,
-                            "startsAt": "2017-06-21T19:48:22.042998664Z"
+                            "startsAt": "2019-01-30T17:13:26.8858002Z"
                         },
                         {
                             "annotations": {
@@ -343,7 +343,7 @@
                                 "instance": "web2",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:48:22.042998664Z"
+                            "startsAt": "2019-01-30T17:13:26.8858002Z"
                         }
                     ],
                     "routeOpts": {
@@ -378,11 +378,27 @@
                             "labels": {
                                 "alertname": "Host_Down",
                                 "cluster": "dev",
+                                "instance": "server8",
+                                "job": "node_ping"
+                            },
+                            "silenced": 2,
+                            "startsAt": "2019-01-30T17:13:26.8858002Z"
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "inhibited": false,
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "dev",
                                 "instance": "server6",
                                 "job": "node_ping"
                             },
                             "silenced": 2,
-                            "startsAt": "2017-06-21T19:48:22.042998664Z"
+                            "startsAt": "2019-01-30T17:13:26.8858002Z"
                         },
                         {
                             "annotations": {
@@ -398,23 +414,7 @@
                                 "job": "node_ping"
                             },
                             "silenced": 2,
-                            "startsAt": "2017-06-21T19:48:22.042998664Z"
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "generatorURL": "localhost/prometheus",
-                            "inhibited": false,
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "dev",
-                                "instance": "server8",
-                                "job": "node_ping"
-                            },
-                            "silenced": 2,
-                            "startsAt": "2017-06-21T19:48:22.042998664Z"
+                            "startsAt": "2019-01-30T17:13:26.8858002Z"
                         }
                     ],
                     "routeOpts": {
@@ -441,6 +441,21 @@
                     "alerts": [
                         {
                             "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "inhibited": false,
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "prod",
+                                "instance": "server2",
+                                "job": "node_ping"
+                            },
+                            "startsAt": "2019-01-30T17:13:26.8858002Z"
+                        },
+                        {
+                            "annotations": {
                                 "summary": "Example summary",
                                 "url": "http://localhost/example.html"
                             },
@@ -453,22 +468,7 @@
                                 "instance": "server1",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:48:22.042998664Z"
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "generatorURL": "localhost/prometheus",
-                            "inhibited": false,
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "prod",
-                                "instance": "server2",
-                                "job": "node_ping"
-                            },
-                            "startsAt": "2017-06-21T19:48:22.042998664Z"
+                            "startsAt": "2019-01-30T17:13:26.8858002Z"
                         }
                     ],
                     "routeOpts": {
@@ -506,7 +506,7 @@
                                 "instance": "server3",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:48:22.042998664Z"
+                            "startsAt": "2019-01-30T17:13:26.8858002Z"
                         },
                         {
                             "annotations": {
@@ -521,7 +521,7 @@
                                 "instance": "server4",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:48:22.042998664Z"
+                            "startsAt": "2019-01-30T17:13:26.8858002Z"
                         },
                         {
                             "annotations": {
@@ -536,14 +536,14 @@
                                 "instance": "server5",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:48:22.042998664Z"
+                            "startsAt": "2019-01-30T17:13:26.8858002Z"
                         }
                     ],
                     "routeOpts": {
                         "groupBy": [
-                            "alertname",
                             "cluster",
-                            "service"
+                            "service",
+                            "alertname"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,
@@ -575,14 +575,14 @@
                                 "instance": "server2",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:48:22.042998664Z"
+                            "startsAt": "2019-01-30T17:13:26.8858002Z"
                         }
                     ],
                     "routeOpts": {
                         "groupBy": [
+                            "alertname",
                             "cluster",
-                            "service",
-                            "alertname"
+                            "service"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,

--- a/internal/mock/0.4.0/api/v1/silences
+++ b/internal/mock/0.4.0/api/v1/silences
@@ -3,7 +3,7 @@
         "silences": [
             {
                 "comment": "Silenced instance",
-                "createdAt": "2017-06-21T19:48:21.965717444Z",
+                "createdAt": "2019-01-30T17:13:26.8482124Z",
                 "createdBy": "john@example.com",
                 "endsAt": "2063-01-01T00:00:00Z",
                 "id": 1,
@@ -18,7 +18,7 @@
             },
             {
                 "comment": "Silenced Host_Down alerts in the dev cluster",
-                "createdAt": "2017-06-21T19:48:21.9919792Z",
+                "createdAt": "2019-01-30T17:13:26.8718361Z",
                 "createdBy": "john@example.com",
                 "endsAt": "2063-01-01T00:00:00Z",
                 "id": 2,
@@ -38,7 +38,7 @@
             },
             {
                 "comment": "Silenced server7",
-                "createdAt": "2017-06-21T19:48:22.015641383Z",
+                "createdAt": "2019-01-30T17:13:26.8776644Z",
                 "createdBy": "john@example.com",
                 "endsAt": "2063-01-01T00:00:00Z",
                 "id": 3,

--- a/internal/mock/0.4.0/api/v1/status
+++ b/internal/mock/0.4.0/api/v1/status
@@ -79,7 +79,7 @@
             },
             "templates": null
         },
-        "uptime": "2017-06-21T19:48:07.083637259Z",
+        "uptime": "2019-01-30T17:13:11.6270897Z",
         "versionInfo": {
             "branch": "master",
             "buildDate": "20160823-12:57:02",

--- a/internal/mock/0.4.0/metrics
+++ b/internal/mock/0.4.0/metrics
@@ -1,0 +1,250 @@
+# HELP alertmanager_alerts_invalid_total The total number of received alerts that were invalid.
+# TYPE alertmanager_alerts_invalid_total counter
+alertmanager_alerts_invalid_total 0
+# HELP alertmanager_alerts_received_total The total number of received alerts.
+# TYPE alertmanager_alerts_received_total counter
+alertmanager_alerts_received_total{status="firing"} 60
+# HELP alertmanager_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which alertmanager was built.
+# TYPE alertmanager_build_info gauge
+alertmanager_build_info{branch="master",goversion="go1.6.2",revision="7f6bc0b6e303ce36b78284e58edb85304c42b355",version="0.4.0"} 1
+# HELP alertmanager_config_last_reload_success_timestamp_seconds Timestamp of the last successful configuration reload.
+# TYPE alertmanager_config_last_reload_success_timestamp_seconds gauge
+alertmanager_config_last_reload_success_timestamp_seconds 1.548868391e+09
+# HELP alertmanager_config_last_reload_successful Whether the last configuration reload attempt was successful.
+# TYPE alertmanager_config_last_reload_successful gauge
+alertmanager_config_last_reload_successful 1
+# HELP go_gc_duration_seconds A summary of the GC invocation durations.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0"} 0.0007101000000000001
+go_gc_duration_seconds{quantile="0.25"} 0.0007101000000000001
+go_gc_duration_seconds{quantile="0.5"} 0.0007101000000000001
+go_gc_duration_seconds{quantile="0.75"} 0.0007101000000000001
+go_gc_duration_seconds{quantile="1"} 0.0007101000000000001
+go_gc_duration_seconds_sum 0.0007101000000000001
+go_gc_duration_seconds_count 1
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 63
+# HELP http_request_duration_microseconds The HTTP request latencies in microseconds.
+# TYPE http_request_duration_microseconds summary
+http_request_duration_microseconds{handler="add_alerts",quantile="0.5"} 569.8
+http_request_duration_microseconds{handler="add_alerts",quantile="0.9"} 1146.7
+http_request_duration_microseconds{handler="add_alerts",quantile="0.99"} 1146.7
+http_request_duration_microseconds_sum{handler="add_alerts"} 5183.1
+http_request_duration_microseconds_count{handler="add_alerts"} 5
+http_request_duration_microseconds{handler="add_silence",quantile="0.5"} 1386.3
+http_request_duration_microseconds{handler="add_silence",quantile="0.9"} 1394.4
+http_request_duration_microseconds{handler="add_silence",quantile="0.99"} 1394.4
+http_request_duration_microseconds_sum{handler="add_silence"} 21622.7
+http_request_duration_microseconds_count{handler="add_silence"} 3
+http_request_duration_microseconds{handler="alert_groups",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="alert_groups",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="alert_groups",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="alert_groups"} 0
+http_request_duration_microseconds_count{handler="alert_groups"} 0
+http_request_duration_microseconds{handler="app_files",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="app_files",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="app_files",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="app_files"} 0
+http_request_duration_microseconds_count{handler="app_files"} 0
+http_request_duration_microseconds{handler="del_silence",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="del_silence",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="del_silence",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="del_silence"} 0
+http_request_duration_microseconds_count{handler="del_silence"} 0
+http_request_duration_microseconds{handler="get_silence",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="get_silence",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="get_silence",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="get_silence"} 0
+http_request_duration_microseconds_count{handler="get_silence"} 0
+http_request_duration_microseconds{handler="index",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="index",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="index",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="index"} 0
+http_request_duration_microseconds_count{handler="index"} 0
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="legacy_add_alerts"} 0
+http_request_duration_microseconds_count{handler="legacy_add_alerts"} 0
+http_request_duration_microseconds{handler="lib_files",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="lib_files",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="lib_files",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="lib_files"} 0
+http_request_duration_microseconds_count{handler="lib_files"} 0
+http_request_duration_microseconds{handler="list_alerts",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="list_alerts",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="list_alerts",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="list_alerts"} 0
+http_request_duration_microseconds_count{handler="list_alerts"} 0
+http_request_duration_microseconds{handler="list_silences",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="list_silences",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="list_silences",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="list_silences"} 0
+http_request_duration_microseconds_count{handler="list_silences"} 0
+http_request_duration_microseconds{handler="prometheus",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="prometheus",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="prometheus",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="prometheus"} 0
+http_request_duration_microseconds_count{handler="prometheus"} 0
+http_request_duration_microseconds{handler="status",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="status",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="status",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="status"} 0
+http_request_duration_microseconds_count{handler="status"} 0
+# HELP http_request_size_bytes The HTTP request sizes in bytes.
+# TYPE http_request_size_bytes summary
+http_request_size_bytes{handler="add_alerts",quantile="0.5"} 2719
+http_request_size_bytes{handler="add_alerts",quantile="0.9"} 2719
+http_request_size_bytes{handler="add_alerts",quantile="0.99"} 2719
+http_request_size_bytes_sum{handler="add_alerts"} 13595
+http_request_size_bytes_count{handler="add_alerts"} 5
+http_request_size_bytes{handler="add_silence",quantile="0.5"} 358
+http_request_size_bytes{handler="add_silence",quantile="0.9"} 360
+http_request_size_bytes{handler="add_silence",quantile="0.99"} 360
+http_request_size_bytes_sum{handler="add_silence"} 1164
+http_request_size_bytes_count{handler="add_silence"} 3
+http_request_size_bytes{handler="alert_groups",quantile="0.5"} NaN
+http_request_size_bytes{handler="alert_groups",quantile="0.9"} NaN
+http_request_size_bytes{handler="alert_groups",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="alert_groups"} 0
+http_request_size_bytes_count{handler="alert_groups"} 0
+http_request_size_bytes{handler="app_files",quantile="0.5"} NaN
+http_request_size_bytes{handler="app_files",quantile="0.9"} NaN
+http_request_size_bytes{handler="app_files",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="app_files"} 0
+http_request_size_bytes_count{handler="app_files"} 0
+http_request_size_bytes{handler="del_silence",quantile="0.5"} NaN
+http_request_size_bytes{handler="del_silence",quantile="0.9"} NaN
+http_request_size_bytes{handler="del_silence",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="del_silence"} 0
+http_request_size_bytes_count{handler="del_silence"} 0
+http_request_size_bytes{handler="get_silence",quantile="0.5"} NaN
+http_request_size_bytes{handler="get_silence",quantile="0.9"} NaN
+http_request_size_bytes{handler="get_silence",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="get_silence"} 0
+http_request_size_bytes_count{handler="get_silence"} 0
+http_request_size_bytes{handler="index",quantile="0.5"} NaN
+http_request_size_bytes{handler="index",quantile="0.9"} NaN
+http_request_size_bytes{handler="index",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="index"} 0
+http_request_size_bytes_count{handler="index"} 0
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="legacy_add_alerts"} 0
+http_request_size_bytes_count{handler="legacy_add_alerts"} 0
+http_request_size_bytes{handler="lib_files",quantile="0.5"} NaN
+http_request_size_bytes{handler="lib_files",quantile="0.9"} NaN
+http_request_size_bytes{handler="lib_files",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="lib_files"} 0
+http_request_size_bytes_count{handler="lib_files"} 0
+http_request_size_bytes{handler="list_alerts",quantile="0.5"} NaN
+http_request_size_bytes{handler="list_alerts",quantile="0.9"} NaN
+http_request_size_bytes{handler="list_alerts",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="list_alerts"} 0
+http_request_size_bytes_count{handler="list_alerts"} 0
+http_request_size_bytes{handler="list_silences",quantile="0.5"} NaN
+http_request_size_bytes{handler="list_silences",quantile="0.9"} NaN
+http_request_size_bytes{handler="list_silences",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="list_silences"} 0
+http_request_size_bytes_count{handler="list_silences"} 0
+http_request_size_bytes{handler="prometheus",quantile="0.5"} NaN
+http_request_size_bytes{handler="prometheus",quantile="0.9"} NaN
+http_request_size_bytes{handler="prometheus",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="prometheus"} 0
+http_request_size_bytes_count{handler="prometheus"} 0
+http_request_size_bytes{handler="status",quantile="0.5"} NaN
+http_request_size_bytes{handler="status",quantile="0.9"} NaN
+http_request_size_bytes{handler="status",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="status"} 0
+http_request_size_bytes_count{handler="status"} 0
+# HELP http_requests_total Total number of HTTP requests made.
+# TYPE http_requests_total counter
+http_requests_total{code="200",handler="add_alerts",method="post"} 5
+http_requests_total{code="200",handler="add_silence",method="post"} 3
+# HELP http_response_size_bytes The HTTP response sizes in bytes.
+# TYPE http_response_size_bytes summary
+http_response_size_bytes{handler="add_alerts",quantile="0.5"} 20
+http_response_size_bytes{handler="add_alerts",quantile="0.9"} 20
+http_response_size_bytes{handler="add_alerts",quantile="0.99"} 20
+http_response_size_bytes_sum{handler="add_alerts"} 100
+http_response_size_bytes_count{handler="add_alerts"} 5
+http_response_size_bytes{handler="add_silence",quantile="0.5"} 43
+http_response_size_bytes{handler="add_silence",quantile="0.9"} 43
+http_response_size_bytes{handler="add_silence",quantile="0.99"} 43
+http_response_size_bytes_sum{handler="add_silence"} 129
+http_response_size_bytes_count{handler="add_silence"} 3
+http_response_size_bytes{handler="alert_groups",quantile="0.5"} NaN
+http_response_size_bytes{handler="alert_groups",quantile="0.9"} NaN
+http_response_size_bytes{handler="alert_groups",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="alert_groups"} 0
+http_response_size_bytes_count{handler="alert_groups"} 0
+http_response_size_bytes{handler="app_files",quantile="0.5"} NaN
+http_response_size_bytes{handler="app_files",quantile="0.9"} NaN
+http_response_size_bytes{handler="app_files",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="app_files"} 0
+http_response_size_bytes_count{handler="app_files"} 0
+http_response_size_bytes{handler="del_silence",quantile="0.5"} NaN
+http_response_size_bytes{handler="del_silence",quantile="0.9"} NaN
+http_response_size_bytes{handler="del_silence",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="del_silence"} 0
+http_response_size_bytes_count{handler="del_silence"} 0
+http_response_size_bytes{handler="get_silence",quantile="0.5"} NaN
+http_response_size_bytes{handler="get_silence",quantile="0.9"} NaN
+http_response_size_bytes{handler="get_silence",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="get_silence"} 0
+http_response_size_bytes_count{handler="get_silence"} 0
+http_response_size_bytes{handler="index",quantile="0.5"} NaN
+http_response_size_bytes{handler="index",quantile="0.9"} NaN
+http_response_size_bytes{handler="index",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="index"} 0
+http_response_size_bytes_count{handler="index"} 0
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="legacy_add_alerts"} 0
+http_response_size_bytes_count{handler="legacy_add_alerts"} 0
+http_response_size_bytes{handler="lib_files",quantile="0.5"} NaN
+http_response_size_bytes{handler="lib_files",quantile="0.9"} NaN
+http_response_size_bytes{handler="lib_files",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="lib_files"} 0
+http_response_size_bytes_count{handler="lib_files"} 0
+http_response_size_bytes{handler="list_alerts",quantile="0.5"} NaN
+http_response_size_bytes{handler="list_alerts",quantile="0.9"} NaN
+http_response_size_bytes{handler="list_alerts",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="list_alerts"} 0
+http_response_size_bytes_count{handler="list_alerts"} 0
+http_response_size_bytes{handler="list_silences",quantile="0.5"} NaN
+http_response_size_bytes{handler="list_silences",quantile="0.9"} NaN
+http_response_size_bytes{handler="list_silences",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="list_silences"} 0
+http_response_size_bytes_count{handler="list_silences"} 0
+http_response_size_bytes{handler="prometheus",quantile="0.5"} NaN
+http_response_size_bytes{handler="prometheus",quantile="0.9"} NaN
+http_response_size_bytes{handler="prometheus",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="prometheus"} 0
+http_response_size_bytes_count{handler="prometheus"} 0
+http_response_size_bytes{handler="status",quantile="0.5"} NaN
+http_response_size_bytes{handler="status",quantile="0.9"} NaN
+http_response_size_bytes{handler="status",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="status"} 0
+http_response_size_bytes_count{handler="status"} 0
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 0.1
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+process_max_fds 1.048576e+06
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+process_open_fds 9
+# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes 1.2230656e+07
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds 1.54886839033e+09
+# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE process_virtual_memory_bytes gauge
+process_virtual_memory_bytes 1.9038208e+07

--- a/internal/mock/0.4.1/api/v1/alerts/groups
+++ b/internal/mock/0.4.1/api/v1/alerts/groups
@@ -18,7 +18,7 @@
                                 "instance": "server5",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:49:30.405529116Z"
+                            "startsAt": "2019-01-30T17:14:41.6028711Z"
                         }
                     ],
                     "routeOpts": {
@@ -56,7 +56,7 @@
                                 "job": "node_exporter"
                             },
                             "silenced": 1,
-                            "startsAt": "2017-06-21T19:49:30.405529116Z"
+                            "startsAt": "2019-01-30T17:14:41.6028711Z"
                         },
                         {
                             "annotations": {
@@ -71,7 +71,7 @@
                                 "instance": "web2",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:49:30.405529116Z"
+                            "startsAt": "2019-01-30T17:14:41.6028711Z"
                         }
                     ],
                     "routeOpts": {
@@ -102,11 +102,56 @@
                             "inhibited": false,
                             "labels": {
                                 "alertname": "Host_Down",
+                                "cluster": "prod",
+                                "instance": "server2",
+                                "job": "node_ping"
+                            },
+                            "startsAt": "2019-01-30T17:14:41.6028711Z"
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "inhibited": false,
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "staging",
+                                "instance": "server3",
+                                "job": "node_ping"
+                            },
+                            "startsAt": "2019-01-30T17:14:41.6028711Z"
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "inhibited": false,
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "staging",
+                                "instance": "server4",
+                                "job": "node_ping"
+                            },
+                            "startsAt": "2019-01-30T17:14:41.6028711Z"
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "inhibited": false,
+                            "labels": {
+                                "alertname": "Host_Down",
                                 "cluster": "staging",
                                 "instance": "server5",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:49:30.405529116Z"
+                            "startsAt": "2019-01-30T17:14:41.6028711Z"
                         },
                         {
                             "annotations": {
@@ -122,7 +167,7 @@
                                 "job": "node_ping"
                             },
                             "silenced": 2,
-                            "startsAt": "2017-06-21T19:49:30.405529116Z"
+                            "startsAt": "2019-01-30T17:14:41.6028711Z"
                         },
                         {
                             "annotations": {
@@ -138,7 +183,7 @@
                                 "job": "node_ping"
                             },
                             "silenced": 2,
-                            "startsAt": "2017-06-21T19:49:30.405529116Z"
+                            "startsAt": "2019-01-30T17:14:41.6028711Z"
                         },
                         {
                             "annotations": {
@@ -154,7 +199,7 @@
                                 "job": "node_ping"
                             },
                             "silenced": 2,
-                            "startsAt": "2017-06-21T19:49:30.405529116Z"
+                            "startsAt": "2019-01-30T17:14:41.6028711Z"
                         },
                         {
                             "annotations": {
@@ -170,52 +215,7 @@
                                 "instance": "server1",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:49:30.405529116Z"
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "generatorURL": "localhost/prometheus",
-                            "inhibited": false,
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "prod",
-                                "instance": "server2",
-                                "job": "node_ping"
-                            },
-                            "startsAt": "2017-06-21T19:49:30.405529116Z"
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "generatorURL": "localhost/prometheus",
-                            "inhibited": false,
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "staging",
-                                "instance": "server3",
-                                "job": "node_ping"
-                            },
-                            "startsAt": "2017-06-21T19:49:30.405529116Z"
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "generatorURL": "localhost/prometheus",
-                            "inhibited": false,
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "staging",
-                                "instance": "server4",
-                                "job": "node_ping"
-                            },
-                            "startsAt": "2017-06-21T19:49:30.405529116Z"
+                            "startsAt": "2019-01-30T17:14:41.6028711Z"
                         }
                     ],
                     "routeOpts": {
@@ -251,7 +251,7 @@
                                 "instance": "server2",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:49:30.405529116Z"
+                            "startsAt": "2019-01-30T17:14:41.6028711Z"
                         }
                     ],
                     "routeOpts": {
@@ -287,14 +287,14 @@
                                 "instance": "server5",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:49:30.405529116Z"
+                            "startsAt": "2019-01-30T17:14:41.6028711Z"
                         }
                     ],
                     "routeOpts": {
                         "groupBy": [
-                            "service",
                             "alertname",
-                            "cluster"
+                            "cluster",
+                            "service"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,
@@ -328,7 +328,7 @@
                                 "job": "node_exporter"
                             },
                             "silenced": 1,
-                            "startsAt": "2017-06-21T19:49:30.405529116Z"
+                            "startsAt": "2019-01-30T17:14:41.6028711Z"
                         },
                         {
                             "annotations": {
@@ -343,7 +343,7 @@
                                 "instance": "web2",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:49:30.405529116Z"
+                            "startsAt": "2019-01-30T17:14:41.6028711Z"
                         }
                     ],
                     "routeOpts": {
@@ -382,7 +382,7 @@
                                 "job": "node_ping"
                             },
                             "silenced": 2,
-                            "startsAt": "2017-06-21T19:49:30.405529116Z"
+                            "startsAt": "2019-01-30T17:14:41.6028711Z"
                         },
                         {
                             "annotations": {
@@ -398,7 +398,7 @@
                                 "job": "node_ping"
                             },
                             "silenced": 2,
-                            "startsAt": "2017-06-21T19:49:30.405529116Z"
+                            "startsAt": "2019-01-30T17:14:41.6028711Z"
                         },
                         {
                             "annotations": {
@@ -414,7 +414,7 @@
                                 "job": "node_ping"
                             },
                             "silenced": 2,
-                            "startsAt": "2017-06-21T19:49:30.405529116Z"
+                            "startsAt": "2019-01-30T17:14:41.6028711Z"
                         }
                     ],
                     "routeOpts": {
@@ -453,7 +453,7 @@
                                 "instance": "server1",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:49:30.405529116Z"
+                            "startsAt": "2019-01-30T17:14:41.6028711Z"
                         },
                         {
                             "annotations": {
@@ -468,7 +468,7 @@
                                 "instance": "server2",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:49:30.405529116Z"
+                            "startsAt": "2019-01-30T17:14:41.6028711Z"
                         }
                     ],
                     "routeOpts": {
@@ -506,7 +506,7 @@
                                 "instance": "server3",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:49:30.405529116Z"
+                            "startsAt": "2019-01-30T17:14:41.6028711Z"
                         },
                         {
                             "annotations": {
@@ -521,7 +521,7 @@
                                 "instance": "server4",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:49:30.405529116Z"
+                            "startsAt": "2019-01-30T17:14:41.6028711Z"
                         },
                         {
                             "annotations": {
@@ -536,7 +536,7 @@
                                 "instance": "server5",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:49:30.405529116Z"
+                            "startsAt": "2019-01-30T17:14:41.6028711Z"
                         }
                     ],
                     "routeOpts": {
@@ -575,14 +575,14 @@
                                 "instance": "server2",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:49:30.405529116Z"
+                            "startsAt": "2019-01-30T17:14:41.6028711Z"
                         }
                     ],
                     "routeOpts": {
                         "groupBy": [
+                            "alertname",
                             "cluster",
-                            "service",
-                            "alertname"
+                            "service"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,

--- a/internal/mock/0.4.1/api/v1/silences
+++ b/internal/mock/0.4.1/api/v1/silences
@@ -3,7 +3,7 @@
         "silences": [
             {
                 "comment": "Silenced instance",
-                "createdAt": "2017-06-21T19:49:30.335152699Z",
+                "createdAt": "2019-01-30T17:14:41.5805344Z",
                 "createdBy": "john@example.com",
                 "endsAt": "2063-01-01T00:00:00Z",
                 "id": 1,
@@ -18,7 +18,7 @@
             },
             {
                 "comment": "Silenced Host_Down alerts in the dev cluster",
-                "createdAt": "2017-06-21T19:49:30.361343044Z",
+                "createdAt": "2019-01-30T17:14:41.5875655Z",
                 "createdBy": "john@example.com",
                 "endsAt": "2063-01-01T00:00:00Z",
                 "id": 2,
@@ -38,7 +38,7 @@
             },
             {
                 "comment": "Silenced server7",
-                "createdAt": "2017-06-21T19:49:30.38309224Z",
+                "createdAt": "2019-01-30T17:14:41.5934903Z",
                 "createdBy": "john@example.com",
                 "endsAt": "2063-01-01T00:00:00Z",
                 "id": 3,

--- a/internal/mock/0.4.1/api/v1/status
+++ b/internal/mock/0.4.1/api/v1/status
@@ -79,7 +79,7 @@
             },
             "templates": null
         },
-        "uptime": "2017-06-21T19:49:15.472651851Z",
+        "uptime": "2019-01-30T17:14:26.3891947Z",
         "versionInfo": {
             "branch": "master",
             "buildDate": "20160831-22:29:03",

--- a/internal/mock/0.4.1/metrics
+++ b/internal/mock/0.4.1/metrics
@@ -1,0 +1,250 @@
+# HELP alertmanager_alerts_invalid_total The total number of received alerts that were invalid.
+# TYPE alertmanager_alerts_invalid_total counter
+alertmanager_alerts_invalid_total 0
+# HELP alertmanager_alerts_received_total The total number of received alerts.
+# TYPE alertmanager_alerts_received_total counter
+alertmanager_alerts_received_total{status="firing"} 60
+# HELP alertmanager_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which alertmanager was built.
+# TYPE alertmanager_build_info gauge
+alertmanager_build_info{branch="master",goversion="go1.6.2",revision="230a80a08942c78e1213e69959d571c292473bde",version="0.4.1"} 1
+# HELP alertmanager_config_last_reload_success_timestamp_seconds Timestamp of the last successful configuration reload.
+# TYPE alertmanager_config_last_reload_success_timestamp_seconds gauge
+alertmanager_config_last_reload_success_timestamp_seconds 1.548868466e+09
+# HELP alertmanager_config_last_reload_successful Whether the last configuration reload attempt was successful.
+# TYPE alertmanager_config_last_reload_successful gauge
+alertmanager_config_last_reload_successful 1
+# HELP go_gc_duration_seconds A summary of the GC invocation durations.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0"} 0.010792300000000001
+go_gc_duration_seconds{quantile="0.25"} 0.010792300000000001
+go_gc_duration_seconds{quantile="0.5"} 0.010792300000000001
+go_gc_duration_seconds{quantile="0.75"} 0.010792300000000001
+go_gc_duration_seconds{quantile="1"} 0.010792300000000001
+go_gc_duration_seconds_sum 0.010792300000000001
+go_gc_duration_seconds_count 1
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 67
+# HELP http_request_duration_microseconds The HTTP request latencies in microseconds.
+# TYPE http_request_duration_microseconds summary
+http_request_duration_microseconds{handler="add_alerts",quantile="0.5"} 456.4
+http_request_duration_microseconds{handler="add_alerts",quantile="0.9"} 724.4
+http_request_duration_microseconds{handler="add_alerts",quantile="0.99"} 724.4
+http_request_duration_microseconds_sum{handler="add_alerts"} 6561.999999999999
+http_request_duration_microseconds_count{handler="add_alerts"} 5
+http_request_duration_microseconds{handler="add_silence",quantile="0.5"} 1679.4
+http_request_duration_microseconds{handler="add_silence",quantile="0.9"} 2454.8
+http_request_duration_microseconds{handler="add_silence",quantile="0.99"} 2454.8
+http_request_duration_microseconds_sum{handler="add_silence"} 7310
+http_request_duration_microseconds_count{handler="add_silence"} 3
+http_request_duration_microseconds{handler="alert_groups",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="alert_groups",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="alert_groups",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="alert_groups"} 0
+http_request_duration_microseconds_count{handler="alert_groups"} 0
+http_request_duration_microseconds{handler="app_files",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="app_files",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="app_files",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="app_files"} 0
+http_request_duration_microseconds_count{handler="app_files"} 0
+http_request_duration_microseconds{handler="del_silence",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="del_silence",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="del_silence",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="del_silence"} 0
+http_request_duration_microseconds_count{handler="del_silence"} 0
+http_request_duration_microseconds{handler="get_silence",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="get_silence",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="get_silence",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="get_silence"} 0
+http_request_duration_microseconds_count{handler="get_silence"} 0
+http_request_duration_microseconds{handler="index",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="index",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="index",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="index"} 0
+http_request_duration_microseconds_count{handler="index"} 0
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="legacy_add_alerts"} 0
+http_request_duration_microseconds_count{handler="legacy_add_alerts"} 0
+http_request_duration_microseconds{handler="lib_files",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="lib_files",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="lib_files",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="lib_files"} 0
+http_request_duration_microseconds_count{handler="lib_files"} 0
+http_request_duration_microseconds{handler="list_alerts",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="list_alerts",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="list_alerts",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="list_alerts"} 0
+http_request_duration_microseconds_count{handler="list_alerts"} 0
+http_request_duration_microseconds{handler="list_silences",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="list_silences",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="list_silences",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="list_silences"} 0
+http_request_duration_microseconds_count{handler="list_silences"} 0
+http_request_duration_microseconds{handler="prometheus",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="prometheus",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="prometheus",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="prometheus"} 0
+http_request_duration_microseconds_count{handler="prometheus"} 0
+http_request_duration_microseconds{handler="status",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="status",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="status",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="status"} 0
+http_request_duration_microseconds_count{handler="status"} 0
+# HELP http_request_size_bytes The HTTP request sizes in bytes.
+# TYPE http_request_size_bytes summary
+http_request_size_bytes{handler="add_alerts",quantile="0.5"} 2719
+http_request_size_bytes{handler="add_alerts",quantile="0.9"} 2719
+http_request_size_bytes{handler="add_alerts",quantile="0.99"} 2719
+http_request_size_bytes_sum{handler="add_alerts"} 13595
+http_request_size_bytes_count{handler="add_alerts"} 5
+http_request_size_bytes{handler="add_silence",quantile="0.5"} 358
+http_request_size_bytes{handler="add_silence",quantile="0.9"} 360
+http_request_size_bytes{handler="add_silence",quantile="0.99"} 360
+http_request_size_bytes_sum{handler="add_silence"} 1164
+http_request_size_bytes_count{handler="add_silence"} 3
+http_request_size_bytes{handler="alert_groups",quantile="0.5"} NaN
+http_request_size_bytes{handler="alert_groups",quantile="0.9"} NaN
+http_request_size_bytes{handler="alert_groups",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="alert_groups"} 0
+http_request_size_bytes_count{handler="alert_groups"} 0
+http_request_size_bytes{handler="app_files",quantile="0.5"} NaN
+http_request_size_bytes{handler="app_files",quantile="0.9"} NaN
+http_request_size_bytes{handler="app_files",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="app_files"} 0
+http_request_size_bytes_count{handler="app_files"} 0
+http_request_size_bytes{handler="del_silence",quantile="0.5"} NaN
+http_request_size_bytes{handler="del_silence",quantile="0.9"} NaN
+http_request_size_bytes{handler="del_silence",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="del_silence"} 0
+http_request_size_bytes_count{handler="del_silence"} 0
+http_request_size_bytes{handler="get_silence",quantile="0.5"} NaN
+http_request_size_bytes{handler="get_silence",quantile="0.9"} NaN
+http_request_size_bytes{handler="get_silence",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="get_silence"} 0
+http_request_size_bytes_count{handler="get_silence"} 0
+http_request_size_bytes{handler="index",quantile="0.5"} NaN
+http_request_size_bytes{handler="index",quantile="0.9"} NaN
+http_request_size_bytes{handler="index",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="index"} 0
+http_request_size_bytes_count{handler="index"} 0
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="legacy_add_alerts"} 0
+http_request_size_bytes_count{handler="legacy_add_alerts"} 0
+http_request_size_bytes{handler="lib_files",quantile="0.5"} NaN
+http_request_size_bytes{handler="lib_files",quantile="0.9"} NaN
+http_request_size_bytes{handler="lib_files",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="lib_files"} 0
+http_request_size_bytes_count{handler="lib_files"} 0
+http_request_size_bytes{handler="list_alerts",quantile="0.5"} NaN
+http_request_size_bytes{handler="list_alerts",quantile="0.9"} NaN
+http_request_size_bytes{handler="list_alerts",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="list_alerts"} 0
+http_request_size_bytes_count{handler="list_alerts"} 0
+http_request_size_bytes{handler="list_silences",quantile="0.5"} NaN
+http_request_size_bytes{handler="list_silences",quantile="0.9"} NaN
+http_request_size_bytes{handler="list_silences",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="list_silences"} 0
+http_request_size_bytes_count{handler="list_silences"} 0
+http_request_size_bytes{handler="prometheus",quantile="0.5"} NaN
+http_request_size_bytes{handler="prometheus",quantile="0.9"} NaN
+http_request_size_bytes{handler="prometheus",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="prometheus"} 0
+http_request_size_bytes_count{handler="prometheus"} 0
+http_request_size_bytes{handler="status",quantile="0.5"} NaN
+http_request_size_bytes{handler="status",quantile="0.9"} NaN
+http_request_size_bytes{handler="status",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="status"} 0
+http_request_size_bytes_count{handler="status"} 0
+# HELP http_requests_total Total number of HTTP requests made.
+# TYPE http_requests_total counter
+http_requests_total{code="200",handler="add_alerts",method="post"} 5
+http_requests_total{code="200",handler="add_silence",method="post"} 3
+# HELP http_response_size_bytes The HTTP response sizes in bytes.
+# TYPE http_response_size_bytes summary
+http_response_size_bytes{handler="add_alerts",quantile="0.5"} 20
+http_response_size_bytes{handler="add_alerts",quantile="0.9"} 20
+http_response_size_bytes{handler="add_alerts",quantile="0.99"} 20
+http_response_size_bytes_sum{handler="add_alerts"} 100
+http_response_size_bytes_count{handler="add_alerts"} 5
+http_response_size_bytes{handler="add_silence",quantile="0.5"} 43
+http_response_size_bytes{handler="add_silence",quantile="0.9"} 43
+http_response_size_bytes{handler="add_silence",quantile="0.99"} 43
+http_response_size_bytes_sum{handler="add_silence"} 129
+http_response_size_bytes_count{handler="add_silence"} 3
+http_response_size_bytes{handler="alert_groups",quantile="0.5"} NaN
+http_response_size_bytes{handler="alert_groups",quantile="0.9"} NaN
+http_response_size_bytes{handler="alert_groups",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="alert_groups"} 0
+http_response_size_bytes_count{handler="alert_groups"} 0
+http_response_size_bytes{handler="app_files",quantile="0.5"} NaN
+http_response_size_bytes{handler="app_files",quantile="0.9"} NaN
+http_response_size_bytes{handler="app_files",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="app_files"} 0
+http_response_size_bytes_count{handler="app_files"} 0
+http_response_size_bytes{handler="del_silence",quantile="0.5"} NaN
+http_response_size_bytes{handler="del_silence",quantile="0.9"} NaN
+http_response_size_bytes{handler="del_silence",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="del_silence"} 0
+http_response_size_bytes_count{handler="del_silence"} 0
+http_response_size_bytes{handler="get_silence",quantile="0.5"} NaN
+http_response_size_bytes{handler="get_silence",quantile="0.9"} NaN
+http_response_size_bytes{handler="get_silence",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="get_silence"} 0
+http_response_size_bytes_count{handler="get_silence"} 0
+http_response_size_bytes{handler="index",quantile="0.5"} NaN
+http_response_size_bytes{handler="index",quantile="0.9"} NaN
+http_response_size_bytes{handler="index",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="index"} 0
+http_response_size_bytes_count{handler="index"} 0
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="legacy_add_alerts"} 0
+http_response_size_bytes_count{handler="legacy_add_alerts"} 0
+http_response_size_bytes{handler="lib_files",quantile="0.5"} NaN
+http_response_size_bytes{handler="lib_files",quantile="0.9"} NaN
+http_response_size_bytes{handler="lib_files",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="lib_files"} 0
+http_response_size_bytes_count{handler="lib_files"} 0
+http_response_size_bytes{handler="list_alerts",quantile="0.5"} NaN
+http_response_size_bytes{handler="list_alerts",quantile="0.9"} NaN
+http_response_size_bytes{handler="list_alerts",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="list_alerts"} 0
+http_response_size_bytes_count{handler="list_alerts"} 0
+http_response_size_bytes{handler="list_silences",quantile="0.5"} NaN
+http_response_size_bytes{handler="list_silences",quantile="0.9"} NaN
+http_response_size_bytes{handler="list_silences",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="list_silences"} 0
+http_response_size_bytes_count{handler="list_silences"} 0
+http_response_size_bytes{handler="prometheus",quantile="0.5"} NaN
+http_response_size_bytes{handler="prometheus",quantile="0.9"} NaN
+http_response_size_bytes{handler="prometheus",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="prometheus"} 0
+http_response_size_bytes_count{handler="prometheus"} 0
+http_response_size_bytes{handler="status",quantile="0.5"} NaN
+http_response_size_bytes{handler="status",quantile="0.9"} NaN
+http_response_size_bytes{handler="status",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="status"} 0
+http_response_size_bytes_count{handler="status"} 0
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 0.2
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+process_max_fds 1.048576e+06
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+process_open_fds 9
+# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes 1.2374016e+07
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds 1.54886846369e+09
+# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE process_virtual_memory_bytes gauge
+process_virtual_memory_bytes 1.90464e+07

--- a/internal/mock/0.4.2/api/v1/alerts/groups
+++ b/internal/mock/0.4.2/api/v1/alerts/groups
@@ -18,7 +18,7 @@
                                 "instance": "server5",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:50:38.674943416Z"
+                            "startsAt": "2019-01-30T17:15:53.7623098Z"
                         }
                     ],
                     "routeOpts": {
@@ -56,7 +56,7 @@
                                 "job": "node_exporter"
                             },
                             "silenced": 1,
-                            "startsAt": "2017-06-21T19:50:38.674943416Z"
+                            "startsAt": "2019-01-30T17:15:53.7623098Z"
                         },
                         {
                             "annotations": {
@@ -71,7 +71,7 @@
                                 "instance": "web2",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:50:38.674943416Z"
+                            "startsAt": "2019-01-30T17:15:53.7623098Z"
                         }
                     ],
                     "routeOpts": {
@@ -102,12 +102,42 @@
                             "inhibited": false,
                             "labels": {
                                 "alertname": "Host_Down",
+                                "cluster": "staging",
+                                "instance": "server4",
+                                "job": "node_ping"
+                            },
+                            "startsAt": "2019-01-30T17:15:53.7623098Z"
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "inhibited": false,
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "staging",
+                                "instance": "server5",
+                                "job": "node_ping"
+                            },
+                            "startsAt": "2019-01-30T17:15:53.7623098Z"
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "inhibited": false,
+                            "labels": {
+                                "alertname": "Host_Down",
                                 "cluster": "dev",
                                 "instance": "server6",
                                 "job": "node_ping"
                             },
                             "silenced": 2,
-                            "startsAt": "2017-06-21T19:50:38.674943416Z"
+                            "startsAt": "2019-01-30T17:15:53.7623098Z"
                         },
                         {
                             "annotations": {
@@ -123,7 +153,7 @@
                                 "job": "node_ping"
                             },
                             "silenced": 2,
-                            "startsAt": "2017-06-21T19:50:38.674943416Z"
+                            "startsAt": "2019-01-30T17:15:53.7623098Z"
                         },
                         {
                             "annotations": {
@@ -139,7 +169,7 @@
                                 "job": "node_ping"
                             },
                             "silenced": 2,
-                            "startsAt": "2017-06-21T19:50:38.674943416Z"
+                            "startsAt": "2019-01-30T17:15:53.7623098Z"
                         },
                         {
                             "annotations": {
@@ -155,7 +185,7 @@
                                 "instance": "server1",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:50:38.674943416Z"
+                            "startsAt": "2019-01-30T17:15:53.7623098Z"
                         },
                         {
                             "annotations": {
@@ -170,7 +200,7 @@
                                 "instance": "server2",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:50:38.674943416Z"
+                            "startsAt": "2019-01-30T17:15:53.7623098Z"
                         },
                         {
                             "annotations": {
@@ -185,37 +215,7 @@
                                 "instance": "server3",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:50:38.674943416Z"
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "generatorURL": "localhost/prometheus",
-                            "inhibited": false,
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "staging",
-                                "instance": "server4",
-                                "job": "node_ping"
-                            },
-                            "startsAt": "2017-06-21T19:50:38.674943416Z"
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "generatorURL": "localhost/prometheus",
-                            "inhibited": false,
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "staging",
-                                "instance": "server5",
-                                "job": "node_ping"
-                            },
-                            "startsAt": "2017-06-21T19:50:38.674943416Z"
+                            "startsAt": "2019-01-30T17:15:53.7623098Z"
                         }
                     ],
                     "routeOpts": {
@@ -251,7 +251,7 @@
                                 "instance": "server2",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:50:38.674943416Z"
+                            "startsAt": "2019-01-30T17:15:53.7623098Z"
                         }
                     ],
                     "routeOpts": {
@@ -287,14 +287,14 @@
                                 "instance": "server5",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:50:38.674943416Z"
+                            "startsAt": "2019-01-30T17:15:53.7623098Z"
                         }
                     ],
                     "routeOpts": {
                         "groupBy": [
-                            "alertname",
                             "cluster",
-                            "service"
+                            "service",
+                            "alertname"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,
@@ -328,7 +328,7 @@
                                 "job": "node_exporter"
                             },
                             "silenced": 1,
-                            "startsAt": "2017-06-21T19:50:38.674943416Z"
+                            "startsAt": "2019-01-30T17:15:53.7623098Z"
                         },
                         {
                             "annotations": {
@@ -343,7 +343,7 @@
                                 "instance": "web2",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:50:38.674943416Z"
+                            "startsAt": "2019-01-30T17:15:53.7623098Z"
                         }
                     ],
                     "routeOpts": {
@@ -378,11 +378,27 @@
                             "labels": {
                                 "alertname": "Host_Down",
                                 "cluster": "dev",
+                                "instance": "server6",
+                                "job": "node_ping"
+                            },
+                            "silenced": 2,
+                            "startsAt": "2019-01-30T17:15:53.7623098Z"
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "inhibited": false,
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "dev",
                                 "instance": "server7",
                                 "job": "node_ping"
                             },
                             "silenced": 2,
-                            "startsAt": "2017-06-21T19:50:38.674943416Z"
+                            "startsAt": "2019-01-30T17:15:53.7623098Z"
                         },
                         {
                             "annotations": {
@@ -398,23 +414,7 @@
                                 "job": "node_ping"
                             },
                             "silenced": 2,
-                            "startsAt": "2017-06-21T19:50:38.674943416Z"
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "generatorURL": "localhost/prometheus",
-                            "inhibited": false,
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "dev",
-                                "instance": "server6",
-                                "job": "node_ping"
-                            },
-                            "silenced": 2,
-                            "startsAt": "2017-06-21T19:50:38.674943416Z"
+                            "startsAt": "2019-01-30T17:15:53.7623098Z"
                         }
                     ],
                     "routeOpts": {
@@ -453,7 +453,7 @@
                                 "instance": "server1",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:50:38.674943416Z"
+                            "startsAt": "2019-01-30T17:15:53.7623098Z"
                         },
                         {
                             "annotations": {
@@ -468,7 +468,7 @@
                                 "instance": "server2",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:50:38.674943416Z"
+                            "startsAt": "2019-01-30T17:15:53.7623098Z"
                         }
                     ],
                     "routeOpts": {
@@ -503,10 +503,25 @@
                             "labels": {
                                 "alertname": "Host_Down",
                                 "cluster": "staging",
+                                "instance": "server5",
+                                "job": "node_ping"
+                            },
+                            "startsAt": "2019-01-30T17:15:53.7623098Z"
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "inhibited": false,
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "staging",
                                 "instance": "server3",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:50:38.674943416Z"
+                            "startsAt": "2019-01-30T17:15:53.7623098Z"
                         },
                         {
                             "annotations": {
@@ -521,22 +536,7 @@
                                 "instance": "server4",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:50:38.674943416Z"
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "generatorURL": "localhost/prometheus",
-                            "inhibited": false,
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "staging",
-                                "instance": "server5",
-                                "job": "node_ping"
-                            },
-                            "startsAt": "2017-06-21T19:50:38.674943416Z"
+                            "startsAt": "2019-01-30T17:15:53.7623098Z"
                         }
                     ],
                     "routeOpts": {
@@ -575,14 +575,14 @@
                                 "instance": "server2",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:50:38.674943416Z"
+                            "startsAt": "2019-01-30T17:15:53.7623098Z"
                         }
                     ],
                     "routeOpts": {
                         "groupBy": [
-                            "alertname",
                             "cluster",
-                            "service"
+                            "service",
+                            "alertname"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,

--- a/internal/mock/0.4.2/api/v1/silences
+++ b/internal/mock/0.4.2/api/v1/silences
@@ -3,7 +3,7 @@
         "silences": [
             {
                 "comment": "Silenced instance",
-                "createdAt": "2017-06-21T19:50:38.603387691Z",
+                "createdAt": "2019-01-30T17:15:53.7422076Z",
                 "createdBy": "john@example.com",
                 "endsAt": "2063-01-01T00:00:00Z",
                 "id": 1,
@@ -18,7 +18,7 @@
             },
             {
                 "comment": "Silenced Host_Down alerts in the dev cluster",
-                "createdAt": "2017-06-21T19:50:38.627448522Z",
+                "createdAt": "2019-01-30T17:15:53.7479117Z",
                 "createdBy": "john@example.com",
                 "endsAt": "2063-01-01T00:00:00Z",
                 "id": 2,
@@ -38,7 +38,7 @@
             },
             {
                 "comment": "Silenced server7",
-                "createdAt": "2017-06-21T19:50:38.649598373Z",
+                "createdAt": "2019-01-30T17:15:53.7554814Z",
                 "createdBy": "john@example.com",
                 "endsAt": "2063-01-01T00:00:00Z",
                 "id": 3,

--- a/internal/mock/0.4.2/api/v1/status
+++ b/internal/mock/0.4.2/api/v1/status
@@ -79,7 +79,7 @@
             },
             "templates": null
         },
-        "uptime": "2017-06-21T19:50:23.725154599Z",
+        "uptime": "2019-01-30T17:15:38.587823Z",
         "versionInfo": {
             "branch": "master",
             "buildDate": "20160902-15:33:13",

--- a/internal/mock/0.4.2/metrics
+++ b/internal/mock/0.4.2/metrics
@@ -1,0 +1,250 @@
+# HELP alertmanager_alerts_invalid_total The total number of received alerts that were invalid.
+# TYPE alertmanager_alerts_invalid_total counter
+alertmanager_alerts_invalid_total 0
+# HELP alertmanager_alerts_received_total The total number of received alerts.
+# TYPE alertmanager_alerts_received_total counter
+alertmanager_alerts_received_total{status="firing"} 60
+# HELP alertmanager_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which alertmanager was built.
+# TYPE alertmanager_build_info gauge
+alertmanager_build_info{branch="master",goversion="go1.6.3",revision="9a5ab2fa63dd7951f4f202b0846d4f4d8e9615b0",version="0.4.2"} 1
+# HELP alertmanager_config_last_reload_success_timestamp_seconds Timestamp of the last successful configuration reload.
+# TYPE alertmanager_config_last_reload_success_timestamp_seconds gauge
+alertmanager_config_last_reload_success_timestamp_seconds 1.548868538e+09
+# HELP alertmanager_config_last_reload_successful Whether the last configuration reload attempt was successful.
+# TYPE alertmanager_config_last_reload_successful gauge
+alertmanager_config_last_reload_successful 1
+# HELP go_gc_duration_seconds A summary of the GC invocation durations.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0"} 0.0026947
+go_gc_duration_seconds{quantile="0.25"} 0.0026947
+go_gc_duration_seconds{quantile="0.5"} 0.0026947
+go_gc_duration_seconds{quantile="0.75"} 0.0026947
+go_gc_duration_seconds{quantile="1"} 0.0026947
+go_gc_duration_seconds_sum 0.0026947
+go_gc_duration_seconds_count 1
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 31
+# HELP http_request_duration_microseconds The HTTP request latencies in microseconds.
+# TYPE http_request_duration_microseconds summary
+http_request_duration_microseconds{handler="add_alerts",quantile="0.5"} 488
+http_request_duration_microseconds{handler="add_alerts",quantile="0.9"} 711
+http_request_duration_microseconds{handler="add_alerts",quantile="0.99"} 711
+http_request_duration_microseconds_sum{handler="add_alerts"} 3250.2000000000003
+http_request_duration_microseconds_count{handler="add_alerts"} 5
+http_request_duration_microseconds{handler="add_silence",quantile="0.5"} 2037.9
+http_request_duration_microseconds{handler="add_silence",quantile="0.9"} 2151.2
+http_request_duration_microseconds{handler="add_silence",quantile="0.99"} 2151.2
+http_request_duration_microseconds_sum{handler="add_silence"} 6587
+http_request_duration_microseconds_count{handler="add_silence"} 3
+http_request_duration_microseconds{handler="alert_groups",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="alert_groups",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="alert_groups",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="alert_groups"} 0
+http_request_duration_microseconds_count{handler="alert_groups"} 0
+http_request_duration_microseconds{handler="app_files",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="app_files",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="app_files",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="app_files"} 0
+http_request_duration_microseconds_count{handler="app_files"} 0
+http_request_duration_microseconds{handler="del_silence",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="del_silence",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="del_silence",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="del_silence"} 0
+http_request_duration_microseconds_count{handler="del_silence"} 0
+http_request_duration_microseconds{handler="get_silence",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="get_silence",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="get_silence",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="get_silence"} 0
+http_request_duration_microseconds_count{handler="get_silence"} 0
+http_request_duration_microseconds{handler="index",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="index",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="index",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="index"} 0
+http_request_duration_microseconds_count{handler="index"} 0
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="legacy_add_alerts"} 0
+http_request_duration_microseconds_count{handler="legacy_add_alerts"} 0
+http_request_duration_microseconds{handler="lib_files",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="lib_files",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="lib_files",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="lib_files"} 0
+http_request_duration_microseconds_count{handler="lib_files"} 0
+http_request_duration_microseconds{handler="list_alerts",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="list_alerts",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="list_alerts",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="list_alerts"} 0
+http_request_duration_microseconds_count{handler="list_alerts"} 0
+http_request_duration_microseconds{handler="list_silences",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="list_silences",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="list_silences",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="list_silences"} 0
+http_request_duration_microseconds_count{handler="list_silences"} 0
+http_request_duration_microseconds{handler="prometheus",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="prometheus",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="prometheus",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="prometheus"} 0
+http_request_duration_microseconds_count{handler="prometheus"} 0
+http_request_duration_microseconds{handler="status",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="status",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="status",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="status"} 0
+http_request_duration_microseconds_count{handler="status"} 0
+# HELP http_request_size_bytes The HTTP request sizes in bytes.
+# TYPE http_request_size_bytes summary
+http_request_size_bytes{handler="add_alerts",quantile="0.5"} 2719
+http_request_size_bytes{handler="add_alerts",quantile="0.9"} 2719
+http_request_size_bytes{handler="add_alerts",quantile="0.99"} 2719
+http_request_size_bytes_sum{handler="add_alerts"} 13595
+http_request_size_bytes_count{handler="add_alerts"} 5
+http_request_size_bytes{handler="add_silence",quantile="0.5"} 358
+http_request_size_bytes{handler="add_silence",quantile="0.9"} 360
+http_request_size_bytes{handler="add_silence",quantile="0.99"} 360
+http_request_size_bytes_sum{handler="add_silence"} 1164
+http_request_size_bytes_count{handler="add_silence"} 3
+http_request_size_bytes{handler="alert_groups",quantile="0.5"} NaN
+http_request_size_bytes{handler="alert_groups",quantile="0.9"} NaN
+http_request_size_bytes{handler="alert_groups",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="alert_groups"} 0
+http_request_size_bytes_count{handler="alert_groups"} 0
+http_request_size_bytes{handler="app_files",quantile="0.5"} NaN
+http_request_size_bytes{handler="app_files",quantile="0.9"} NaN
+http_request_size_bytes{handler="app_files",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="app_files"} 0
+http_request_size_bytes_count{handler="app_files"} 0
+http_request_size_bytes{handler="del_silence",quantile="0.5"} NaN
+http_request_size_bytes{handler="del_silence",quantile="0.9"} NaN
+http_request_size_bytes{handler="del_silence",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="del_silence"} 0
+http_request_size_bytes_count{handler="del_silence"} 0
+http_request_size_bytes{handler="get_silence",quantile="0.5"} NaN
+http_request_size_bytes{handler="get_silence",quantile="0.9"} NaN
+http_request_size_bytes{handler="get_silence",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="get_silence"} 0
+http_request_size_bytes_count{handler="get_silence"} 0
+http_request_size_bytes{handler="index",quantile="0.5"} NaN
+http_request_size_bytes{handler="index",quantile="0.9"} NaN
+http_request_size_bytes{handler="index",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="index"} 0
+http_request_size_bytes_count{handler="index"} 0
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="legacy_add_alerts"} 0
+http_request_size_bytes_count{handler="legacy_add_alerts"} 0
+http_request_size_bytes{handler="lib_files",quantile="0.5"} NaN
+http_request_size_bytes{handler="lib_files",quantile="0.9"} NaN
+http_request_size_bytes{handler="lib_files",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="lib_files"} 0
+http_request_size_bytes_count{handler="lib_files"} 0
+http_request_size_bytes{handler="list_alerts",quantile="0.5"} NaN
+http_request_size_bytes{handler="list_alerts",quantile="0.9"} NaN
+http_request_size_bytes{handler="list_alerts",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="list_alerts"} 0
+http_request_size_bytes_count{handler="list_alerts"} 0
+http_request_size_bytes{handler="list_silences",quantile="0.5"} NaN
+http_request_size_bytes{handler="list_silences",quantile="0.9"} NaN
+http_request_size_bytes{handler="list_silences",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="list_silences"} 0
+http_request_size_bytes_count{handler="list_silences"} 0
+http_request_size_bytes{handler="prometheus",quantile="0.5"} NaN
+http_request_size_bytes{handler="prometheus",quantile="0.9"} NaN
+http_request_size_bytes{handler="prometheus",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="prometheus"} 0
+http_request_size_bytes_count{handler="prometheus"} 0
+http_request_size_bytes{handler="status",quantile="0.5"} NaN
+http_request_size_bytes{handler="status",quantile="0.9"} NaN
+http_request_size_bytes{handler="status",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="status"} 0
+http_request_size_bytes_count{handler="status"} 0
+# HELP http_requests_total Total number of HTTP requests made.
+# TYPE http_requests_total counter
+http_requests_total{code="200",handler="add_alerts",method="post"} 5
+http_requests_total{code="200",handler="add_silence",method="post"} 3
+# HELP http_response_size_bytes The HTTP response sizes in bytes.
+# TYPE http_response_size_bytes summary
+http_response_size_bytes{handler="add_alerts",quantile="0.5"} 20
+http_response_size_bytes{handler="add_alerts",quantile="0.9"} 20
+http_response_size_bytes{handler="add_alerts",quantile="0.99"} 20
+http_response_size_bytes_sum{handler="add_alerts"} 100
+http_response_size_bytes_count{handler="add_alerts"} 5
+http_response_size_bytes{handler="add_silence",quantile="0.5"} 43
+http_response_size_bytes{handler="add_silence",quantile="0.9"} 43
+http_response_size_bytes{handler="add_silence",quantile="0.99"} 43
+http_response_size_bytes_sum{handler="add_silence"} 129
+http_response_size_bytes_count{handler="add_silence"} 3
+http_response_size_bytes{handler="alert_groups",quantile="0.5"} NaN
+http_response_size_bytes{handler="alert_groups",quantile="0.9"} NaN
+http_response_size_bytes{handler="alert_groups",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="alert_groups"} 0
+http_response_size_bytes_count{handler="alert_groups"} 0
+http_response_size_bytes{handler="app_files",quantile="0.5"} NaN
+http_response_size_bytes{handler="app_files",quantile="0.9"} NaN
+http_response_size_bytes{handler="app_files",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="app_files"} 0
+http_response_size_bytes_count{handler="app_files"} 0
+http_response_size_bytes{handler="del_silence",quantile="0.5"} NaN
+http_response_size_bytes{handler="del_silence",quantile="0.9"} NaN
+http_response_size_bytes{handler="del_silence",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="del_silence"} 0
+http_response_size_bytes_count{handler="del_silence"} 0
+http_response_size_bytes{handler="get_silence",quantile="0.5"} NaN
+http_response_size_bytes{handler="get_silence",quantile="0.9"} NaN
+http_response_size_bytes{handler="get_silence",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="get_silence"} 0
+http_response_size_bytes_count{handler="get_silence"} 0
+http_response_size_bytes{handler="index",quantile="0.5"} NaN
+http_response_size_bytes{handler="index",quantile="0.9"} NaN
+http_response_size_bytes{handler="index",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="index"} 0
+http_response_size_bytes_count{handler="index"} 0
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="legacy_add_alerts"} 0
+http_response_size_bytes_count{handler="legacy_add_alerts"} 0
+http_response_size_bytes{handler="lib_files",quantile="0.5"} NaN
+http_response_size_bytes{handler="lib_files",quantile="0.9"} NaN
+http_response_size_bytes{handler="lib_files",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="lib_files"} 0
+http_response_size_bytes_count{handler="lib_files"} 0
+http_response_size_bytes{handler="list_alerts",quantile="0.5"} NaN
+http_response_size_bytes{handler="list_alerts",quantile="0.9"} NaN
+http_response_size_bytes{handler="list_alerts",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="list_alerts"} 0
+http_response_size_bytes_count{handler="list_alerts"} 0
+http_response_size_bytes{handler="list_silences",quantile="0.5"} NaN
+http_response_size_bytes{handler="list_silences",quantile="0.9"} NaN
+http_response_size_bytes{handler="list_silences",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="list_silences"} 0
+http_response_size_bytes_count{handler="list_silences"} 0
+http_response_size_bytes{handler="prometheus",quantile="0.5"} NaN
+http_response_size_bytes{handler="prometheus",quantile="0.9"} NaN
+http_response_size_bytes{handler="prometheus",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="prometheus"} 0
+http_response_size_bytes_count{handler="prometheus"} 0
+http_response_size_bytes{handler="status",quantile="0.5"} NaN
+http_response_size_bytes{handler="status",quantile="0.9"} NaN
+http_response_size_bytes{handler="status",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="status"} 0
+http_response_size_bytes_count{handler="status"} 0
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 0.15
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+process_max_fds 1.048576e+06
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+process_open_fds 9
+# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes 1.1808768e+07
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds 1.54886853731e+09
+# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE process_virtual_memory_bytes gauge
+process_virtual_memory_bytes 1.90464e+07

--- a/internal/mock/0.5.0/api/v1/alerts/groups
+++ b/internal/mock/0.5.0/api/v1/alerts/groups
@@ -18,7 +18,7 @@
                                 "instance": "server5",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:51:46.796673741Z"
+                            "startsAt": "2019-01-30T17:17:06.3372901Z"
                         }
                     ],
                     "routeOpts": {
@@ -42,21 +42,6 @@
                     "alerts": [
                         {
                             "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "generatorURL": "localhost/prometheus",
-                            "inhibited": false,
-                            "labels": {
-                                "alertname": "HTTP_Probe_Failed",
-                                "cluster": "dev",
-                                "instance": "web2",
-                                "job": "node_exporter"
-                            },
-                            "startsAt": "2017-06-21T19:51:46.796673741Z"
-                        },
-                        {
-                            "annotations": {
                                 "help": "Example help annotation",
                                 "summary": "Example summary",
                                 "url": "http://localhost/example.html"
@@ -70,8 +55,23 @@
                                 "instance": "web1",
                                 "job": "node_exporter"
                             },
-                            "silenced": "975ee419-5688-4d47-8fa6-6f432577da0e",
-                            "startsAt": "2017-06-21T19:51:46.796673741Z"
+                            "silenced": "1db44623-a54a-4375-9843-7f452f7e6cc0",
+                            "startsAt": "2019-01-30T17:17:06.3372901Z"
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "inhibited": false,
+                            "labels": {
+                                "alertname": "HTTP_Probe_Failed",
+                                "cluster": "dev",
+                                "instance": "web2",
+                                "job": "node_exporter"
+                            },
+                            "startsAt": "2019-01-30T17:17:06.3372901Z"
                         }
                     ],
                     "routeOpts": {
@@ -102,43 +102,12 @@
                             "inhibited": false,
                             "labels": {
                                 "alertname": "Host_Down",
-                                "cluster": "staging",
-                                "instance": "server5",
-                                "job": "node_ping"
-                            },
-                            "startsAt": "2017-06-21T19:51:46.796673741Z"
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "generatorURL": "localhost/prometheus",
-                            "inhibited": false,
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "dev",
-                                "instance": "server6",
-                                "job": "node_ping"
-                            },
-                            "silenced": "ded13fb8-a31d-4654-a272-ffcf987146fc",
-                            "startsAt": "2017-06-21T19:51:46.796673741Z"
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "generatorURL": "localhost/prometheus",
-                            "inhibited": false,
-                            "labels": {
-                                "alertname": "Host_Down",
                                 "cluster": "dev",
                                 "instance": "server7",
                                 "job": "node_ping"
                             },
-                            "silenced": "ded13fb8-a31d-4654-a272-ffcf987146fc",
-                            "startsAt": "2017-06-21T19:51:46.796673741Z"
+                            "silenced": "916e91db-f36d-4dcf-9df7-cc5df5ddb49a",
+                            "startsAt": "2019-01-30T17:17:06.3372901Z"
                         },
                         {
                             "annotations": {
@@ -153,8 +122,8 @@
                                 "instance": "server8",
                                 "job": "node_ping"
                             },
-                            "silenced": "ded13fb8-a31d-4654-a272-ffcf987146fc",
-                            "startsAt": "2017-06-21T19:51:46.796673741Z"
+                            "silenced": "916e91db-f36d-4dcf-9df7-cc5df5ddb49a",
+                            "startsAt": "2019-01-30T17:17:06.3372901Z"
                         },
                         {
                             "annotations": {
@@ -170,7 +139,7 @@
                                 "instance": "server1",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:51:46.796673741Z"
+                            "startsAt": "2019-01-30T17:17:06.3372901Z"
                         },
                         {
                             "annotations": {
@@ -185,7 +154,7 @@
                                 "instance": "server2",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:51:46.796673741Z"
+                            "startsAt": "2019-01-30T17:17:06.3372901Z"
                         },
                         {
                             "annotations": {
@@ -200,7 +169,7 @@
                                 "instance": "server3",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:51:46.796673741Z"
+                            "startsAt": "2019-01-30T17:17:06.3372901Z"
                         },
                         {
                             "annotations": {
@@ -215,7 +184,38 @@
                                 "instance": "server4",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:51:46.796673741Z"
+                            "startsAt": "2019-01-30T17:17:06.3372901Z"
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "inhibited": false,
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "staging",
+                                "instance": "server5",
+                                "job": "node_ping"
+                            },
+                            "startsAt": "2019-01-30T17:17:06.3372901Z"
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "inhibited": false,
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "dev",
+                                "instance": "server6",
+                                "job": "node_ping"
+                            },
+                            "silenced": "916e91db-f36d-4dcf-9df7-cc5df5ddb49a",
+                            "startsAt": "2019-01-30T17:17:06.3372901Z"
                         }
                     ],
                     "routeOpts": {
@@ -251,7 +251,7 @@
                                 "instance": "server2",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:51:46.796673741Z"
+                            "startsAt": "2019-01-30T17:17:06.3372901Z"
                         }
                     ],
                     "routeOpts": {
@@ -287,7 +287,7 @@
                                 "instance": "server5",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:51:46.796673741Z"
+                            "startsAt": "2019-01-30T17:17:06.3372901Z"
                         }
                     ],
                     "routeOpts": {
@@ -327,8 +327,8 @@
                                 "instance": "web1",
                                 "job": "node_exporter"
                             },
-                            "silenced": "975ee419-5688-4d47-8fa6-6f432577da0e",
-                            "startsAt": "2017-06-21T19:51:46.796673741Z"
+                            "silenced": "1db44623-a54a-4375-9843-7f452f7e6cc0",
+                            "startsAt": "2019-01-30T17:17:06.3372901Z"
                         },
                         {
                             "annotations": {
@@ -343,7 +343,7 @@
                                 "instance": "web2",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:51:46.796673741Z"
+                            "startsAt": "2019-01-30T17:17:06.3372901Z"
                         }
                     ],
                     "routeOpts": {
@@ -381,8 +381,8 @@
                                 "instance": "server6",
                                 "job": "node_ping"
                             },
-                            "silenced": "ded13fb8-a31d-4654-a272-ffcf987146fc",
-                            "startsAt": "2017-06-21T19:51:46.796673741Z"
+                            "silenced": "916e91db-f36d-4dcf-9df7-cc5df5ddb49a",
+                            "startsAt": "2019-01-30T17:17:06.3372901Z"
                         },
                         {
                             "annotations": {
@@ -397,8 +397,8 @@
                                 "instance": "server7",
                                 "job": "node_ping"
                             },
-                            "silenced": "ded13fb8-a31d-4654-a272-ffcf987146fc",
-                            "startsAt": "2017-06-21T19:51:46.796673741Z"
+                            "silenced": "916e91db-f36d-4dcf-9df7-cc5df5ddb49a",
+                            "startsAt": "2019-01-30T17:17:06.3372901Z"
                         },
                         {
                             "annotations": {
@@ -413,8 +413,8 @@
                                 "instance": "server8",
                                 "job": "node_ping"
                             },
-                            "silenced": "ded13fb8-a31d-4654-a272-ffcf987146fc",
-                            "startsAt": "2017-06-21T19:51:46.796673741Z"
+                            "silenced": "916e91db-f36d-4dcf-9df7-cc5df5ddb49a",
+                            "startsAt": "2019-01-30T17:17:06.3372901Z"
                         }
                     ],
                     "routeOpts": {
@@ -453,7 +453,7 @@
                                 "instance": "server1",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:51:46.796673741Z"
+                            "startsAt": "2019-01-30T17:17:06.3372901Z"
                         },
                         {
                             "annotations": {
@@ -468,14 +468,14 @@
                                 "instance": "server2",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:51:46.796673741Z"
+                            "startsAt": "2019-01-30T17:17:06.3372901Z"
                         }
                     ],
                     "routeOpts": {
                         "groupBy": [
+                            "alertname",
                             "cluster",
-                            "service",
-                            "alertname"
+                            "service"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,
@@ -506,7 +506,7 @@
                                 "instance": "server3",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:51:46.796673741Z"
+                            "startsAt": "2019-01-30T17:17:06.3372901Z"
                         },
                         {
                             "annotations": {
@@ -521,7 +521,7 @@
                                 "instance": "server4",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:51:46.796673741Z"
+                            "startsAt": "2019-01-30T17:17:06.3372901Z"
                         },
                         {
                             "annotations": {
@@ -536,7 +536,7 @@
                                 "instance": "server5",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:51:46.796673741Z"
+                            "startsAt": "2019-01-30T17:17:06.3372901Z"
                         }
                     ],
                     "routeOpts": {
@@ -575,7 +575,7 @@
                                 "instance": "server2",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:51:46.796673741Z"
+                            "startsAt": "2019-01-30T17:17:06.3372901Z"
                         }
                     ],
                     "routeOpts": {

--- a/internal/mock/0.5.0/api/v1/silences
+++ b/internal/mock/0.5.0/api/v1/silences
@@ -1,25 +1,10 @@
 {
     "data": [
         {
-            "comment": "Silenced instance",
-            "createdBy": "john@example.com",
-            "endsAt": "2063-01-01T00:00:00Z",
-            "id": "975ee419-5688-4d47-8fa6-6f432577da0e",
-            "matchers": [
-                {
-                    "isRegex": false,
-                    "name": "instance",
-                    "value": "web1"
-                }
-            ],
-            "startsAt": "2017-06-21T19:51:46.787701467Z",
-            "updatedAt": "2017-06-21T19:51:46.787701467Z"
-        },
-        {
             "comment": "Silenced Host_Down alerts in the dev cluster",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "ded13fb8-a31d-4654-a272-ffcf987146fc",
+            "id": "916e91db-f36d-4dcf-9df7-cc5df5ddb49a",
             "matchers": [
                 {
                     "isRegex": false,
@@ -32,14 +17,14 @@
                     "value": "dev"
                 }
             ],
-            "startsAt": "2017-06-21T19:51:46.791102968Z",
-            "updatedAt": "2017-06-21T19:51:46.791102968Z"
+            "startsAt": "2019-01-30T17:17:06.3296259Z",
+            "updatedAt": "2019-01-30T17:17:06.3296259Z"
         },
         {
             "comment": "Silenced server7",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "dd9d06d7-e3d5-4c0d-b5d1-a83eddea1ff3",
+            "id": "6358f97b-3fc9-420d-a8a2-0a873fe25eeb",
             "matchers": [
                 {
                     "isRegex": false,
@@ -47,8 +32,23 @@
                     "value": "server7"
                 }
             ],
-            "startsAt": "2017-06-21T19:51:46.794709503Z",
-            "updatedAt": "2017-06-21T19:51:46.794709503Z"
+            "startsAt": "2019-01-30T17:17:06.3334782Z",
+            "updatedAt": "2019-01-30T17:17:06.3334782Z"
+        },
+        {
+            "comment": "Silenced instance",
+            "createdBy": "john@example.com",
+            "endsAt": "2063-01-01T00:00:00Z",
+            "id": "1db44623-a54a-4375-9843-7f452f7e6cc0",
+            "matchers": [
+                {
+                    "isRegex": false,
+                    "name": "instance",
+                    "value": "web1"
+                }
+            ],
+            "startsAt": "2019-01-30T17:17:06.3259552Z",
+            "updatedAt": "2019-01-30T17:17:06.3259552Z"
         }
     ],
     "status": "success"

--- a/internal/mock/0.5.0/api/v1/status
+++ b/internal/mock/0.5.0/api/v1/status
@@ -1,7 +1,7 @@
 {
     "data": {
         "config": "route:\n  group_by: ['alertname']\n  group_wait: 15s\n  group_interval: 35s\n  repeat_interval: 999h\n  receiver: 'default'\n  routes:\n    - receiver: 'by-cluster-service'\n      group_by: ['alertname', 'cluster', 'service']\n      match_re:\n        alertname: .*\n      continue: true\n    - receiver: 'by-name'\n      group_by: [alertname]\n      match_re:\n        alertname: .*\n      continue: true\n\ninhibit_rules:\n  - source_match:\n      severity: 'critical'\n    target_match:\n      severity: 'warning'\n    # Apply inhibition if the alertname is the same.\n    equal: ['alertname', 'cluster', 'service']\n\nreceivers:\n  - name: 'default'\n  - name: 'by-cluster-service'\n  - name: 'by-name'\n",
-        "uptime": "2017-06-21T19:51:31.752337137Z",
+        "uptime": "2019-01-30T17:16:51.1637502Z",
         "versionInfo": {
             "branch": "master",
             "buildDate": "20161101-18:10:50",

--- a/internal/mock/0.5.0/metrics
+++ b/internal/mock/0.5.0/metrics
@@ -1,0 +1,370 @@
+# HELP alertmanager_alerts_invalid_total The total number of received alerts that were invalid.
+# TYPE alertmanager_alerts_invalid_total counter
+alertmanager_alerts_invalid_total 0
+# HELP alertmanager_alerts_received_total The total number of received alerts.
+# TYPE alertmanager_alerts_received_total counter
+alertmanager_alerts_received_total{status="firing"} 60
+# HELP alertmanager_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which alertmanager was built.
+# TYPE alertmanager_build_info gauge
+alertmanager_build_info{branch="master",goversion="go1.7.3",revision="a91fe17ddf0a57c627e2cfcdaa0ab364b1ab3e04",version="0.5.0"} 1
+# HELP alertmanager_config_last_reload_success_timestamp_seconds Timestamp of the last successful configuration reload.
+# TYPE alertmanager_config_last_reload_success_timestamp_seconds gauge
+alertmanager_config_last_reload_success_timestamp_seconds 1.548868611e+09
+# HELP alertmanager_config_last_reload_successful Whether the last configuration reload attempt was successful.
+# TYPE alertmanager_config_last_reload_successful gauge
+alertmanager_config_last_reload_successful 1
+# HELP alertmanager_silences_gc_duration_seconds Duration of the last silence garbage collection cycle.
+# TYPE alertmanager_silences_gc_duration_seconds summary
+alertmanager_silences_gc_duration_seconds{quantile="0.5"} NaN
+alertmanager_silences_gc_duration_seconds{quantile="0.9"} NaN
+alertmanager_silences_gc_duration_seconds{quantile="0.99"} NaN
+alertmanager_silences_gc_duration_seconds_sum 0
+alertmanager_silences_gc_duration_seconds_count 0
+# HELP alertmanager_silences_queries_total How many silence queries were received.
+# TYPE alertmanager_silences_queries_total counter
+alertmanager_silences_queries_total 48
+# HELP alertmanager_silences_query_duration_seconds Duration of silence query evaluation.
+# TYPE alertmanager_silences_query_duration_seconds histogram
+alertmanager_silences_query_duration_seconds_bucket{le="0.005"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.01"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.025"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.05"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.1"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.25"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.5"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="1"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="2.5"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="5"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="10"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="+Inf"} 48
+alertmanager_silences_query_duration_seconds_sum 0.0017717999999999996
+alertmanager_silences_query_duration_seconds_count 48
+# HELP alertmanager_silences_query_errors_total How many silence received queries did not succeed.
+# TYPE alertmanager_silences_query_errors_total counter
+alertmanager_silences_query_errors_total 0
+# HELP alertmanager_silences_snapshot_duration_seconds Duration of the last silence snapshot.
+# TYPE alertmanager_silences_snapshot_duration_seconds summary
+alertmanager_silences_snapshot_duration_seconds{quantile="0.5"} NaN
+alertmanager_silences_snapshot_duration_seconds{quantile="0.9"} NaN
+alertmanager_silences_snapshot_duration_seconds{quantile="0.99"} NaN
+alertmanager_silences_snapshot_duration_seconds_sum 0
+alertmanager_silences_snapshot_duration_seconds_count 0
+# HELP go_gc_duration_seconds A summary of the GC invocation durations.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0"} 0.0005391
+go_gc_duration_seconds{quantile="0.25"} 0.0005391
+go_gc_duration_seconds{quantile="0.5"} 0.0005391
+go_gc_duration_seconds{quantile="0.75"} 0.0005391
+go_gc_duration_seconds{quantile="1"} 0.0005391
+go_gc_duration_seconds_sum 0.0005391
+go_gc_duration_seconds_count 1
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 63
+# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+# TYPE go_memstats_alloc_bytes gauge
+go_memstats_alloc_bytes 4.464272e+06
+# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
+# TYPE go_memstats_alloc_bytes_total counter
+go_memstats_alloc_bytes_total 4.968144e+06
+# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
+# TYPE go_memstats_buck_hash_sys_bytes gauge
+go_memstats_buck_hash_sys_bytes 2739
+# HELP go_memstats_frees_total Total number of frees.
+# TYPE go_memstats_frees_total counter
+go_memstats_frees_total 4591
+# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+# TYPE go_memstats_gc_sys_bytes gauge
+go_memstats_gc_sys_bytes 344064
+# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
+# TYPE go_memstats_heap_alloc_bytes gauge
+go_memstats_heap_alloc_bytes 4.464272e+06
+# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
+# TYPE go_memstats_heap_idle_bytes gauge
+go_memstats_heap_idle_bytes 729088
+# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
+# TYPE go_memstats_heap_inuse_bytes gauge
+go_memstats_heap_inuse_bytes 4.939776e+06
+# HELP go_memstats_heap_objects Number of allocated objects.
+# TYPE go_memstats_heap_objects gauge
+go_memstats_heap_objects 16840
+# HELP go_memstats_heap_released_bytes_total Total number of heap bytes released to OS.
+# TYPE go_memstats_heap_released_bytes_total counter
+go_memstats_heap_released_bytes_total 0
+# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
+# TYPE go_memstats_heap_sys_bytes gauge
+go_memstats_heap_sys_bytes 5.668864e+06
+# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
+# TYPE go_memstats_last_gc_time_seconds gauge
+go_memstats_last_gc_time_seconds 1.5488686111786394e+09
+# HELP go_memstats_lookups_total Total number of pointer lookups.
+# TYPE go_memstats_lookups_total counter
+go_memstats_lookups_total 32
+# HELP go_memstats_mallocs_total Total number of mallocs.
+# TYPE go_memstats_mallocs_total counter
+go_memstats_mallocs_total 21431
+# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
+# TYPE go_memstats_mcache_inuse_bytes gauge
+go_memstats_mcache_inuse_bytes 2400
+# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
+# TYPE go_memstats_mcache_sys_bytes gauge
+go_memstats_mcache_sys_bytes 16384
+# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
+# TYPE go_memstats_mspan_inuse_bytes gauge
+go_memstats_mspan_inuse_bytes 57600
+# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
+# TYPE go_memstats_mspan_sys_bytes gauge
+go_memstats_mspan_sys_bytes 65536
+# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
+# TYPE go_memstats_next_gc_bytes gauge
+go_memstats_next_gc_bytes 6.583861e+06
+# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
+# TYPE go_memstats_other_sys_bytes gauge
+go_memstats_other_sys_bytes 759117
+# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
+# TYPE go_memstats_stack_inuse_bytes gauge
+go_memstats_stack_inuse_bytes 622592
+# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
+# TYPE go_memstats_stack_sys_bytes gauge
+go_memstats_stack_sys_bytes 622592
+# HELP go_memstats_sys_bytes Number of bytes obtained by system. Sum of all system allocations.
+# TYPE go_memstats_sys_bytes gauge
+go_memstats_sys_bytes 7.479296e+06
+# HELP http_request_duration_microseconds The HTTP request latencies in microseconds.
+# TYPE http_request_duration_microseconds summary
+http_request_duration_microseconds{handler="add_alerts",quantile="0.5"} 466.4
+http_request_duration_microseconds{handler="add_alerts",quantile="0.9"} 1321.7
+http_request_duration_microseconds{handler="add_alerts",quantile="0.99"} 1321.7
+http_request_duration_microseconds_sum{handler="add_alerts"} 4102
+http_request_duration_microseconds_count{handler="add_alerts"} 5
+http_request_duration_microseconds{handler="add_silence",quantile="0.5"} 162.4
+http_request_duration_microseconds{handler="add_silence",quantile="0.9"} 238.3
+http_request_duration_microseconds{handler="add_silence",quantile="0.99"} 238.3
+http_request_duration_microseconds_sum{handler="add_silence"} 679.3
+http_request_duration_microseconds_count{handler="add_silence"} 3
+http_request_duration_microseconds{handler="alert_groups",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="alert_groups",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="alert_groups",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="alert_groups"} 0
+http_request_duration_microseconds_count{handler="alert_groups"} 0
+http_request_duration_microseconds{handler="app_files",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="app_files",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="app_files",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="app_files"} 0
+http_request_duration_microseconds_count{handler="app_files"} 0
+http_request_duration_microseconds{handler="del_silence",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="del_silence",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="del_silence",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="del_silence"} 0
+http_request_duration_microseconds_count{handler="del_silence"} 0
+http_request_duration_microseconds{handler="get_silence",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="get_silence",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="get_silence",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="get_silence"} 0
+http_request_duration_microseconds_count{handler="get_silence"} 0
+http_request_duration_microseconds{handler="index",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="index",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="index",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="index"} 0
+http_request_duration_microseconds_count{handler="index"} 0
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="legacy_add_alerts"} 0
+http_request_duration_microseconds_count{handler="legacy_add_alerts"} 0
+http_request_duration_microseconds{handler="lib_files",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="lib_files",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="lib_files",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="lib_files"} 0
+http_request_duration_microseconds_count{handler="lib_files"} 0
+http_request_duration_microseconds{handler="list_alerts",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="list_alerts",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="list_alerts",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="list_alerts"} 0
+http_request_duration_microseconds_count{handler="list_alerts"} 0
+http_request_duration_microseconds{handler="list_silences",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="list_silences",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="list_silences",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="list_silences"} 0
+http_request_duration_microseconds_count{handler="list_silences"} 0
+http_request_duration_microseconds{handler="options",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="options",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="options",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="options"} 0
+http_request_duration_microseconds_count{handler="options"} 0
+http_request_duration_microseconds{handler="prometheus",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="prometheus",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="prometheus",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="prometheus"} 0
+http_request_duration_microseconds_count{handler="prometheus"} 0
+http_request_duration_microseconds{handler="status",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="status",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="status",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="status"} 0
+http_request_duration_microseconds_count{handler="status"} 0
+# HELP http_request_size_bytes The HTTP request sizes in bytes.
+# TYPE http_request_size_bytes summary
+http_request_size_bytes{handler="add_alerts",quantile="0.5"} 2719
+http_request_size_bytes{handler="add_alerts",quantile="0.9"} 2719
+http_request_size_bytes{handler="add_alerts",quantile="0.99"} 2719
+http_request_size_bytes_sum{handler="add_alerts"} 13595
+http_request_size_bytes_count{handler="add_alerts"} 5
+http_request_size_bytes{handler="add_silence",quantile="0.5"} 358
+http_request_size_bytes{handler="add_silence",quantile="0.9"} 360
+http_request_size_bytes{handler="add_silence",quantile="0.99"} 360
+http_request_size_bytes_sum{handler="add_silence"} 1164
+http_request_size_bytes_count{handler="add_silence"} 3
+http_request_size_bytes{handler="alert_groups",quantile="0.5"} NaN
+http_request_size_bytes{handler="alert_groups",quantile="0.9"} NaN
+http_request_size_bytes{handler="alert_groups",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="alert_groups"} 0
+http_request_size_bytes_count{handler="alert_groups"} 0
+http_request_size_bytes{handler="app_files",quantile="0.5"} NaN
+http_request_size_bytes{handler="app_files",quantile="0.9"} NaN
+http_request_size_bytes{handler="app_files",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="app_files"} 0
+http_request_size_bytes_count{handler="app_files"} 0
+http_request_size_bytes{handler="del_silence",quantile="0.5"} NaN
+http_request_size_bytes{handler="del_silence",quantile="0.9"} NaN
+http_request_size_bytes{handler="del_silence",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="del_silence"} 0
+http_request_size_bytes_count{handler="del_silence"} 0
+http_request_size_bytes{handler="get_silence",quantile="0.5"} NaN
+http_request_size_bytes{handler="get_silence",quantile="0.9"} NaN
+http_request_size_bytes{handler="get_silence",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="get_silence"} 0
+http_request_size_bytes_count{handler="get_silence"} 0
+http_request_size_bytes{handler="index",quantile="0.5"} NaN
+http_request_size_bytes{handler="index",quantile="0.9"} NaN
+http_request_size_bytes{handler="index",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="index"} 0
+http_request_size_bytes_count{handler="index"} 0
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="legacy_add_alerts"} 0
+http_request_size_bytes_count{handler="legacy_add_alerts"} 0
+http_request_size_bytes{handler="lib_files",quantile="0.5"} NaN
+http_request_size_bytes{handler="lib_files",quantile="0.9"} NaN
+http_request_size_bytes{handler="lib_files",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="lib_files"} 0
+http_request_size_bytes_count{handler="lib_files"} 0
+http_request_size_bytes{handler="list_alerts",quantile="0.5"} NaN
+http_request_size_bytes{handler="list_alerts",quantile="0.9"} NaN
+http_request_size_bytes{handler="list_alerts",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="list_alerts"} 0
+http_request_size_bytes_count{handler="list_alerts"} 0
+http_request_size_bytes{handler="list_silences",quantile="0.5"} NaN
+http_request_size_bytes{handler="list_silences",quantile="0.9"} NaN
+http_request_size_bytes{handler="list_silences",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="list_silences"} 0
+http_request_size_bytes_count{handler="list_silences"} 0
+http_request_size_bytes{handler="options",quantile="0.5"} NaN
+http_request_size_bytes{handler="options",quantile="0.9"} NaN
+http_request_size_bytes{handler="options",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="options"} 0
+http_request_size_bytes_count{handler="options"} 0
+http_request_size_bytes{handler="prometheus",quantile="0.5"} NaN
+http_request_size_bytes{handler="prometheus",quantile="0.9"} NaN
+http_request_size_bytes{handler="prometheus",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="prometheus"} 0
+http_request_size_bytes_count{handler="prometheus"} 0
+http_request_size_bytes{handler="status",quantile="0.5"} NaN
+http_request_size_bytes{handler="status",quantile="0.9"} NaN
+http_request_size_bytes{handler="status",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="status"} 0
+http_request_size_bytes_count{handler="status"} 0
+# HELP http_requests_total Total number of HTTP requests made.
+# TYPE http_requests_total counter
+http_requests_total{code="200",handler="add_alerts",method="post"} 5
+http_requests_total{code="200",handler="add_silence",method="post"} 3
+# HELP http_response_size_bytes The HTTP response sizes in bytes.
+# TYPE http_response_size_bytes summary
+http_response_size_bytes{handler="add_alerts",quantile="0.5"} 20
+http_response_size_bytes{handler="add_alerts",quantile="0.9"} 20
+http_response_size_bytes{handler="add_alerts",quantile="0.99"} 20
+http_response_size_bytes_sum{handler="add_alerts"} 100
+http_response_size_bytes_count{handler="add_alerts"} 5
+http_response_size_bytes{handler="add_silence",quantile="0.5"} 80
+http_response_size_bytes{handler="add_silence",quantile="0.9"} 80
+http_response_size_bytes{handler="add_silence",quantile="0.99"} 80
+http_response_size_bytes_sum{handler="add_silence"} 240
+http_response_size_bytes_count{handler="add_silence"} 3
+http_response_size_bytes{handler="alert_groups",quantile="0.5"} NaN
+http_response_size_bytes{handler="alert_groups",quantile="0.9"} NaN
+http_response_size_bytes{handler="alert_groups",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="alert_groups"} 0
+http_response_size_bytes_count{handler="alert_groups"} 0
+http_response_size_bytes{handler="app_files",quantile="0.5"} NaN
+http_response_size_bytes{handler="app_files",quantile="0.9"} NaN
+http_response_size_bytes{handler="app_files",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="app_files"} 0
+http_response_size_bytes_count{handler="app_files"} 0
+http_response_size_bytes{handler="del_silence",quantile="0.5"} NaN
+http_response_size_bytes{handler="del_silence",quantile="0.9"} NaN
+http_response_size_bytes{handler="del_silence",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="del_silence"} 0
+http_response_size_bytes_count{handler="del_silence"} 0
+http_response_size_bytes{handler="get_silence",quantile="0.5"} NaN
+http_response_size_bytes{handler="get_silence",quantile="0.9"} NaN
+http_response_size_bytes{handler="get_silence",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="get_silence"} 0
+http_response_size_bytes_count{handler="get_silence"} 0
+http_response_size_bytes{handler="index",quantile="0.5"} NaN
+http_response_size_bytes{handler="index",quantile="0.9"} NaN
+http_response_size_bytes{handler="index",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="index"} 0
+http_response_size_bytes_count{handler="index"} 0
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="legacy_add_alerts"} 0
+http_response_size_bytes_count{handler="legacy_add_alerts"} 0
+http_response_size_bytes{handler="lib_files",quantile="0.5"} NaN
+http_response_size_bytes{handler="lib_files",quantile="0.9"} NaN
+http_response_size_bytes{handler="lib_files",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="lib_files"} 0
+http_response_size_bytes_count{handler="lib_files"} 0
+http_response_size_bytes{handler="list_alerts",quantile="0.5"} NaN
+http_response_size_bytes{handler="list_alerts",quantile="0.9"} NaN
+http_response_size_bytes{handler="list_alerts",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="list_alerts"} 0
+http_response_size_bytes_count{handler="list_alerts"} 0
+http_response_size_bytes{handler="list_silences",quantile="0.5"} NaN
+http_response_size_bytes{handler="list_silences",quantile="0.9"} NaN
+http_response_size_bytes{handler="list_silences",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="list_silences"} 0
+http_response_size_bytes_count{handler="list_silences"} 0
+http_response_size_bytes{handler="options",quantile="0.5"} NaN
+http_response_size_bytes{handler="options",quantile="0.9"} NaN
+http_response_size_bytes{handler="options",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="options"} 0
+http_response_size_bytes_count{handler="options"} 0
+http_response_size_bytes{handler="prometheus",quantile="0.5"} NaN
+http_response_size_bytes{handler="prometheus",quantile="0.9"} NaN
+http_response_size_bytes{handler="prometheus",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="prometheus"} 0
+http_response_size_bytes_count{handler="prometheus"} 0
+http_response_size_bytes{handler="status",quantile="0.5"} NaN
+http_response_size_bytes{handler="status",quantile="0.9"} NaN
+http_response_size_bytes{handler="status",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="status"} 0
+http_response_size_bytes_count{handler="status"} 0
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 0.12
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+process_max_fds 1.048576e+06
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+process_open_fds 8
+# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes 9.19552e+06
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds 1.54886861003e+09
+# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE process_virtual_memory_bytes gauge
+process_virtual_memory_bytes 1.585152e+07

--- a/internal/mock/0.5.1/api/v1/alerts/groups
+++ b/internal/mock/0.5.1/api/v1/alerts/groups
@@ -18,7 +18,7 @@
                                 "instance": "server5",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:52:54.919953909Z"
+                            "startsAt": "2019-01-30T17:18:17.8206769Z"
                         }
                     ],
                     "routeOpts": {
@@ -55,8 +55,8 @@
                                 "instance": "web1",
                                 "job": "node_exporter"
                             },
-                            "silenced": "5917f10f-b9ba-4267-8024-ad6f0d4ebe90",
-                            "startsAt": "2017-06-21T19:52:54.919953909Z"
+                            "silenced": "65f56557-5ab9-4111-bcc1-543e631dc382",
+                            "startsAt": "2019-01-30T17:18:17.8206769Z"
                         },
                         {
                             "annotations": {
@@ -71,7 +71,7 @@
                                 "instance": "web2",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:52:54.919953909Z"
+                            "startsAt": "2019-01-30T17:18:17.8206769Z"
                         }
                     ],
                     "routeOpts": {
@@ -102,12 +102,57 @@
                             "inhibited": false,
                             "labels": {
                                 "alertname": "Host_Down",
+                                "cluster": "staging",
+                                "instance": "server3",
+                                "job": "node_ping"
+                            },
+                            "startsAt": "2019-01-30T17:18:17.8206769Z"
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "inhibited": false,
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "staging",
+                                "instance": "server4",
+                                "job": "node_ping"
+                            },
+                            "startsAt": "2019-01-30T17:18:17.8206769Z"
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "inhibited": false,
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "staging",
+                                "instance": "server5",
+                                "job": "node_ping"
+                            },
+                            "startsAt": "2019-01-30T17:18:17.8206769Z"
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "inhibited": false,
+                            "labels": {
+                                "alertname": "Host_Down",
                                 "cluster": "dev",
                                 "instance": "server6",
                                 "job": "node_ping"
                             },
-                            "silenced": "7cd828a9-50dd-4bad-a1fc-6ed2c22ac8dd",
-                            "startsAt": "2017-06-21T19:52:54.919953909Z"
+                            "silenced": "a5609bb3-c6e9-40e8-87ce-0a091d0b8477",
+                            "startsAt": "2019-01-30T17:18:17.8206769Z"
                         },
                         {
                             "annotations": {
@@ -122,8 +167,8 @@
                                 "instance": "server7",
                                 "job": "node_ping"
                             },
-                            "silenced": "7cd828a9-50dd-4bad-a1fc-6ed2c22ac8dd",
-                            "startsAt": "2017-06-21T19:52:54.919953909Z"
+                            "silenced": "a5609bb3-c6e9-40e8-87ce-0a091d0b8477",
+                            "startsAt": "2019-01-30T17:18:17.8206769Z"
                         },
                         {
                             "annotations": {
@@ -138,8 +183,8 @@
                                 "instance": "server8",
                                 "job": "node_ping"
                             },
-                            "silenced": "7cd828a9-50dd-4bad-a1fc-6ed2c22ac8dd",
-                            "startsAt": "2017-06-21T19:52:54.919953909Z"
+                            "silenced": "a5609bb3-c6e9-40e8-87ce-0a091d0b8477",
+                            "startsAt": "2019-01-30T17:18:17.8206769Z"
                         },
                         {
                             "annotations": {
@@ -155,7 +200,7 @@
                                 "instance": "server1",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:52:54.919953909Z"
+                            "startsAt": "2019-01-30T17:18:17.8206769Z"
                         },
                         {
                             "annotations": {
@@ -170,52 +215,7 @@
                                 "instance": "server2",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:52:54.919953909Z"
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "generatorURL": "localhost/prometheus",
-                            "inhibited": false,
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "staging",
-                                "instance": "server3",
-                                "job": "node_ping"
-                            },
-                            "startsAt": "2017-06-21T19:52:54.919953909Z"
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "generatorURL": "localhost/prometheus",
-                            "inhibited": false,
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "staging",
-                                "instance": "server4",
-                                "job": "node_ping"
-                            },
-                            "startsAt": "2017-06-21T19:52:54.919953909Z"
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "generatorURL": "localhost/prometheus",
-                            "inhibited": false,
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "staging",
-                                "instance": "server5",
-                                "job": "node_ping"
-                            },
-                            "startsAt": "2017-06-21T19:52:54.919953909Z"
+                            "startsAt": "2019-01-30T17:18:17.8206769Z"
                         }
                     ],
                     "routeOpts": {
@@ -251,7 +251,7 @@
                                 "instance": "server2",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:52:54.919953909Z"
+                            "startsAt": "2019-01-30T17:18:17.8206769Z"
                         }
                     ],
                     "routeOpts": {
@@ -287,7 +287,7 @@
                                 "instance": "server5",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:52:54.919953909Z"
+                            "startsAt": "2019-01-30T17:18:17.8206769Z"
                         }
                     ],
                     "routeOpts": {
@@ -327,8 +327,8 @@
                                 "instance": "web1",
                                 "job": "node_exporter"
                             },
-                            "silenced": "5917f10f-b9ba-4267-8024-ad6f0d4ebe90",
-                            "startsAt": "2017-06-21T19:52:54.919953909Z"
+                            "silenced": "65f56557-5ab9-4111-bcc1-543e631dc382",
+                            "startsAt": "2019-01-30T17:18:17.8206769Z"
                         },
                         {
                             "annotations": {
@@ -343,7 +343,7 @@
                                 "instance": "web2",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:52:54.919953909Z"
+                            "startsAt": "2019-01-30T17:18:17.8206769Z"
                         }
                     ],
                     "routeOpts": {
@@ -378,11 +378,27 @@
                             "labels": {
                                 "alertname": "Host_Down",
                                 "cluster": "dev",
+                                "instance": "server6",
+                                "job": "node_ping"
+                            },
+                            "silenced": "a5609bb3-c6e9-40e8-87ce-0a091d0b8477",
+                            "startsAt": "2019-01-30T17:18:17.8206769Z"
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "inhibited": false,
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "dev",
                                 "instance": "server7",
                                 "job": "node_ping"
                             },
-                            "silenced": "7cd828a9-50dd-4bad-a1fc-6ed2c22ac8dd",
-                            "startsAt": "2017-06-21T19:52:54.919953909Z"
+                            "silenced": "a5609bb3-c6e9-40e8-87ce-0a091d0b8477",
+                            "startsAt": "2019-01-30T17:18:17.8206769Z"
                         },
                         {
                             "annotations": {
@@ -397,31 +413,15 @@
                                 "instance": "server8",
                                 "job": "node_ping"
                             },
-                            "silenced": "7cd828a9-50dd-4bad-a1fc-6ed2c22ac8dd",
-                            "startsAt": "2017-06-21T19:52:54.919953909Z"
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "generatorURL": "localhost/prometheus",
-                            "inhibited": false,
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "dev",
-                                "instance": "server6",
-                                "job": "node_ping"
-                            },
-                            "silenced": "7cd828a9-50dd-4bad-a1fc-6ed2c22ac8dd",
-                            "startsAt": "2017-06-21T19:52:54.919953909Z"
+                            "silenced": "a5609bb3-c6e9-40e8-87ce-0a091d0b8477",
+                            "startsAt": "2019-01-30T17:18:17.8206769Z"
                         }
                     ],
                     "routeOpts": {
                         "groupBy": [
-                            "service",
                             "alertname",
-                            "cluster"
+                            "cluster",
+                            "service"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,
@@ -453,7 +453,7 @@
                                 "instance": "server1",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:52:54.919953909Z"
+                            "startsAt": "2019-01-30T17:18:17.8206769Z"
                         },
                         {
                             "annotations": {
@@ -468,7 +468,7 @@
                                 "instance": "server2",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:52:54.919953909Z"
+                            "startsAt": "2019-01-30T17:18:17.8206769Z"
                         }
                     ],
                     "routeOpts": {
@@ -506,7 +506,7 @@
                                 "instance": "server3",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:52:54.919953909Z"
+                            "startsAt": "2019-01-30T17:18:17.8206769Z"
                         },
                         {
                             "annotations": {
@@ -521,7 +521,7 @@
                                 "instance": "server4",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:52:54.919953909Z"
+                            "startsAt": "2019-01-30T17:18:17.8206769Z"
                         },
                         {
                             "annotations": {
@@ -536,7 +536,7 @@
                                 "instance": "server5",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:52:54.919953909Z"
+                            "startsAt": "2019-01-30T17:18:17.8206769Z"
                         }
                     ],
                     "routeOpts": {
@@ -575,7 +575,7 @@
                                 "instance": "server2",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:52:54.919953909Z"
+                            "startsAt": "2019-01-30T17:18:17.8206769Z"
                         }
                     ],
                     "routeOpts": {

--- a/internal/mock/0.5.1/api/v1/silences
+++ b/internal/mock/0.5.1/api/v1/silences
@@ -4,7 +4,7 @@
             "comment": "Silenced instance",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "5917f10f-b9ba-4267-8024-ad6f0d4ebe90",
+            "id": "65f56557-5ab9-4111-bcc1-543e631dc382",
             "matchers": [
                 {
                     "isRegex": false,
@@ -12,14 +12,14 @@
                     "value": "web1"
                 }
             ],
-            "startsAt": "2017-06-21T19:52:54.914055435Z",
-            "updatedAt": "2017-06-21T19:52:54.914055435Z"
+            "startsAt": "2019-01-30T17:18:17.8061084Z",
+            "updatedAt": "2019-01-30T17:18:17.8061084Z"
         },
         {
             "comment": "Silenced Host_Down alerts in the dev cluster",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "7cd828a9-50dd-4bad-a1fc-6ed2c22ac8dd",
+            "id": "a5609bb3-c6e9-40e8-87ce-0a091d0b8477",
             "matchers": [
                 {
                     "isRegex": false,
@@ -32,14 +32,14 @@
                     "value": "dev"
                 }
             ],
-            "startsAt": "2017-06-21T19:52:54.916254883Z",
-            "updatedAt": "2017-06-21T19:52:54.916254883Z"
+            "startsAt": "2019-01-30T17:18:17.8100135Z",
+            "updatedAt": "2019-01-30T17:18:17.8100135Z"
         },
         {
             "comment": "Silenced server7",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "08594d9b-b479-4941-af6e-abcec89bbbd6",
+            "id": "0a7572fb-e4b9-4ac5-a1c3-40df4dd3ebce",
             "matchers": [
                 {
                     "isRegex": false,
@@ -47,8 +47,8 @@
                     "value": "server7"
                 }
             ],
-            "startsAt": "2017-06-21T19:52:54.917958631Z",
-            "updatedAt": "2017-06-21T19:52:54.917958631Z"
+            "startsAt": "2019-01-30T17:18:17.8139276Z",
+            "updatedAt": "2019-01-30T17:18:17.8139276Z"
         }
     ],
     "status": "success"

--- a/internal/mock/0.5.1/api/v1/status
+++ b/internal/mock/0.5.1/api/v1/status
@@ -81,7 +81,7 @@
             },
             "templates": null
         },
-        "uptime": "2017-06-21T19:52:39.893041646Z",
+        "uptime": "2019-01-30T17:18:02.6818317Z",
         "versionInfo": {
             "branch": "master",
             "buildDate": "20161125-08:14:40",

--- a/internal/mock/0.5.1/metrics
+++ b/internal/mock/0.5.1/metrics
@@ -1,0 +1,406 @@
+# HELP alertmanager_alerts_invalid_total The total number of received alerts that were invalid.
+# TYPE alertmanager_alerts_invalid_total counter
+alertmanager_alerts_invalid_total 0
+# HELP alertmanager_alerts_received_total The total number of received alerts.
+# TYPE alertmanager_alerts_received_total counter
+alertmanager_alerts_received_total{status="firing"} 60
+# HELP alertmanager_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which alertmanager was built.
+# TYPE alertmanager_build_info gauge
+alertmanager_build_info{branch="master",goversion="go1.7.3",revision="0ea1cac51e6a620ec09d053f0484b97932b5c902",version="0.5.1"} 1
+# HELP alertmanager_config_last_reload_success_timestamp_seconds Timestamp of the last successful configuration reload.
+# TYPE alertmanager_config_last_reload_success_timestamp_seconds gauge
+alertmanager_config_last_reload_success_timestamp_seconds 1.548868682e+09
+# HELP alertmanager_config_last_reload_successful Whether the last configuration reload attempt was successful.
+# TYPE alertmanager_config_last_reload_successful gauge
+alertmanager_config_last_reload_successful 1
+# HELP alertmanager_nflog_gc_duration_seconds Duration of the last notification log garbage collection cycle.
+# TYPE alertmanager_nflog_gc_duration_seconds summary
+alertmanager_nflog_gc_duration_seconds{quantile="0.5"} NaN
+alertmanager_nflog_gc_duration_seconds{quantile="0.9"} NaN
+alertmanager_nflog_gc_duration_seconds{quantile="0.99"} NaN
+alertmanager_nflog_gc_duration_seconds_sum 0
+alertmanager_nflog_gc_duration_seconds_count 0
+# HELP alertmanager_nflog_queries_total Number of notification log queries were received.
+# TYPE alertmanager_nflog_queries_total counter
+alertmanager_nflog_queries_total 0
+# HELP alertmanager_nflog_query_duration_seconds Duration of notification log query evaluation.
+# TYPE alertmanager_nflog_query_duration_seconds histogram
+alertmanager_nflog_query_duration_seconds_bucket{le="0.005"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.01"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.025"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.05"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.1"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.25"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="1"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="2.5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="10"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="+Inf"} 0
+alertmanager_nflog_query_duration_seconds_sum 0
+alertmanager_nflog_query_duration_seconds_count 0
+# HELP alertmanager_nflog_query_errors_total Number notification log received queries that failed.
+# TYPE alertmanager_nflog_query_errors_total counter
+alertmanager_nflog_query_errors_total 0
+# HELP alertmanager_nflog_snapshot_duration_seconds Duration of the last notification log snapshot.
+# TYPE alertmanager_nflog_snapshot_duration_seconds summary
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.5"} NaN
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.9"} NaN
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.99"} NaN
+alertmanager_nflog_snapshot_duration_seconds_sum 0
+alertmanager_nflog_snapshot_duration_seconds_count 0
+# HELP alertmanager_silences_gc_duration_seconds Duration of the last silence garbage collection cycle.
+# TYPE alertmanager_silences_gc_duration_seconds summary
+alertmanager_silences_gc_duration_seconds{quantile="0.5"} NaN
+alertmanager_silences_gc_duration_seconds{quantile="0.9"} NaN
+alertmanager_silences_gc_duration_seconds{quantile="0.99"} NaN
+alertmanager_silences_gc_duration_seconds_sum 0
+alertmanager_silences_gc_duration_seconds_count 0
+# HELP alertmanager_silences_queries_total How many silence queries were received.
+# TYPE alertmanager_silences_queries_total counter
+alertmanager_silences_queries_total 48
+# HELP alertmanager_silences_query_duration_seconds Duration of silence query evaluation.
+# TYPE alertmanager_silences_query_duration_seconds histogram
+alertmanager_silences_query_duration_seconds_bucket{le="0.005"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.01"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.025"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.05"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.1"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.25"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.5"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="1"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="2.5"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="5"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="10"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="+Inf"} 48
+alertmanager_silences_query_duration_seconds_sum 0.0025806
+alertmanager_silences_query_duration_seconds_count 48
+# HELP alertmanager_silences_query_errors_total How many silence received queries did not succeed.
+# TYPE alertmanager_silences_query_errors_total counter
+alertmanager_silences_query_errors_total 0
+# HELP alertmanager_silences_snapshot_duration_seconds Duration of the last silence snapshot.
+# TYPE alertmanager_silences_snapshot_duration_seconds summary
+alertmanager_silences_snapshot_duration_seconds{quantile="0.5"} NaN
+alertmanager_silences_snapshot_duration_seconds{quantile="0.9"} NaN
+alertmanager_silences_snapshot_duration_seconds{quantile="0.99"} NaN
+alertmanager_silences_snapshot_duration_seconds_sum 0
+alertmanager_silences_snapshot_duration_seconds_count 0
+# HELP go_gc_duration_seconds A summary of the GC invocation durations.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0"} 0.0040226
+go_gc_duration_seconds{quantile="0.25"} 0.0040226
+go_gc_duration_seconds{quantile="0.5"} 0.0040226
+go_gc_duration_seconds{quantile="0.75"} 0.0040226
+go_gc_duration_seconds{quantile="1"} 0.0040226
+go_gc_duration_seconds_sum 0.0040226
+go_gc_duration_seconds_count 1
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 102
+# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+# TYPE go_memstats_alloc_bytes gauge
+go_memstats_alloc_bytes 4.618296e+06
+# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
+# TYPE go_memstats_alloc_bytes_total counter
+go_memstats_alloc_bytes_total 5.143688e+06
+# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
+# TYPE go_memstats_buck_hash_sys_bytes gauge
+go_memstats_buck_hash_sys_bytes 1.444979e+06
+# HELP go_memstats_frees_total Total number of frees.
+# TYPE go_memstats_frees_total counter
+go_memstats_frees_total 5008
+# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+# TYPE go_memstats_gc_sys_bytes gauge
+go_memstats_gc_sys_bytes 346112
+# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
+# TYPE go_memstats_heap_alloc_bytes gauge
+go_memstats_heap_alloc_bytes 4.618296e+06
+# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
+# TYPE go_memstats_heap_idle_bytes gauge
+go_memstats_heap_idle_bytes 434176
+# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
+# TYPE go_memstats_heap_inuse_bytes gauge
+go_memstats_heap_inuse_bytes 5.169152e+06
+# HELP go_memstats_heap_objects Number of allocated objects.
+# TYPE go_memstats_heap_objects gauge
+go_memstats_heap_objects 16988
+# HELP go_memstats_heap_released_bytes_total Total number of heap bytes released to OS.
+# TYPE go_memstats_heap_released_bytes_total counter
+go_memstats_heap_released_bytes_total 0
+# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
+# TYPE go_memstats_heap_sys_bytes gauge
+go_memstats_heap_sys_bytes 5.603328e+06
+# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
+# TYPE go_memstats_last_gc_time_seconds gauge
+go_memstats_last_gc_time_seconds 1.54886868270069e+09
+# HELP go_memstats_lookups_total Total number of pointer lookups.
+# TYPE go_memstats_lookups_total counter
+go_memstats_lookups_total 32
+# HELP go_memstats_mallocs_total Total number of mallocs.
+# TYPE go_memstats_mallocs_total counter
+go_memstats_mallocs_total 21996
+# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
+# TYPE go_memstats_mcache_inuse_bytes gauge
+go_memstats_mcache_inuse_bytes 2400
+# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
+# TYPE go_memstats_mcache_sys_bytes gauge
+go_memstats_mcache_sys_bytes 16384
+# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
+# TYPE go_memstats_mspan_inuse_bytes gauge
+go_memstats_mspan_inuse_bytes 60640
+# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
+# TYPE go_memstats_mspan_sys_bytes gauge
+go_memstats_mspan_sys_bytes 65536
+# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
+# TYPE go_memstats_next_gc_bytes gauge
+go_memstats_next_gc_bytes 6.377556e+06
+# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
+# TYPE go_memstats_other_sys_bytes gauge
+go_memstats_other_sys_bytes 754821
+# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
+# TYPE go_memstats_stack_inuse_bytes gauge
+go_memstats_stack_inuse_bytes 688128
+# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
+# TYPE go_memstats_stack_sys_bytes gauge
+go_memstats_stack_sys_bytes 688128
+# HELP go_memstats_sys_bytes Number of bytes obtained by system. Sum of all system allocations.
+# TYPE go_memstats_sys_bytes gauge
+go_memstats_sys_bytes 8.919288e+06
+# HELP http_request_duration_microseconds The HTTP request latencies in microseconds.
+# TYPE http_request_duration_microseconds summary
+http_request_duration_microseconds{handler="add_alerts",quantile="0.5"} 581.8
+http_request_duration_microseconds{handler="add_alerts",quantile="0.9"} 596.9
+http_request_duration_microseconds{handler="add_alerts",quantile="0.99"} 596.9
+http_request_duration_microseconds_sum{handler="add_alerts"} 3082.5
+http_request_duration_microseconds_count{handler="add_alerts"} 5
+http_request_duration_microseconds{handler="add_silence",quantile="0.5"} 155.3
+http_request_duration_microseconds{handler="add_silence",quantile="0.9"} 284.5
+http_request_duration_microseconds{handler="add_silence",quantile="0.99"} 284.5
+http_request_duration_microseconds_sum{handler="add_silence"} 726.8
+http_request_duration_microseconds_count{handler="add_silence"} 3
+http_request_duration_microseconds{handler="alert_groups",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="alert_groups",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="alert_groups",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="alert_groups"} 0
+http_request_duration_microseconds_count{handler="alert_groups"} 0
+http_request_duration_microseconds{handler="app_files",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="app_files",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="app_files",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="app_files"} 0
+http_request_duration_microseconds_count{handler="app_files"} 0
+http_request_duration_microseconds{handler="del_silence",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="del_silence",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="del_silence",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="del_silence"} 0
+http_request_duration_microseconds_count{handler="del_silence"} 0
+http_request_duration_microseconds{handler="get_silence",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="get_silence",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="get_silence",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="get_silence"} 0
+http_request_duration_microseconds_count{handler="get_silence"} 0
+http_request_duration_microseconds{handler="index",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="index",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="index",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="index"} 0
+http_request_duration_microseconds_count{handler="index"} 0
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="legacy_add_alerts"} 0
+http_request_duration_microseconds_count{handler="legacy_add_alerts"} 0
+http_request_duration_microseconds{handler="lib_files",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="lib_files",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="lib_files",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="lib_files"} 0
+http_request_duration_microseconds_count{handler="lib_files"} 0
+http_request_duration_microseconds{handler="list_alerts",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="list_alerts",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="list_alerts",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="list_alerts"} 0
+http_request_duration_microseconds_count{handler="list_alerts"} 0
+http_request_duration_microseconds{handler="list_silences",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="list_silences",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="list_silences",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="list_silences"} 0
+http_request_duration_microseconds_count{handler="list_silences"} 0
+http_request_duration_microseconds{handler="options",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="options",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="options",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="options"} 0
+http_request_duration_microseconds_count{handler="options"} 0
+http_request_duration_microseconds{handler="prometheus",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="prometheus",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="prometheus",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="prometheus"} 0
+http_request_duration_microseconds_count{handler="prometheus"} 0
+http_request_duration_microseconds{handler="status",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="status",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="status",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="status"} 0
+http_request_duration_microseconds_count{handler="status"} 0
+# HELP http_request_size_bytes The HTTP request sizes in bytes.
+# TYPE http_request_size_bytes summary
+http_request_size_bytes{handler="add_alerts",quantile="0.5"} 2719
+http_request_size_bytes{handler="add_alerts",quantile="0.9"} 2719
+http_request_size_bytes{handler="add_alerts",quantile="0.99"} 2719
+http_request_size_bytes_sum{handler="add_alerts"} 13595
+http_request_size_bytes_count{handler="add_alerts"} 5
+http_request_size_bytes{handler="add_silence",quantile="0.5"} 358
+http_request_size_bytes{handler="add_silence",quantile="0.9"} 360
+http_request_size_bytes{handler="add_silence",quantile="0.99"} 360
+http_request_size_bytes_sum{handler="add_silence"} 1164
+http_request_size_bytes_count{handler="add_silence"} 3
+http_request_size_bytes{handler="alert_groups",quantile="0.5"} NaN
+http_request_size_bytes{handler="alert_groups",quantile="0.9"} NaN
+http_request_size_bytes{handler="alert_groups",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="alert_groups"} 0
+http_request_size_bytes_count{handler="alert_groups"} 0
+http_request_size_bytes{handler="app_files",quantile="0.5"} NaN
+http_request_size_bytes{handler="app_files",quantile="0.9"} NaN
+http_request_size_bytes{handler="app_files",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="app_files"} 0
+http_request_size_bytes_count{handler="app_files"} 0
+http_request_size_bytes{handler="del_silence",quantile="0.5"} NaN
+http_request_size_bytes{handler="del_silence",quantile="0.9"} NaN
+http_request_size_bytes{handler="del_silence",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="del_silence"} 0
+http_request_size_bytes_count{handler="del_silence"} 0
+http_request_size_bytes{handler="get_silence",quantile="0.5"} NaN
+http_request_size_bytes{handler="get_silence",quantile="0.9"} NaN
+http_request_size_bytes{handler="get_silence",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="get_silence"} 0
+http_request_size_bytes_count{handler="get_silence"} 0
+http_request_size_bytes{handler="index",quantile="0.5"} NaN
+http_request_size_bytes{handler="index",quantile="0.9"} NaN
+http_request_size_bytes{handler="index",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="index"} 0
+http_request_size_bytes_count{handler="index"} 0
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="legacy_add_alerts"} 0
+http_request_size_bytes_count{handler="legacy_add_alerts"} 0
+http_request_size_bytes{handler="lib_files",quantile="0.5"} NaN
+http_request_size_bytes{handler="lib_files",quantile="0.9"} NaN
+http_request_size_bytes{handler="lib_files",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="lib_files"} 0
+http_request_size_bytes_count{handler="lib_files"} 0
+http_request_size_bytes{handler="list_alerts",quantile="0.5"} NaN
+http_request_size_bytes{handler="list_alerts",quantile="0.9"} NaN
+http_request_size_bytes{handler="list_alerts",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="list_alerts"} 0
+http_request_size_bytes_count{handler="list_alerts"} 0
+http_request_size_bytes{handler="list_silences",quantile="0.5"} NaN
+http_request_size_bytes{handler="list_silences",quantile="0.9"} NaN
+http_request_size_bytes{handler="list_silences",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="list_silences"} 0
+http_request_size_bytes_count{handler="list_silences"} 0
+http_request_size_bytes{handler="options",quantile="0.5"} NaN
+http_request_size_bytes{handler="options",quantile="0.9"} NaN
+http_request_size_bytes{handler="options",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="options"} 0
+http_request_size_bytes_count{handler="options"} 0
+http_request_size_bytes{handler="prometheus",quantile="0.5"} NaN
+http_request_size_bytes{handler="prometheus",quantile="0.9"} NaN
+http_request_size_bytes{handler="prometheus",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="prometheus"} 0
+http_request_size_bytes_count{handler="prometheus"} 0
+http_request_size_bytes{handler="status",quantile="0.5"} NaN
+http_request_size_bytes{handler="status",quantile="0.9"} NaN
+http_request_size_bytes{handler="status",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="status"} 0
+http_request_size_bytes_count{handler="status"} 0
+# HELP http_requests_total Total number of HTTP requests made.
+# TYPE http_requests_total counter
+http_requests_total{code="200",handler="add_alerts",method="post"} 5
+http_requests_total{code="200",handler="add_silence",method="post"} 3
+# HELP http_response_size_bytes The HTTP response sizes in bytes.
+# TYPE http_response_size_bytes summary
+http_response_size_bytes{handler="add_alerts",quantile="0.5"} 20
+http_response_size_bytes{handler="add_alerts",quantile="0.9"} 20
+http_response_size_bytes{handler="add_alerts",quantile="0.99"} 20
+http_response_size_bytes_sum{handler="add_alerts"} 100
+http_response_size_bytes_count{handler="add_alerts"} 5
+http_response_size_bytes{handler="add_silence",quantile="0.5"} 80
+http_response_size_bytes{handler="add_silence",quantile="0.9"} 80
+http_response_size_bytes{handler="add_silence",quantile="0.99"} 80
+http_response_size_bytes_sum{handler="add_silence"} 240
+http_response_size_bytes_count{handler="add_silence"} 3
+http_response_size_bytes{handler="alert_groups",quantile="0.5"} NaN
+http_response_size_bytes{handler="alert_groups",quantile="0.9"} NaN
+http_response_size_bytes{handler="alert_groups",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="alert_groups"} 0
+http_response_size_bytes_count{handler="alert_groups"} 0
+http_response_size_bytes{handler="app_files",quantile="0.5"} NaN
+http_response_size_bytes{handler="app_files",quantile="0.9"} NaN
+http_response_size_bytes{handler="app_files",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="app_files"} 0
+http_response_size_bytes_count{handler="app_files"} 0
+http_response_size_bytes{handler="del_silence",quantile="0.5"} NaN
+http_response_size_bytes{handler="del_silence",quantile="0.9"} NaN
+http_response_size_bytes{handler="del_silence",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="del_silence"} 0
+http_response_size_bytes_count{handler="del_silence"} 0
+http_response_size_bytes{handler="get_silence",quantile="0.5"} NaN
+http_response_size_bytes{handler="get_silence",quantile="0.9"} NaN
+http_response_size_bytes{handler="get_silence",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="get_silence"} 0
+http_response_size_bytes_count{handler="get_silence"} 0
+http_response_size_bytes{handler="index",quantile="0.5"} NaN
+http_response_size_bytes{handler="index",quantile="0.9"} NaN
+http_response_size_bytes{handler="index",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="index"} 0
+http_response_size_bytes_count{handler="index"} 0
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="legacy_add_alerts"} 0
+http_response_size_bytes_count{handler="legacy_add_alerts"} 0
+http_response_size_bytes{handler="lib_files",quantile="0.5"} NaN
+http_response_size_bytes{handler="lib_files",quantile="0.9"} NaN
+http_response_size_bytes{handler="lib_files",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="lib_files"} 0
+http_response_size_bytes_count{handler="lib_files"} 0
+http_response_size_bytes{handler="list_alerts",quantile="0.5"} NaN
+http_response_size_bytes{handler="list_alerts",quantile="0.9"} NaN
+http_response_size_bytes{handler="list_alerts",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="list_alerts"} 0
+http_response_size_bytes_count{handler="list_alerts"} 0
+http_response_size_bytes{handler="list_silences",quantile="0.5"} NaN
+http_response_size_bytes{handler="list_silences",quantile="0.9"} NaN
+http_response_size_bytes{handler="list_silences",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="list_silences"} 0
+http_response_size_bytes_count{handler="list_silences"} 0
+http_response_size_bytes{handler="options",quantile="0.5"} NaN
+http_response_size_bytes{handler="options",quantile="0.9"} NaN
+http_response_size_bytes{handler="options",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="options"} 0
+http_response_size_bytes_count{handler="options"} 0
+http_response_size_bytes{handler="prometheus",quantile="0.5"} NaN
+http_response_size_bytes{handler="prometheus",quantile="0.9"} NaN
+http_response_size_bytes{handler="prometheus",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="prometheus"} 0
+http_response_size_bytes_count{handler="prometheus"} 0
+http_response_size_bytes{handler="status",quantile="0.5"} NaN
+http_response_size_bytes{handler="status",quantile="0.9"} NaN
+http_response_size_bytes{handler="status",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="status"} 0
+http_response_size_bytes_count{handler="status"} 0
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 0.1
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+process_max_fds 1.048576e+06
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+process_open_fds 8
+# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes 9.494528e+06
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds 1.5488686816e+09
+# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE process_virtual_memory_bytes gauge
+process_virtual_memory_bytes 1.7289216e+07

--- a/internal/mock/0.6.0/api/v1/alerts/groups
+++ b/internal/mock/0.6.0/api/v1/alerts/groups
@@ -18,7 +18,7 @@
                                 "instance": "server5",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:54:02.96073587Z"
+                            "startsAt": "2019-01-30T17:19:30.5586268Z"
                         }
                     ],
                     "routeOpts": {
@@ -43,6 +43,21 @@
                     "alerts": [
                         {
                             "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "inhibited": false,
+                            "labels": {
+                                "alertname": "HTTP_Probe_Failed",
+                                "cluster": "dev",
+                                "instance": "web2",
+                                "job": "node_exporter"
+                            },
+                            "startsAt": "2019-01-30T17:19:30.5586268Z"
+                        },
+                        {
+                            "annotations": {
                                 "help": "Example help annotation",
                                 "summary": "Example summary",
                                 "url": "http://localhost/example.html"
@@ -56,23 +71,8 @@
                                 "instance": "web1",
                                 "job": "node_exporter"
                             },
-                            "silenced": "56992aa1-3bb1-4bc9-8378-f233a2b83671",
-                            "startsAt": "2017-06-21T19:54:02.96073587Z"
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "generatorURL": "localhost/prometheus",
-                            "inhibited": false,
-                            "labels": {
-                                "alertname": "HTTP_Probe_Failed",
-                                "cluster": "dev",
-                                "instance": "web2",
-                                "job": "node_exporter"
-                            },
-                            "startsAt": "2017-06-21T19:54:02.96073587Z"
+                            "silenced": "584fae9a-1d22-40b8-bb1a-083e9c65b673",
+                            "startsAt": "2019-01-30T17:19:30.5586268Z"
                         }
                     ],
                     "routeOpts": {
@@ -108,8 +108,8 @@
                                 "instance": "server8",
                                 "job": "node_ping"
                             },
-                            "silenced": "84c7dd5a-31bc-4318-a63a-2b9e7b1f62b3",
-                            "startsAt": "2017-06-21T19:54:02.96073587Z"
+                            "silenced": "b65cfc66-ec1b-45c6-844a-7f3f1540721f",
+                            "startsAt": "2019-01-30T17:19:30.5586268Z"
                         },
                         {
                             "annotations": {
@@ -125,7 +125,7 @@
                                 "instance": "server1",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:54:02.96073587Z"
+                            "startsAt": "2019-01-30T17:19:30.5586268Z"
                         },
                         {
                             "annotations": {
@@ -140,7 +140,7 @@
                                 "instance": "server2",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:54:02.96073587Z"
+                            "startsAt": "2019-01-30T17:19:30.5586268Z"
                         },
                         {
                             "annotations": {
@@ -155,7 +155,7 @@
                                 "instance": "server3",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:54:02.96073587Z"
+                            "startsAt": "2019-01-30T17:19:30.5586268Z"
                         },
                         {
                             "annotations": {
@@ -170,7 +170,7 @@
                                 "instance": "server4",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:54:02.96073587Z"
+                            "startsAt": "2019-01-30T17:19:30.5586268Z"
                         },
                         {
                             "annotations": {
@@ -185,7 +185,7 @@
                                 "instance": "server5",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:54:02.96073587Z"
+                            "startsAt": "2019-01-30T17:19:30.5586268Z"
                         },
                         {
                             "annotations": {
@@ -200,8 +200,8 @@
                                 "instance": "server6",
                                 "job": "node_ping"
                             },
-                            "silenced": "84c7dd5a-31bc-4318-a63a-2b9e7b1f62b3",
-                            "startsAt": "2017-06-21T19:54:02.96073587Z"
+                            "silenced": "b65cfc66-ec1b-45c6-844a-7f3f1540721f",
+                            "startsAt": "2019-01-30T17:19:30.5586268Z"
                         },
                         {
                             "annotations": {
@@ -216,8 +216,8 @@
                                 "instance": "server7",
                                 "job": "node_ping"
                             },
-                            "silenced": "84c7dd5a-31bc-4318-a63a-2b9e7b1f62b3",
-                            "startsAt": "2017-06-21T19:54:02.96073587Z"
+                            "silenced": "b65cfc66-ec1b-45c6-844a-7f3f1540721f",
+                            "startsAt": "2019-01-30T17:19:30.5586268Z"
                         }
                     ],
                     "routeOpts": {
@@ -254,7 +254,7 @@
                                 "instance": "server2",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:54:02.96073587Z"
+                            "startsAt": "2019-01-30T17:19:30.5586268Z"
                         }
                     ],
                     "routeOpts": {
@@ -291,14 +291,14 @@
                                 "instance": "server5",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:54:02.96073587Z"
+                            "startsAt": "2019-01-30T17:19:30.5586268Z"
                         }
                     ],
                     "routeOpts": {
                         "groupBy": [
-                            "alertname",
                             "cluster",
-                            "service"
+                            "service",
+                            "alertname"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,
@@ -332,8 +332,8 @@
                                 "instance": "web1",
                                 "job": "node_exporter"
                             },
-                            "silenced": "56992aa1-3bb1-4bc9-8378-f233a2b83671",
-                            "startsAt": "2017-06-21T19:54:02.96073587Z"
+                            "silenced": "584fae9a-1d22-40b8-bb1a-083e9c65b673",
+                            "startsAt": "2019-01-30T17:19:30.5586268Z"
                         },
                         {
                             "annotations": {
@@ -348,7 +348,7 @@
                                 "instance": "web2",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:54:02.96073587Z"
+                            "startsAt": "2019-01-30T17:19:30.5586268Z"
                         }
                     ],
                     "routeOpts": {
@@ -387,8 +387,8 @@
                                 "instance": "server6",
                                 "job": "node_ping"
                             },
-                            "silenced": "84c7dd5a-31bc-4318-a63a-2b9e7b1f62b3",
-                            "startsAt": "2017-06-21T19:54:02.96073587Z"
+                            "silenced": "b65cfc66-ec1b-45c6-844a-7f3f1540721f",
+                            "startsAt": "2019-01-30T17:19:30.5586268Z"
                         },
                         {
                             "annotations": {
@@ -403,8 +403,8 @@
                                 "instance": "server7",
                                 "job": "node_ping"
                             },
-                            "silenced": "84c7dd5a-31bc-4318-a63a-2b9e7b1f62b3",
-                            "startsAt": "2017-06-21T19:54:02.96073587Z"
+                            "silenced": "b65cfc66-ec1b-45c6-844a-7f3f1540721f",
+                            "startsAt": "2019-01-30T17:19:30.5586268Z"
                         },
                         {
                             "annotations": {
@@ -419,8 +419,8 @@
                                 "instance": "server8",
                                 "job": "node_ping"
                             },
-                            "silenced": "84c7dd5a-31bc-4318-a63a-2b9e7b1f62b3",
-                            "startsAt": "2017-06-21T19:54:02.96073587Z"
+                            "silenced": "b65cfc66-ec1b-45c6-844a-7f3f1540721f",
+                            "startsAt": "2019-01-30T17:19:30.5586268Z"
                         }
                     ],
                     "routeOpts": {
@@ -460,7 +460,7 @@
                                 "instance": "server1",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:54:02.96073587Z"
+                            "startsAt": "2019-01-30T17:19:30.5586268Z"
                         },
                         {
                             "annotations": {
@@ -475,14 +475,14 @@
                                 "instance": "server2",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:54:02.96073587Z"
+                            "startsAt": "2019-01-30T17:19:30.5586268Z"
                         }
                     ],
                     "routeOpts": {
                         "groupBy": [
-                            "alertname",
                             "cluster",
-                            "service"
+                            "service",
+                            "alertname"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,
@@ -511,25 +511,10 @@
                             "labels": {
                                 "alertname": "Host_Down",
                                 "cluster": "staging",
-                                "instance": "server5",
-                                "job": "node_ping"
-                            },
-                            "startsAt": "2017-06-21T19:54:02.96073587Z"
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "generatorURL": "localhost/prometheus",
-                            "inhibited": false,
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "staging",
                                 "instance": "server3",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:54:02.96073587Z"
+                            "startsAt": "2019-01-30T17:19:30.5586268Z"
                         },
                         {
                             "annotations": {
@@ -544,7 +529,22 @@
                                 "instance": "server4",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:54:02.96073587Z"
+                            "startsAt": "2019-01-30T17:19:30.5586268Z"
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "inhibited": false,
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "staging",
+                                "instance": "server5",
+                                "job": "node_ping"
+                            },
+                            "startsAt": "2019-01-30T17:19:30.5586268Z"
                         }
                     ],
                     "routeOpts": {
@@ -584,7 +584,7 @@
                                 "instance": "server2",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:54:02.96073587Z"
+                            "startsAt": "2019-01-30T17:19:30.5586268Z"
                         }
                     ],
                     "routeOpts": {

--- a/internal/mock/0.6.0/api/v1/silences
+++ b/internal/mock/0.6.0/api/v1/silences
@@ -4,7 +4,7 @@
             "comment": "Silenced instance",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "56992aa1-3bb1-4bc9-8378-f233a2b83671",
+            "id": "584fae9a-1d22-40b8-bb1a-083e9c65b673",
             "matchers": [
                 {
                     "isRegex": false,
@@ -12,14 +12,14 @@
                     "value": "web1"
                 }
             ],
-            "startsAt": "2017-06-21T19:54:02.954898476Z",
-            "updatedAt": "2017-06-21T19:54:02.954898476Z"
+            "startsAt": "2019-01-30T17:19:30.5404029Z",
+            "updatedAt": "2019-01-30T17:19:30.5404029Z"
         },
         {
             "comment": "Silenced Host_Down alerts in the dev cluster",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "84c7dd5a-31bc-4318-a63a-2b9e7b1f62b3",
+            "id": "b65cfc66-ec1b-45c6-844a-7f3f1540721f",
             "matchers": [
                 {
                     "isRegex": false,
@@ -32,14 +32,14 @@
                     "value": "dev"
                 }
             ],
-            "startsAt": "2017-06-21T19:54:02.957027907Z",
-            "updatedAt": "2017-06-21T19:54:02.957027907Z"
+            "startsAt": "2019-01-30T17:19:30.5446497Z",
+            "updatedAt": "2019-01-30T17:19:30.5446497Z"
         },
         {
             "comment": "Silenced server7",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "60dfd0f4-bfa9-4741-aa02-74be9dc5e585",
+            "id": "2acec23d-4236-4cad-8ca3-ed488a01a8a8",
             "matchers": [
                 {
                     "isRegex": false,
@@ -47,8 +47,8 @@
                     "value": "server7"
                 }
             ],
-            "startsAt": "2017-06-21T19:54:02.958838414Z",
-            "updatedAt": "2017-06-21T19:54:02.958838414Z"
+            "startsAt": "2019-01-30T17:19:30.5482529Z",
+            "updatedAt": "2019-01-30T17:19:30.5482529Z"
         }
     ],
     "status": "success"

--- a/internal/mock/0.6.0/api/v1/status
+++ b/internal/mock/0.6.0/api/v1/status
@@ -83,16 +83,16 @@
         },
         "meshStatus": {
             "name": "02:42:ac:11:00:02",
-            "nickName": "50bf7fbfa0d9",
+            "nickName": "eff13a74d2ba",
             "peers": [
                 {
                     "name": "02:42:ac:11:00:02",
-                    "nickName": "50bf7fbfa0d9",
-                    "uid": 7500147642750525955
+                    "nickName": "eff13a74d2ba",
+                    "uid": 10372873245996735375
                 }
             ]
         },
-        "uptime": "2017-06-21T19:53:47.932629807Z",
+        "uptime": "2019-01-30T17:19:15.2909216Z",
         "versionInfo": {
             "branch": "master",
             "buildDate": "20170425-19:48:54",

--- a/internal/mock/0.6.0/metrics
+++ b/internal/mock/0.6.0/metrics
@@ -1,0 +1,406 @@
+# HELP alertmanager_alerts_invalid_total The total number of received alerts that were invalid.
+# TYPE alertmanager_alerts_invalid_total counter
+alertmanager_alerts_invalid_total 0
+# HELP alertmanager_alerts_received_total The total number of received alerts.
+# TYPE alertmanager_alerts_received_total counter
+alertmanager_alerts_received_total{status="firing"} 60
+# HELP alertmanager_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which alertmanager was built.
+# TYPE alertmanager_build_info gauge
+alertmanager_build_info{branch="master",goversion="go1.8.1",revision="762b5c479a8d35c8ed9763fe13a16b4e521f7c54",version="0.6.0"} 1
+# HELP alertmanager_config_last_reload_success_timestamp_seconds Timestamp of the last successful configuration reload.
+# TYPE alertmanager_config_last_reload_success_timestamp_seconds gauge
+alertmanager_config_last_reload_success_timestamp_seconds 1.548868755e+09
+# HELP alertmanager_config_last_reload_successful Whether the last configuration reload attempt was successful.
+# TYPE alertmanager_config_last_reload_successful gauge
+alertmanager_config_last_reload_successful 1
+# HELP alertmanager_nflog_gc_duration_seconds Duration of the last notification log garbage collection cycle.
+# TYPE alertmanager_nflog_gc_duration_seconds summary
+alertmanager_nflog_gc_duration_seconds{quantile="0.5"} NaN
+alertmanager_nflog_gc_duration_seconds{quantile="0.9"} NaN
+alertmanager_nflog_gc_duration_seconds{quantile="0.99"} NaN
+alertmanager_nflog_gc_duration_seconds_sum 0
+alertmanager_nflog_gc_duration_seconds_count 0
+# HELP alertmanager_nflog_queries_total Number of notification log queries were received.
+# TYPE alertmanager_nflog_queries_total counter
+alertmanager_nflog_queries_total 0
+# HELP alertmanager_nflog_query_duration_seconds Duration of notification log query evaluation.
+# TYPE alertmanager_nflog_query_duration_seconds histogram
+alertmanager_nflog_query_duration_seconds_bucket{le="0.005"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.01"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.025"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.05"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.1"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.25"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="1"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="2.5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="10"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="+Inf"} 0
+alertmanager_nflog_query_duration_seconds_sum 0
+alertmanager_nflog_query_duration_seconds_count 0
+# HELP alertmanager_nflog_query_errors_total Number notification log received queries that failed.
+# TYPE alertmanager_nflog_query_errors_total counter
+alertmanager_nflog_query_errors_total 0
+# HELP alertmanager_nflog_snapshot_duration_seconds Duration of the last notification log snapshot.
+# TYPE alertmanager_nflog_snapshot_duration_seconds summary
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.5"} NaN
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.9"} NaN
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.99"} NaN
+alertmanager_nflog_snapshot_duration_seconds_sum 0
+alertmanager_nflog_snapshot_duration_seconds_count 0
+# HELP alertmanager_silences_gc_duration_seconds Duration of the last silence garbage collection cycle.
+# TYPE alertmanager_silences_gc_duration_seconds summary
+alertmanager_silences_gc_duration_seconds{quantile="0.5"} NaN
+alertmanager_silences_gc_duration_seconds{quantile="0.9"} NaN
+alertmanager_silences_gc_duration_seconds{quantile="0.99"} NaN
+alertmanager_silences_gc_duration_seconds_sum 0
+alertmanager_silences_gc_duration_seconds_count 0
+# HELP alertmanager_silences_queries_total How many silence queries were received.
+# TYPE alertmanager_silences_queries_total counter
+alertmanager_silences_queries_total 48
+# HELP alertmanager_silences_query_duration_seconds Duration of silence query evaluation.
+# TYPE alertmanager_silences_query_duration_seconds histogram
+alertmanager_silences_query_duration_seconds_bucket{le="0.005"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.01"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.025"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.05"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.1"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.25"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.5"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="1"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="2.5"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="5"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="10"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="+Inf"} 48
+alertmanager_silences_query_duration_seconds_sum 0.0021241999999999997
+alertmanager_silences_query_duration_seconds_count 48
+# HELP alertmanager_silences_query_errors_total How many silence received queries did not succeed.
+# TYPE alertmanager_silences_query_errors_total counter
+alertmanager_silences_query_errors_total 0
+# HELP alertmanager_silences_snapshot_duration_seconds Duration of the last silence snapshot.
+# TYPE alertmanager_silences_snapshot_duration_seconds summary
+alertmanager_silences_snapshot_duration_seconds{quantile="0.5"} NaN
+alertmanager_silences_snapshot_duration_seconds{quantile="0.9"} NaN
+alertmanager_silences_snapshot_duration_seconds{quantile="0.99"} NaN
+alertmanager_silences_snapshot_duration_seconds_sum 0
+alertmanager_silences_snapshot_duration_seconds_count 0
+# HELP go_gc_duration_seconds A summary of the GC invocation durations.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0"} 0.0003868
+go_gc_duration_seconds{quantile="0.25"} 0.0003868
+go_gc_duration_seconds{quantile="0.5"} 0.0003868
+go_gc_duration_seconds{quantile="0.75"} 0.0003868
+go_gc_duration_seconds{quantile="1"} 0.0003868
+go_gc_duration_seconds_sum 0.0003868
+go_gc_duration_seconds_count 1
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 63
+# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+# TYPE go_memstats_alloc_bytes gauge
+go_memstats_alloc_bytes 4.795144e+06
+# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
+# TYPE go_memstats_alloc_bytes_total counter
+go_memstats_alloc_bytes_total 5.250672e+06
+# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
+# TYPE go_memstats_buck_hash_sys_bytes gauge
+go_memstats_buck_hash_sys_bytes 1.44371e+06
+# HELP go_memstats_frees_total Total number of frees.
+# TYPE go_memstats_frees_total counter
+go_memstats_frees_total 5715
+# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+# TYPE go_memstats_gc_sys_bytes gauge
+go_memstats_gc_sys_bytes 356352
+# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
+# TYPE go_memstats_heap_alloc_bytes gauge
+go_memstats_heap_alloc_bytes 4.795144e+06
+# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
+# TYPE go_memstats_heap_idle_bytes gauge
+go_memstats_heap_idle_bytes 180224
+# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
+# TYPE go_memstats_heap_inuse_bytes gauge
+go_memstats_heap_inuse_bytes 5.390336e+06
+# HELP go_memstats_heap_objects Number of allocated objects.
+# TYPE go_memstats_heap_objects gauge
+go_memstats_heap_objects 18212
+# HELP go_memstats_heap_released_bytes_total Total number of heap bytes released to OS.
+# TYPE go_memstats_heap_released_bytes_total counter
+go_memstats_heap_released_bytes_total 0
+# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
+# TYPE go_memstats_heap_sys_bytes gauge
+go_memstats_heap_sys_bytes 5.57056e+06
+# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
+# TYPE go_memstats_last_gc_time_seconds gauge
+go_memstats_last_gc_time_seconds 1.5488687553348098e+09
+# HELP go_memstats_lookups_total Total number of pointer lookups.
+# TYPE go_memstats_lookups_total counter
+go_memstats_lookups_total 39
+# HELP go_memstats_mallocs_total Total number of mallocs.
+# TYPE go_memstats_mallocs_total counter
+go_memstats_mallocs_total 23927
+# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
+# TYPE go_memstats_mcache_inuse_bytes gauge
+go_memstats_mcache_inuse_bytes 2400
+# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
+# TYPE go_memstats_mcache_sys_bytes gauge
+go_memstats_mcache_sys_bytes 16384
+# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
+# TYPE go_memstats_mspan_inuse_bytes gauge
+go_memstats_mspan_inuse_bytes 60952
+# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
+# TYPE go_memstats_mspan_sys_bytes gauge
+go_memstats_mspan_sys_bytes 65536
+# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
+# TYPE go_memstats_next_gc_bytes gauge
+go_memstats_next_gc_bytes 8.237376e+06
+# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
+# TYPE go_memstats_other_sys_bytes gauge
+go_memstats_other_sys_bytes 745850
+# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
+# TYPE go_memstats_stack_inuse_bytes gauge
+go_memstats_stack_inuse_bytes 720896
+# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
+# TYPE go_memstats_stack_sys_bytes gauge
+go_memstats_stack_sys_bytes 720896
+# HELP go_memstats_sys_bytes Number of bytes obtained by system. Sum of all system allocations.
+# TYPE go_memstats_sys_bytes gauge
+go_memstats_sys_bytes 8.919288e+06
+# HELP http_request_duration_microseconds The HTTP request latencies in microseconds.
+# TYPE http_request_duration_microseconds summary
+http_request_duration_microseconds{handler="add_alerts",quantile="0.5"} 524.1
+http_request_duration_microseconds{handler="add_alerts",quantile="0.9"} 1737.5
+http_request_duration_microseconds{handler="add_alerts",quantile="0.99"} 1737.5
+http_request_duration_microseconds_sum{handler="add_alerts"} 9364.7
+http_request_duration_microseconds_count{handler="add_alerts"} 5
+http_request_duration_microseconds{handler="add_silence",quantile="0.5"} 211.4
+http_request_duration_microseconds{handler="add_silence",quantile="0.9"} 263.8
+http_request_duration_microseconds{handler="add_silence",quantile="0.99"} 263.8
+http_request_duration_microseconds_sum{handler="add_silence"} 956
+http_request_duration_microseconds_count{handler="add_silence"} 3
+http_request_duration_microseconds{handler="alert_groups",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="alert_groups",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="alert_groups",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="alert_groups"} 0
+http_request_duration_microseconds_count{handler="alert_groups"} 0
+http_request_duration_microseconds{handler="app_files",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="app_files",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="app_files",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="app_files"} 0
+http_request_duration_microseconds_count{handler="app_files"} 0
+http_request_duration_microseconds{handler="del_silence",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="del_silence",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="del_silence",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="del_silence"} 0
+http_request_duration_microseconds_count{handler="del_silence"} 0
+http_request_duration_microseconds{handler="get_silence",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="get_silence",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="get_silence",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="get_silence"} 0
+http_request_duration_microseconds_count{handler="get_silence"} 0
+http_request_duration_microseconds{handler="index",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="index",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="index",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="index"} 0
+http_request_duration_microseconds_count{handler="index"} 0
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="legacy_add_alerts"} 0
+http_request_duration_microseconds_count{handler="legacy_add_alerts"} 0
+http_request_duration_microseconds{handler="lib_files",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="lib_files",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="lib_files",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="lib_files"} 0
+http_request_duration_microseconds_count{handler="lib_files"} 0
+http_request_duration_microseconds{handler="list_alerts",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="list_alerts",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="list_alerts",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="list_alerts"} 0
+http_request_duration_microseconds_count{handler="list_alerts"} 0
+http_request_duration_microseconds{handler="list_silences",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="list_silences",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="list_silences",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="list_silences"} 0
+http_request_duration_microseconds_count{handler="list_silences"} 0
+http_request_duration_microseconds{handler="options",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="options",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="options",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="options"} 0
+http_request_duration_microseconds_count{handler="options"} 0
+http_request_duration_microseconds{handler="prometheus",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="prometheus",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="prometheus",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="prometheus"} 0
+http_request_duration_microseconds_count{handler="prometheus"} 0
+http_request_duration_microseconds{handler="status",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="status",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="status",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="status"} 0
+http_request_duration_microseconds_count{handler="status"} 0
+# HELP http_request_size_bytes The HTTP request sizes in bytes.
+# TYPE http_request_size_bytes summary
+http_request_size_bytes{handler="add_alerts",quantile="0.5"} 2719
+http_request_size_bytes{handler="add_alerts",quantile="0.9"} 2719
+http_request_size_bytes{handler="add_alerts",quantile="0.99"} 2719
+http_request_size_bytes_sum{handler="add_alerts"} 13595
+http_request_size_bytes_count{handler="add_alerts"} 5
+http_request_size_bytes{handler="add_silence",quantile="0.5"} 358
+http_request_size_bytes{handler="add_silence",quantile="0.9"} 360
+http_request_size_bytes{handler="add_silence",quantile="0.99"} 360
+http_request_size_bytes_sum{handler="add_silence"} 1164
+http_request_size_bytes_count{handler="add_silence"} 3
+http_request_size_bytes{handler="alert_groups",quantile="0.5"} NaN
+http_request_size_bytes{handler="alert_groups",quantile="0.9"} NaN
+http_request_size_bytes{handler="alert_groups",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="alert_groups"} 0
+http_request_size_bytes_count{handler="alert_groups"} 0
+http_request_size_bytes{handler="app_files",quantile="0.5"} NaN
+http_request_size_bytes{handler="app_files",quantile="0.9"} NaN
+http_request_size_bytes{handler="app_files",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="app_files"} 0
+http_request_size_bytes_count{handler="app_files"} 0
+http_request_size_bytes{handler="del_silence",quantile="0.5"} NaN
+http_request_size_bytes{handler="del_silence",quantile="0.9"} NaN
+http_request_size_bytes{handler="del_silence",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="del_silence"} 0
+http_request_size_bytes_count{handler="del_silence"} 0
+http_request_size_bytes{handler="get_silence",quantile="0.5"} NaN
+http_request_size_bytes{handler="get_silence",quantile="0.9"} NaN
+http_request_size_bytes{handler="get_silence",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="get_silence"} 0
+http_request_size_bytes_count{handler="get_silence"} 0
+http_request_size_bytes{handler="index",quantile="0.5"} NaN
+http_request_size_bytes{handler="index",quantile="0.9"} NaN
+http_request_size_bytes{handler="index",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="index"} 0
+http_request_size_bytes_count{handler="index"} 0
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="legacy_add_alerts"} 0
+http_request_size_bytes_count{handler="legacy_add_alerts"} 0
+http_request_size_bytes{handler="lib_files",quantile="0.5"} NaN
+http_request_size_bytes{handler="lib_files",quantile="0.9"} NaN
+http_request_size_bytes{handler="lib_files",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="lib_files"} 0
+http_request_size_bytes_count{handler="lib_files"} 0
+http_request_size_bytes{handler="list_alerts",quantile="0.5"} NaN
+http_request_size_bytes{handler="list_alerts",quantile="0.9"} NaN
+http_request_size_bytes{handler="list_alerts",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="list_alerts"} 0
+http_request_size_bytes_count{handler="list_alerts"} 0
+http_request_size_bytes{handler="list_silences",quantile="0.5"} NaN
+http_request_size_bytes{handler="list_silences",quantile="0.9"} NaN
+http_request_size_bytes{handler="list_silences",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="list_silences"} 0
+http_request_size_bytes_count{handler="list_silences"} 0
+http_request_size_bytes{handler="options",quantile="0.5"} NaN
+http_request_size_bytes{handler="options",quantile="0.9"} NaN
+http_request_size_bytes{handler="options",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="options"} 0
+http_request_size_bytes_count{handler="options"} 0
+http_request_size_bytes{handler="prometheus",quantile="0.5"} NaN
+http_request_size_bytes{handler="prometheus",quantile="0.9"} NaN
+http_request_size_bytes{handler="prometheus",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="prometheus"} 0
+http_request_size_bytes_count{handler="prometheus"} 0
+http_request_size_bytes{handler="status",quantile="0.5"} NaN
+http_request_size_bytes{handler="status",quantile="0.9"} NaN
+http_request_size_bytes{handler="status",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="status"} 0
+http_request_size_bytes_count{handler="status"} 0
+# HELP http_requests_total Total number of HTTP requests made.
+# TYPE http_requests_total counter
+http_requests_total{code="200",handler="add_alerts",method="post"} 5
+http_requests_total{code="200",handler="add_silence",method="post"} 3
+# HELP http_response_size_bytes The HTTP response sizes in bytes.
+# TYPE http_response_size_bytes summary
+http_response_size_bytes{handler="add_alerts",quantile="0.5"} 20
+http_response_size_bytes{handler="add_alerts",quantile="0.9"} 20
+http_response_size_bytes{handler="add_alerts",quantile="0.99"} 20
+http_response_size_bytes_sum{handler="add_alerts"} 100
+http_response_size_bytes_count{handler="add_alerts"} 5
+http_response_size_bytes{handler="add_silence",quantile="0.5"} 80
+http_response_size_bytes{handler="add_silence",quantile="0.9"} 80
+http_response_size_bytes{handler="add_silence",quantile="0.99"} 80
+http_response_size_bytes_sum{handler="add_silence"} 240
+http_response_size_bytes_count{handler="add_silence"} 3
+http_response_size_bytes{handler="alert_groups",quantile="0.5"} NaN
+http_response_size_bytes{handler="alert_groups",quantile="0.9"} NaN
+http_response_size_bytes{handler="alert_groups",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="alert_groups"} 0
+http_response_size_bytes_count{handler="alert_groups"} 0
+http_response_size_bytes{handler="app_files",quantile="0.5"} NaN
+http_response_size_bytes{handler="app_files",quantile="0.9"} NaN
+http_response_size_bytes{handler="app_files",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="app_files"} 0
+http_response_size_bytes_count{handler="app_files"} 0
+http_response_size_bytes{handler="del_silence",quantile="0.5"} NaN
+http_response_size_bytes{handler="del_silence",quantile="0.9"} NaN
+http_response_size_bytes{handler="del_silence",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="del_silence"} 0
+http_response_size_bytes_count{handler="del_silence"} 0
+http_response_size_bytes{handler="get_silence",quantile="0.5"} NaN
+http_response_size_bytes{handler="get_silence",quantile="0.9"} NaN
+http_response_size_bytes{handler="get_silence",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="get_silence"} 0
+http_response_size_bytes_count{handler="get_silence"} 0
+http_response_size_bytes{handler="index",quantile="0.5"} NaN
+http_response_size_bytes{handler="index",quantile="0.9"} NaN
+http_response_size_bytes{handler="index",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="index"} 0
+http_response_size_bytes_count{handler="index"} 0
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="legacy_add_alerts"} 0
+http_response_size_bytes_count{handler="legacy_add_alerts"} 0
+http_response_size_bytes{handler="lib_files",quantile="0.5"} NaN
+http_response_size_bytes{handler="lib_files",quantile="0.9"} NaN
+http_response_size_bytes{handler="lib_files",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="lib_files"} 0
+http_response_size_bytes_count{handler="lib_files"} 0
+http_response_size_bytes{handler="list_alerts",quantile="0.5"} NaN
+http_response_size_bytes{handler="list_alerts",quantile="0.9"} NaN
+http_response_size_bytes{handler="list_alerts",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="list_alerts"} 0
+http_response_size_bytes_count{handler="list_alerts"} 0
+http_response_size_bytes{handler="list_silences",quantile="0.5"} NaN
+http_response_size_bytes{handler="list_silences",quantile="0.9"} NaN
+http_response_size_bytes{handler="list_silences",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="list_silences"} 0
+http_response_size_bytes_count{handler="list_silences"} 0
+http_response_size_bytes{handler="options",quantile="0.5"} NaN
+http_response_size_bytes{handler="options",quantile="0.9"} NaN
+http_response_size_bytes{handler="options",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="options"} 0
+http_response_size_bytes_count{handler="options"} 0
+http_response_size_bytes{handler="prometheus",quantile="0.5"} NaN
+http_response_size_bytes{handler="prometheus",quantile="0.9"} NaN
+http_response_size_bytes{handler="prometheus",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="prometheus"} 0
+http_response_size_bytes_count{handler="prometheus"} 0
+http_response_size_bytes{handler="status",quantile="0.5"} NaN
+http_response_size_bytes{handler="status",quantile="0.9"} NaN
+http_response_size_bytes{handler="status",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="status"} 0
+http_response_size_bytes_count{handler="status"} 0
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 0.15
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+process_max_fds 1.048576e+06
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+process_open_fds 8
+# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes 1.0215424e+07
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds 1.5488687543e+09
+# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE process_virtual_memory_bytes gauge
+process_virtual_memory_bytes 1.8505728e+07

--- a/internal/mock/0.6.2/api/v1/alerts/groups
+++ b/internal/mock/0.6.2/api/v1/alerts/groups
@@ -17,7 +17,7 @@
                                 "instance": "server5",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:58:13.560493443Z",
+                            "startsAt": "2019-01-30T17:20:41.311083Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -59,11 +59,11 @@
                                 "instance": "web1",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:58:13.560493443Z",
+                            "startsAt": "2019-01-30T17:20:41.311083Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "2f4adc48-2326-41b4-b0b3-300df61669f2"
+                                    "2994d7ec-9651-4f68-8bc1-74a2186c1d33"
                                 ],
                                 "state": "suppressed"
                             }
@@ -80,7 +80,7 @@
                                 "instance": "web2",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:58:13.560493443Z",
+                            "startsAt": "2019-01-30T17:20:41.311083Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -116,11 +116,52 @@
                             "generatorURL": "localhost/prometheus",
                             "labels": {
                                 "alertname": "Host_Down",
+                                "cluster": "dev",
+                                "instance": "server8",
+                                "job": "node_ping"
+                            },
+                            "startsAt": "2019-01-30T17:20:41.311083Z",
+                            "status": {
+                                "inhibitedBy": null,
+                                "silencedBy": [
+                                    "796f3800-09fa-48b7-817e-0599325797c0"
+                                ],
+                                "state": "suppressed"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary",
+                                "url": "http://localhost/example.html"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "prod",
+                                "instance": "server1",
+                                "job": "node_ping"
+                            },
+                            "startsAt": "2019-01-30T17:20:41.311083Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
                                 "cluster": "prod",
                                 "instance": "server2",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:58:13.560493443Z",
+                            "startsAt": "2019-01-30T17:20:41.311083Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -139,7 +180,7 @@
                                 "instance": "server3",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:58:13.560493443Z",
+                            "startsAt": "2019-01-30T17:20:41.311083Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -158,7 +199,7 @@
                                 "instance": "server4",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:58:13.560493443Z",
+                            "startsAt": "2019-01-30T17:20:41.311083Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -177,7 +218,7 @@
                                 "instance": "server5",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:58:13.560493443Z",
+                            "startsAt": "2019-01-30T17:20:41.311083Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -196,11 +237,11 @@
                                 "instance": "server6",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:58:13.560493443Z",
+                            "startsAt": "2019-01-30T17:20:41.311083Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "cb8dea83-bb92-4887-a0ad-ed3549a315b4"
+                                    "796f3800-09fa-48b7-817e-0599325797c0"
                                 ],
                                 "state": "suppressed"
                             }
@@ -217,55 +258,14 @@
                                 "instance": "server7",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:58:13.560493443Z",
+                            "startsAt": "2019-01-30T17:20:41.311083Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "cb8dea83-bb92-4887-a0ad-ed3549a315b4",
-                                    "45edb919-4bc1-46ea-b7fd-97c1692cab75"
+                                    "796f3800-09fa-48b7-817e-0599325797c0",
+                                    "8c5c3e8d-1cda-4966-b6f1-74fee83ec908"
                                 ],
                                 "state": "suppressed"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "dev",
-                                "instance": "server8",
-                                "job": "node_ping"
-                            },
-                            "startsAt": "2017-06-21T19:58:13.560493443Z",
-                            "status": {
-                                "inhibitedBy": null,
-                                "silencedBy": [
-                                    "cb8dea83-bb92-4887-a0ad-ed3549a315b4"
-                                ],
-                                "state": "suppressed"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary",
-                                "url": "http://localhost/example.html"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "prod",
-                                "instance": "server1",
-                                "job": "node_ping"
-                            },
-                            "startsAt": "2017-06-21T19:58:13.560493443Z",
-                            "status": {
-                                "inhibitedBy": [],
-                                "silencedBy": [],
-                                "state": "active"
                             }
                         }
                     ],
@@ -302,7 +302,7 @@
                                 "instance": "server2",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:58:13.560493443Z",
+                            "startsAt": "2019-01-30T17:20:41.311083Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -343,7 +343,7 @@
                                 "instance": "server5",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:58:13.560493443Z",
+                            "startsAt": "2019-01-30T17:20:41.311083Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -388,11 +388,11 @@
                                 "instance": "web1",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:58:13.560493443Z",
+                            "startsAt": "2019-01-30T17:20:41.311083Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "2f4adc48-2326-41b4-b0b3-300df61669f2"
+                                    "2994d7ec-9651-4f68-8bc1-74a2186c1d33"
                                 ],
                                 "state": "suppressed"
                             }
@@ -409,7 +409,7 @@
                                 "instance": "web2",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:58:13.560493443Z",
+                            "startsAt": "2019-01-30T17:20:41.311083Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -419,9 +419,9 @@
                     ],
                     "routeOpts": {
                         "groupBy": [
+                            "service",
                             "alertname",
-                            "cluster",
-                            "service"
+                            "cluster"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,
@@ -452,11 +452,11 @@
                                 "instance": "server6",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:58:13.560493443Z",
+                            "startsAt": "2019-01-30T17:20:41.311083Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "cb8dea83-bb92-4887-a0ad-ed3549a315b4"
+                                    "796f3800-09fa-48b7-817e-0599325797c0"
                                 ],
                                 "state": "suppressed"
                             }
@@ -473,12 +473,12 @@
                                 "instance": "server7",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:58:13.560493443Z",
+                            "startsAt": "2019-01-30T17:20:41.311083Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "cb8dea83-bb92-4887-a0ad-ed3549a315b4",
-                                    "45edb919-4bc1-46ea-b7fd-97c1692cab75"
+                                    "796f3800-09fa-48b7-817e-0599325797c0",
+                                    "8c5c3e8d-1cda-4966-b6f1-74fee83ec908"
                                 ],
                                 "state": "suppressed"
                             }
@@ -495,11 +495,11 @@
                                 "instance": "server8",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:58:13.560493443Z",
+                            "startsAt": "2019-01-30T17:20:41.311083Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "cb8dea83-bb92-4887-a0ad-ed3549a315b4"
+                                    "796f3800-09fa-48b7-817e-0599325797c0"
                                 ],
                                 "state": "suppressed"
                             }
@@ -541,7 +541,7 @@
                                 "instance": "server1",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:58:13.560493443Z",
+                            "startsAt": "2019-01-30T17:20:41.311083Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -560,7 +560,7 @@
                                 "instance": "server2",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:58:13.560493443Z",
+                            "startsAt": "2019-01-30T17:20:41.311083Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -603,7 +603,7 @@
                                 "instance": "server3",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:58:13.560493443Z",
+                            "startsAt": "2019-01-30T17:20:41.311083Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -622,7 +622,7 @@
                                 "instance": "server4",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:58:13.560493443Z",
+                            "startsAt": "2019-01-30T17:20:41.311083Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -641,7 +641,7 @@
                                 "instance": "server5",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:58:13.560493443Z",
+                            "startsAt": "2019-01-30T17:20:41.311083Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -685,7 +685,7 @@
                                 "instance": "server2",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:58:13.560493443Z",
+                            "startsAt": "2019-01-30T17:20:41.311083Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -695,9 +695,9 @@
                     ],
                     "routeOpts": {
                         "groupBy": [
-                            "alertname",
                             "cluster",
-                            "service"
+                            "service",
+                            "alertname"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,

--- a/internal/mock/0.6.2/api/v1/silences
+++ b/internal/mock/0.6.2/api/v1/silences
@@ -4,7 +4,7 @@
             "comment": "Silenced instance",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "2f4adc48-2326-41b4-b0b3-300df61669f2",
+            "id": "2994d7ec-9651-4f68-8bc1-74a2186c1d33",
             "matchers": [
                 {
                     "isRegex": false,
@@ -12,14 +12,14 @@
                     "value": "web1"
                 }
             ],
-            "startsAt": "2017-06-21T19:58:13.551032775Z",
-            "updatedAt": "2017-06-21T19:58:13.551032775Z"
+            "startsAt": "2019-01-30T17:20:41.2985576Z",
+            "updatedAt": "2019-01-30T17:20:41.2985576Z"
         },
         {
             "comment": "Silenced Host_Down alerts in the dev cluster",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "cb8dea83-bb92-4887-a0ad-ed3549a315b4",
+            "id": "796f3800-09fa-48b7-817e-0599325797c0",
             "matchers": [
                 {
                     "isRegex": false,
@@ -32,14 +32,14 @@
                     "value": "dev"
                 }
             ],
-            "startsAt": "2017-06-21T19:58:13.554249508Z",
-            "updatedAt": "2017-06-21T19:58:13.554249508Z"
+            "startsAt": "2019-01-30T17:20:41.3026119Z",
+            "updatedAt": "2019-01-30T17:20:41.3026119Z"
         },
         {
             "comment": "Silenced server7",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "45edb919-4bc1-46ea-b7fd-97c1692cab75",
+            "id": "8c5c3e8d-1cda-4966-b6f1-74fee83ec908",
             "matchers": [
                 {
                     "isRegex": false,
@@ -47,8 +47,8 @@
                     "value": "server7"
                 }
             ],
-            "startsAt": "2017-06-21T19:58:13.55840755Z",
-            "updatedAt": "2017-06-21T19:58:13.55840755Z"
+            "startsAt": "2019-01-30T17:20:41.3065872Z",
+            "updatedAt": "2019-01-30T17:20:41.3065872Z"
         }
     ],
     "status": "success"

--- a/internal/mock/0.6.2/api/v1/status
+++ b/internal/mock/0.6.2/api/v1/status
@@ -83,16 +83,16 @@
         },
         "meshStatus": {
             "name": "02:42:ac:11:00:02",
-            "nickName": "ba205ac89c68",
+            "nickName": "aee08f2dac62",
             "peers": [
                 {
                     "name": "02:42:ac:11:00:02",
-                    "nickName": "ba205ac89c68",
-                    "uid": 2202700455073252735
+                    "nickName": "aee08f2dac62",
+                    "uid": 6444584588054702875
                 }
             ]
         },
-        "uptime": "2017-06-21T19:57:58.529748916Z",
+        "uptime": "2019-01-30T17:20:26.1429883Z",
         "versionInfo": {
             "branch": "master",
             "buildDate": "20170509-08:56:14",

--- a/internal/mock/0.6.2/metrics
+++ b/internal/mock/0.6.2/metrics
@@ -1,0 +1,409 @@
+# HELP alertmanager_alerts_invalid_total The total number of received alerts that were invalid.
+# TYPE alertmanager_alerts_invalid_total counter
+alertmanager_alerts_invalid_total 0
+# HELP alertmanager_alerts_received_total The total number of received alerts.
+# TYPE alertmanager_alerts_received_total counter
+alertmanager_alerts_received_total{status="firing"} 60
+# HELP alertmanager_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which alertmanager was built.
+# TYPE alertmanager_build_info gauge
+alertmanager_build_info{branch="master",goversion="go1.8.1",revision="b011c0a32ce887c1a10f7d34d52fd8cce485c1cf",version="0.6.2"} 1
+# HELP alertmanager_config_hash Hash of the currently loaded alertmanager configuration.
+# TYPE alertmanager_config_hash gauge
+alertmanager_config_hash 6.2645753076152e+13
+# HELP alertmanager_config_last_reload_success_timestamp_seconds Timestamp of the last successful configuration reload.
+# TYPE alertmanager_config_last_reload_success_timestamp_seconds gauge
+alertmanager_config_last_reload_success_timestamp_seconds 1.548868826e+09
+# HELP alertmanager_config_last_reload_successful Whether the last configuration reload attempt was successful.
+# TYPE alertmanager_config_last_reload_successful gauge
+alertmanager_config_last_reload_successful 1
+# HELP alertmanager_nflog_gc_duration_seconds Duration of the last notification log garbage collection cycle.
+# TYPE alertmanager_nflog_gc_duration_seconds summary
+alertmanager_nflog_gc_duration_seconds{quantile="0.5"} NaN
+alertmanager_nflog_gc_duration_seconds{quantile="0.9"} NaN
+alertmanager_nflog_gc_duration_seconds{quantile="0.99"} NaN
+alertmanager_nflog_gc_duration_seconds_sum 0
+alertmanager_nflog_gc_duration_seconds_count 0
+# HELP alertmanager_nflog_queries_total Number of notification log queries were received.
+# TYPE alertmanager_nflog_queries_total counter
+alertmanager_nflog_queries_total 0
+# HELP alertmanager_nflog_query_duration_seconds Duration of notification log query evaluation.
+# TYPE alertmanager_nflog_query_duration_seconds histogram
+alertmanager_nflog_query_duration_seconds_bucket{le="0.005"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.01"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.025"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.05"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.1"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.25"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="1"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="2.5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="10"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="+Inf"} 0
+alertmanager_nflog_query_duration_seconds_sum 0
+alertmanager_nflog_query_duration_seconds_count 0
+# HELP alertmanager_nflog_query_errors_total Number notification log received queries that failed.
+# TYPE alertmanager_nflog_query_errors_total counter
+alertmanager_nflog_query_errors_total 0
+# HELP alertmanager_nflog_snapshot_duration_seconds Duration of the last notification log snapshot.
+# TYPE alertmanager_nflog_snapshot_duration_seconds summary
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.5"} NaN
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.9"} NaN
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.99"} NaN
+alertmanager_nflog_snapshot_duration_seconds_sum 0
+alertmanager_nflog_snapshot_duration_seconds_count 0
+# HELP alertmanager_silences_gc_duration_seconds Duration of the last silence garbage collection cycle.
+# TYPE alertmanager_silences_gc_duration_seconds summary
+alertmanager_silences_gc_duration_seconds{quantile="0.5"} NaN
+alertmanager_silences_gc_duration_seconds{quantile="0.9"} NaN
+alertmanager_silences_gc_duration_seconds{quantile="0.99"} NaN
+alertmanager_silences_gc_duration_seconds_sum 0
+alertmanager_silences_gc_duration_seconds_count 0
+# HELP alertmanager_silences_queries_total How many silence queries were received.
+# TYPE alertmanager_silences_queries_total counter
+alertmanager_silences_queries_total 48
+# HELP alertmanager_silences_query_duration_seconds Duration of silence query evaluation.
+# TYPE alertmanager_silences_query_duration_seconds histogram
+alertmanager_silences_query_duration_seconds_bucket{le="0.005"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.01"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.025"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.05"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.1"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.25"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.5"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="1"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="2.5"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="5"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="10"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="+Inf"} 48
+alertmanager_silences_query_duration_seconds_sum 0.0020937
+alertmanager_silences_query_duration_seconds_count 48
+# HELP alertmanager_silences_query_errors_total How many silence received queries did not succeed.
+# TYPE alertmanager_silences_query_errors_total counter
+alertmanager_silences_query_errors_total 0
+# HELP alertmanager_silences_snapshot_duration_seconds Duration of the last silence snapshot.
+# TYPE alertmanager_silences_snapshot_duration_seconds summary
+alertmanager_silences_snapshot_duration_seconds{quantile="0.5"} NaN
+alertmanager_silences_snapshot_duration_seconds{quantile="0.9"} NaN
+alertmanager_silences_snapshot_duration_seconds{quantile="0.99"} NaN
+alertmanager_silences_snapshot_duration_seconds_sum 0
+alertmanager_silences_snapshot_duration_seconds_count 0
+# HELP go_gc_duration_seconds A summary of the GC invocation durations.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0"} 0.0027676
+go_gc_duration_seconds{quantile="0.25"} 0.0027676
+go_gc_duration_seconds{quantile="0.5"} 0.0027676
+go_gc_duration_seconds{quantile="0.75"} 0.0027676
+go_gc_duration_seconds{quantile="1"} 0.0027676
+go_gc_duration_seconds_sum 0.0027676
+go_gc_duration_seconds_count 1
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 71
+# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+# TYPE go_memstats_alloc_bytes gauge
+go_memstats_alloc_bytes 4.796888e+06
+# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
+# TYPE go_memstats_alloc_bytes_total counter
+go_memstats_alloc_bytes_total 5.25504e+06
+# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
+# TYPE go_memstats_buck_hash_sys_bytes gauge
+go_memstats_buck_hash_sys_bytes 1.444582e+06
+# HELP go_memstats_frees_total Total number of frees.
+# TYPE go_memstats_frees_total counter
+go_memstats_frees_total 5700
+# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+# TYPE go_memstats_gc_sys_bytes gauge
+go_memstats_gc_sys_bytes 356352
+# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
+# TYPE go_memstats_heap_alloc_bytes gauge
+go_memstats_heap_alloc_bytes 4.796888e+06
+# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
+# TYPE go_memstats_heap_idle_bytes gauge
+go_memstats_heap_idle_bytes 245760
+# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
+# TYPE go_memstats_heap_inuse_bytes gauge
+go_memstats_heap_inuse_bytes 5.357568e+06
+# HELP go_memstats_heap_objects Number of allocated objects.
+# TYPE go_memstats_heap_objects gauge
+go_memstats_heap_objects 18091
+# HELP go_memstats_heap_released_bytes_total Total number of heap bytes released to OS.
+# TYPE go_memstats_heap_released_bytes_total counter
+go_memstats_heap_released_bytes_total 0
+# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
+# TYPE go_memstats_heap_sys_bytes gauge
+go_memstats_heap_sys_bytes 5.603328e+06
+# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
+# TYPE go_memstats_last_gc_time_seconds gauge
+go_memstats_last_gc_time_seconds 1.5488688261542249e+09
+# HELP go_memstats_lookups_total Total number of pointer lookups.
+# TYPE go_memstats_lookups_total counter
+go_memstats_lookups_total 39
+# HELP go_memstats_mallocs_total Total number of mallocs.
+# TYPE go_memstats_mallocs_total counter
+go_memstats_mallocs_total 23791
+# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
+# TYPE go_memstats_mcache_inuse_bytes gauge
+go_memstats_mcache_inuse_bytes 2400
+# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
+# TYPE go_memstats_mcache_sys_bytes gauge
+go_memstats_mcache_sys_bytes 16384
+# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
+# TYPE go_memstats_mspan_inuse_bytes gauge
+go_memstats_mspan_inuse_bytes 60344
+# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
+# TYPE go_memstats_mspan_sys_bytes gauge
+go_memstats_mspan_sys_bytes 65536
+# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
+# TYPE go_memstats_next_gc_bytes gauge
+go_memstats_next_gc_bytes 7.798048e+06
+# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
+# TYPE go_memstats_other_sys_bytes gauge
+go_memstats_other_sys_bytes 744978
+# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
+# TYPE go_memstats_stack_inuse_bytes gauge
+go_memstats_stack_inuse_bytes 688128
+# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
+# TYPE go_memstats_stack_sys_bytes gauge
+go_memstats_stack_sys_bytes 688128
+# HELP go_memstats_sys_bytes Number of bytes obtained by system. Sum of all system allocations.
+# TYPE go_memstats_sys_bytes gauge
+go_memstats_sys_bytes 8.919288e+06
+# HELP http_request_duration_microseconds The HTTP request latencies in microseconds.
+# TYPE http_request_duration_microseconds summary
+http_request_duration_microseconds{handler="add_alerts",quantile="0.5"} 561.9
+http_request_duration_microseconds{handler="add_alerts",quantile="0.9"} 1195.5
+http_request_duration_microseconds{handler="add_alerts",quantile="0.99"} 1195.5
+http_request_duration_microseconds_sum{handler="add_alerts"} 4276.8
+http_request_duration_microseconds_count{handler="add_alerts"} 5
+http_request_duration_microseconds{handler="add_silence",quantile="0.5"} 133.3
+http_request_duration_microseconds{handler="add_silence",quantile="0.9"} 179.5
+http_request_duration_microseconds{handler="add_silence",quantile="0.99"} 179.5
+http_request_duration_microseconds_sum{handler="add_silence"} 688.0999999999999
+http_request_duration_microseconds_count{handler="add_silence"} 3
+http_request_duration_microseconds{handler="alert_groups",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="alert_groups",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="alert_groups",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="alert_groups"} 0
+http_request_duration_microseconds_count{handler="alert_groups"} 0
+http_request_duration_microseconds{handler="app_files",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="app_files",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="app_files",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="app_files"} 0
+http_request_duration_microseconds_count{handler="app_files"} 0
+http_request_duration_microseconds{handler="del_silence",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="del_silence",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="del_silence",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="del_silence"} 0
+http_request_duration_microseconds_count{handler="del_silence"} 0
+http_request_duration_microseconds{handler="get_silence",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="get_silence",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="get_silence",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="get_silence"} 0
+http_request_duration_microseconds_count{handler="get_silence"} 0
+http_request_duration_microseconds{handler="index",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="index",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="index",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="index"} 0
+http_request_duration_microseconds_count{handler="index"} 0
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="legacy_add_alerts"} 0
+http_request_duration_microseconds_count{handler="legacy_add_alerts"} 0
+http_request_duration_microseconds{handler="lib_files",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="lib_files",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="lib_files",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="lib_files"} 0
+http_request_duration_microseconds_count{handler="lib_files"} 0
+http_request_duration_microseconds{handler="list_alerts",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="list_alerts",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="list_alerts",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="list_alerts"} 0
+http_request_duration_microseconds_count{handler="list_alerts"} 0
+http_request_duration_microseconds{handler="list_silences",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="list_silences",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="list_silences",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="list_silences"} 0
+http_request_duration_microseconds_count{handler="list_silences"} 0
+http_request_duration_microseconds{handler="options",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="options",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="options",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="options"} 0
+http_request_duration_microseconds_count{handler="options"} 0
+http_request_duration_microseconds{handler="prometheus",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="prometheus",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="prometheus",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="prometheus"} 0
+http_request_duration_microseconds_count{handler="prometheus"} 0
+http_request_duration_microseconds{handler="status",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="status",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="status",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="status"} 0
+http_request_duration_microseconds_count{handler="status"} 0
+# HELP http_request_size_bytes The HTTP request sizes in bytes.
+# TYPE http_request_size_bytes summary
+http_request_size_bytes{handler="add_alerts",quantile="0.5"} 2719
+http_request_size_bytes{handler="add_alerts",quantile="0.9"} 2719
+http_request_size_bytes{handler="add_alerts",quantile="0.99"} 2719
+http_request_size_bytes_sum{handler="add_alerts"} 13595
+http_request_size_bytes_count{handler="add_alerts"} 5
+http_request_size_bytes{handler="add_silence",quantile="0.5"} 358
+http_request_size_bytes{handler="add_silence",quantile="0.9"} 360
+http_request_size_bytes{handler="add_silence",quantile="0.99"} 360
+http_request_size_bytes_sum{handler="add_silence"} 1164
+http_request_size_bytes_count{handler="add_silence"} 3
+http_request_size_bytes{handler="alert_groups",quantile="0.5"} NaN
+http_request_size_bytes{handler="alert_groups",quantile="0.9"} NaN
+http_request_size_bytes{handler="alert_groups",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="alert_groups"} 0
+http_request_size_bytes_count{handler="alert_groups"} 0
+http_request_size_bytes{handler="app_files",quantile="0.5"} NaN
+http_request_size_bytes{handler="app_files",quantile="0.9"} NaN
+http_request_size_bytes{handler="app_files",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="app_files"} 0
+http_request_size_bytes_count{handler="app_files"} 0
+http_request_size_bytes{handler="del_silence",quantile="0.5"} NaN
+http_request_size_bytes{handler="del_silence",quantile="0.9"} NaN
+http_request_size_bytes{handler="del_silence",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="del_silence"} 0
+http_request_size_bytes_count{handler="del_silence"} 0
+http_request_size_bytes{handler="get_silence",quantile="0.5"} NaN
+http_request_size_bytes{handler="get_silence",quantile="0.9"} NaN
+http_request_size_bytes{handler="get_silence",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="get_silence"} 0
+http_request_size_bytes_count{handler="get_silence"} 0
+http_request_size_bytes{handler="index",quantile="0.5"} NaN
+http_request_size_bytes{handler="index",quantile="0.9"} NaN
+http_request_size_bytes{handler="index",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="index"} 0
+http_request_size_bytes_count{handler="index"} 0
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="legacy_add_alerts"} 0
+http_request_size_bytes_count{handler="legacy_add_alerts"} 0
+http_request_size_bytes{handler="lib_files",quantile="0.5"} NaN
+http_request_size_bytes{handler="lib_files",quantile="0.9"} NaN
+http_request_size_bytes{handler="lib_files",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="lib_files"} 0
+http_request_size_bytes_count{handler="lib_files"} 0
+http_request_size_bytes{handler="list_alerts",quantile="0.5"} NaN
+http_request_size_bytes{handler="list_alerts",quantile="0.9"} NaN
+http_request_size_bytes{handler="list_alerts",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="list_alerts"} 0
+http_request_size_bytes_count{handler="list_alerts"} 0
+http_request_size_bytes{handler="list_silences",quantile="0.5"} NaN
+http_request_size_bytes{handler="list_silences",quantile="0.9"} NaN
+http_request_size_bytes{handler="list_silences",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="list_silences"} 0
+http_request_size_bytes_count{handler="list_silences"} 0
+http_request_size_bytes{handler="options",quantile="0.5"} NaN
+http_request_size_bytes{handler="options",quantile="0.9"} NaN
+http_request_size_bytes{handler="options",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="options"} 0
+http_request_size_bytes_count{handler="options"} 0
+http_request_size_bytes{handler="prometheus",quantile="0.5"} NaN
+http_request_size_bytes{handler="prometheus",quantile="0.9"} NaN
+http_request_size_bytes{handler="prometheus",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="prometheus"} 0
+http_request_size_bytes_count{handler="prometheus"} 0
+http_request_size_bytes{handler="status",quantile="0.5"} NaN
+http_request_size_bytes{handler="status",quantile="0.9"} NaN
+http_request_size_bytes{handler="status",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="status"} 0
+http_request_size_bytes_count{handler="status"} 0
+# HELP http_requests_total Total number of HTTP requests made.
+# TYPE http_requests_total counter
+http_requests_total{code="200",handler="add_alerts",method="post"} 5
+http_requests_total{code="200",handler="add_silence",method="post"} 3
+# HELP http_response_size_bytes The HTTP response sizes in bytes.
+# TYPE http_response_size_bytes summary
+http_response_size_bytes{handler="add_alerts",quantile="0.5"} 20
+http_response_size_bytes{handler="add_alerts",quantile="0.9"} 20
+http_response_size_bytes{handler="add_alerts",quantile="0.99"} 20
+http_response_size_bytes_sum{handler="add_alerts"} 100
+http_response_size_bytes_count{handler="add_alerts"} 5
+http_response_size_bytes{handler="add_silence",quantile="0.5"} 80
+http_response_size_bytes{handler="add_silence",quantile="0.9"} 80
+http_response_size_bytes{handler="add_silence",quantile="0.99"} 80
+http_response_size_bytes_sum{handler="add_silence"} 240
+http_response_size_bytes_count{handler="add_silence"} 3
+http_response_size_bytes{handler="alert_groups",quantile="0.5"} NaN
+http_response_size_bytes{handler="alert_groups",quantile="0.9"} NaN
+http_response_size_bytes{handler="alert_groups",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="alert_groups"} 0
+http_response_size_bytes_count{handler="alert_groups"} 0
+http_response_size_bytes{handler="app_files",quantile="0.5"} NaN
+http_response_size_bytes{handler="app_files",quantile="0.9"} NaN
+http_response_size_bytes{handler="app_files",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="app_files"} 0
+http_response_size_bytes_count{handler="app_files"} 0
+http_response_size_bytes{handler="del_silence",quantile="0.5"} NaN
+http_response_size_bytes{handler="del_silence",quantile="0.9"} NaN
+http_response_size_bytes{handler="del_silence",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="del_silence"} 0
+http_response_size_bytes_count{handler="del_silence"} 0
+http_response_size_bytes{handler="get_silence",quantile="0.5"} NaN
+http_response_size_bytes{handler="get_silence",quantile="0.9"} NaN
+http_response_size_bytes{handler="get_silence",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="get_silence"} 0
+http_response_size_bytes_count{handler="get_silence"} 0
+http_response_size_bytes{handler="index",quantile="0.5"} NaN
+http_response_size_bytes{handler="index",quantile="0.9"} NaN
+http_response_size_bytes{handler="index",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="index"} 0
+http_response_size_bytes_count{handler="index"} 0
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="legacy_add_alerts"} 0
+http_response_size_bytes_count{handler="legacy_add_alerts"} 0
+http_response_size_bytes{handler="lib_files",quantile="0.5"} NaN
+http_response_size_bytes{handler="lib_files",quantile="0.9"} NaN
+http_response_size_bytes{handler="lib_files",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="lib_files"} 0
+http_response_size_bytes_count{handler="lib_files"} 0
+http_response_size_bytes{handler="list_alerts",quantile="0.5"} NaN
+http_response_size_bytes{handler="list_alerts",quantile="0.9"} NaN
+http_response_size_bytes{handler="list_alerts",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="list_alerts"} 0
+http_response_size_bytes_count{handler="list_alerts"} 0
+http_response_size_bytes{handler="list_silences",quantile="0.5"} NaN
+http_response_size_bytes{handler="list_silences",quantile="0.9"} NaN
+http_response_size_bytes{handler="list_silences",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="list_silences"} 0
+http_response_size_bytes_count{handler="list_silences"} 0
+http_response_size_bytes{handler="options",quantile="0.5"} NaN
+http_response_size_bytes{handler="options",quantile="0.9"} NaN
+http_response_size_bytes{handler="options",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="options"} 0
+http_response_size_bytes_count{handler="options"} 0
+http_response_size_bytes{handler="prometheus",quantile="0.5"} NaN
+http_response_size_bytes{handler="prometheus",quantile="0.9"} NaN
+http_response_size_bytes{handler="prometheus",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="prometheus"} 0
+http_response_size_bytes_count{handler="prometheus"} 0
+http_response_size_bytes{handler="status",quantile="0.5"} NaN
+http_response_size_bytes{handler="status",quantile="0.9"} NaN
+http_response_size_bytes{handler="status",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="status"} 0
+http_response_size_bytes_count{handler="status"} 0
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 0.12
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+process_max_fds 1.048576e+06
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+process_open_fds 8
+# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes 1.0264576e+07
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds 1.54886882531e+09
+# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE process_virtual_memory_bytes gauge
+process_virtual_memory_bytes 1.8505728e+07

--- a/internal/mock/0.7.0/api/v1/alerts/groups
+++ b/internal/mock/0.7.0/api/v1/alerts/groups
@@ -17,7 +17,7 @@
                                 "instance": "server5",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:59:21.607980084Z",
+                            "startsAt": "2019-01-30T17:21:55.2745601Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -59,11 +59,11 @@
                                 "instance": "web1",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:59:21.607980084Z",
+                            "startsAt": "2019-01-30T17:21:55.2745601Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "bd452296-bf0b-4c0b-9eb3-5ef84fc3ad2c"
+                                    "d4d5250d-fa14-4be9-b8aa-5fe9c87d7595"
                                 ],
                                 "state": "suppressed"
                             }
@@ -80,7 +80,7 @@
                                 "instance": "web2",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:59:21.607980084Z",
+                            "startsAt": "2019-01-30T17:21:55.2745601Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -110,127 +110,6 @@
                     "alerts": [
                         {
                             "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "staging",
-                                "instance": "server3",
-                                "job": "node_ping"
-                            },
-                            "startsAt": "2017-06-21T19:59:21.607980084Z",
-                            "status": {
-                                "inhibitedBy": [],
-                                "silencedBy": [],
-                                "state": "active"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "staging",
-                                "instance": "server4",
-                                "job": "node_ping"
-                            },
-                            "startsAt": "2017-06-21T19:59:21.607980084Z",
-                            "status": {
-                                "inhibitedBy": [],
-                                "silencedBy": [],
-                                "state": "active"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "staging",
-                                "instance": "server5",
-                                "job": "node_ping"
-                            },
-                            "startsAt": "2017-06-21T19:59:21.607980084Z",
-                            "status": {
-                                "inhibitedBy": [],
-                                "silencedBy": [],
-                                "state": "active"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "dev",
-                                "instance": "server6",
-                                "job": "node_ping"
-                            },
-                            "startsAt": "2017-06-21T19:59:21.607980084Z",
-                            "status": {
-                                "inhibitedBy": null,
-                                "silencedBy": [
-                                    "6faee101-39cf-4700-acd0-f140290db8f8"
-                                ],
-                                "state": "suppressed"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "dev",
-                                "instance": "server7",
-                                "job": "node_ping"
-                            },
-                            "startsAt": "2017-06-21T19:59:21.607980084Z",
-                            "status": {
-                                "inhibitedBy": null,
-                                "silencedBy": [
-                                    "6faee101-39cf-4700-acd0-f140290db8f8",
-                                    "552bccef-c6ff-40ce-a519-eeb14e3f0c80"
-                                ],
-                                "state": "suppressed"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "dev",
-                                "instance": "server8",
-                                "job": "node_ping"
-                            },
-                            "startsAt": "2017-06-21T19:59:21.607980084Z",
-                            "status": {
-                                "inhibitedBy": null,
-                                "silencedBy": [
-                                    "6faee101-39cf-4700-acd0-f140290db8f8"
-                                ],
-                                "state": "suppressed"
-                            }
-                        },
-                        {
-                            "annotations": {
                                 "summary": "Example summary",
                                 "url": "http://localhost/example.html"
                             },
@@ -242,7 +121,7 @@
                                 "instance": "server1",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:59:21.607980084Z",
+                            "startsAt": "2019-01-30T17:21:55.2745601Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -261,11 +140,132 @@
                                 "instance": "server2",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:59:21.607980084Z",
+                            "startsAt": "2019-01-30T17:21:55.2745601Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
                                 "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "staging",
+                                "instance": "server3",
+                                "job": "node_ping"
+                            },
+                            "startsAt": "2019-01-30T17:21:55.2745601Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "staging",
+                                "instance": "server4",
+                                "job": "node_ping"
+                            },
+                            "startsAt": "2019-01-30T17:21:55.2745601Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "staging",
+                                "instance": "server5",
+                                "job": "node_ping"
+                            },
+                            "startsAt": "2019-01-30T17:21:55.2745601Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "dev",
+                                "instance": "server6",
+                                "job": "node_ping"
+                            },
+                            "startsAt": "2019-01-30T17:21:55.2745601Z",
+                            "status": {
+                                "inhibitedBy": null,
+                                "silencedBy": [
+                                    "a84fd104-72d3-4e36-8fcd-8602fdcb15fd"
+                                ],
+                                "state": "suppressed"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "dev",
+                                "instance": "server7",
+                                "job": "node_ping"
+                            },
+                            "startsAt": "2019-01-30T17:21:55.2745601Z",
+                            "status": {
+                                "inhibitedBy": null,
+                                "silencedBy": [
+                                    "a84fd104-72d3-4e36-8fcd-8602fdcb15fd",
+                                    "372d8926-0aeb-42c4-b525-6cdaf415397e"
+                                ],
+                                "state": "suppressed"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "dev",
+                                "instance": "server8",
+                                "job": "node_ping"
+                            },
+                            "startsAt": "2019-01-30T17:21:55.2745601Z",
+                            "status": {
+                                "inhibitedBy": null,
+                                "silencedBy": [
+                                    "a84fd104-72d3-4e36-8fcd-8602fdcb15fd"
+                                ],
+                                "state": "suppressed"
                             }
                         }
                     ],
@@ -302,7 +302,7 @@
                                 "instance": "server2",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:59:21.607980084Z",
+                            "startsAt": "2019-01-30T17:21:55.2745601Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -343,7 +343,7 @@
                                 "instance": "server5",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:59:21.607980084Z",
+                            "startsAt": "2019-01-30T17:21:55.2745601Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -353,9 +353,9 @@
                     ],
                     "routeOpts": {
                         "groupBy": [
+                            "service",
                             "alertname",
-                            "cluster",
-                            "service"
+                            "cluster"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,
@@ -388,11 +388,11 @@
                                 "instance": "web1",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:59:21.607980084Z",
+                            "startsAt": "2019-01-30T17:21:55.2745601Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "bd452296-bf0b-4c0b-9eb3-5ef84fc3ad2c"
+                                    "d4d5250d-fa14-4be9-b8aa-5fe9c87d7595"
                                 ],
                                 "state": "suppressed"
                             }
@@ -409,7 +409,7 @@
                                 "instance": "web2",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:59:21.607980084Z",
+                            "startsAt": "2019-01-30T17:21:55.2745601Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -452,11 +452,11 @@
                                 "instance": "server6",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:59:21.607980084Z",
+                            "startsAt": "2019-01-30T17:21:55.2745601Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "6faee101-39cf-4700-acd0-f140290db8f8"
+                                    "a84fd104-72d3-4e36-8fcd-8602fdcb15fd"
                                 ],
                                 "state": "suppressed"
                             }
@@ -473,12 +473,12 @@
                                 "instance": "server7",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:59:21.607980084Z",
+                            "startsAt": "2019-01-30T17:21:55.2745601Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "6faee101-39cf-4700-acd0-f140290db8f8",
-                                    "552bccef-c6ff-40ce-a519-eeb14e3f0c80"
+                                    "a84fd104-72d3-4e36-8fcd-8602fdcb15fd",
+                                    "372d8926-0aeb-42c4-b525-6cdaf415397e"
                                 ],
                                 "state": "suppressed"
                             }
@@ -495,11 +495,11 @@
                                 "instance": "server8",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:59:21.607980084Z",
+                            "startsAt": "2019-01-30T17:21:55.2745601Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "6faee101-39cf-4700-acd0-f140290db8f8"
+                                    "a84fd104-72d3-4e36-8fcd-8602fdcb15fd"
                                 ],
                                 "state": "suppressed"
                             }
@@ -541,7 +541,7 @@
                                 "instance": "server1",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:59:21.607980084Z",
+                            "startsAt": "2019-01-30T17:21:55.2745601Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -560,7 +560,7 @@
                                 "instance": "server2",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:59:21.607980084Z",
+                            "startsAt": "2019-01-30T17:21:55.2745601Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -603,7 +603,7 @@
                                 "instance": "server3",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:59:21.607980084Z",
+                            "startsAt": "2019-01-30T17:21:55.2745601Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -622,7 +622,7 @@
                                 "instance": "server4",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:59:21.607980084Z",
+                            "startsAt": "2019-01-30T17:21:55.2745601Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -641,7 +641,7 @@
                                 "instance": "server5",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T19:59:21.607980084Z",
+                            "startsAt": "2019-01-30T17:21:55.2745601Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -685,7 +685,7 @@
                                 "instance": "server2",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T19:59:21.607980084Z",
+                            "startsAt": "2019-01-30T17:21:55.2745601Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],

--- a/internal/mock/0.7.0/api/v1/silences
+++ b/internal/mock/0.7.0/api/v1/silences
@@ -1,10 +1,28 @@
 {
     "data": [
         {
+            "comment": "Silenced server7",
+            "createdBy": "john@example.com",
+            "endsAt": "2063-01-01T00:00:00Z",
+            "id": "372d8926-0aeb-42c4-b525-6cdaf415397e",
+            "matchers": [
+                {
+                    "isRegex": false,
+                    "name": "instance",
+                    "value": "server7"
+                }
+            ],
+            "startsAt": "2019-01-30T17:21:55.2645789Z",
+            "status": {
+                "state": "active"
+            },
+            "updatedAt": "2019-01-30T17:21:55.2645971Z"
+        },
+        {
             "comment": "Silenced instance",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "bd452296-bf0b-4c0b-9eb3-5ef84fc3ad2c",
+            "id": "d4d5250d-fa14-4be9-b8aa-5fe9c87d7595",
             "matchers": [
                 {
                     "isRegex": false,
@@ -12,17 +30,17 @@
                     "value": "web1"
                 }
             ],
-            "startsAt": "2017-06-21T19:59:21.60217124Z",
+            "startsAt": "2019-01-30T17:21:55.2525591Z",
             "status": {
                 "state": "active"
             },
-            "updatedAt": "2017-06-21T19:59:21.602176988Z"
+            "updatedAt": "2019-01-30T17:21:55.2525795Z"
         },
         {
             "comment": "Silenced Host_Down alerts in the dev cluster",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "6faee101-39cf-4700-acd0-f140290db8f8",
+            "id": "a84fd104-72d3-4e36-8fcd-8602fdcb15fd",
             "matchers": [
                 {
                     "isRegex": false,
@@ -35,29 +53,11 @@
                     "value": "dev"
                 }
             ],
-            "startsAt": "2017-06-21T19:59:21.604369673Z",
+            "startsAt": "2019-01-30T17:21:55.2594885Z",
             "status": {
                 "state": "active"
             },
-            "updatedAt": "2017-06-21T19:59:21.604373791Z"
-        },
-        {
-            "comment": "Silenced server7",
-            "createdBy": "john@example.com",
-            "endsAt": "2063-01-01T00:00:00Z",
-            "id": "552bccef-c6ff-40ce-a519-eeb14e3f0c80",
-            "matchers": [
-                {
-                    "isRegex": false,
-                    "name": "instance",
-                    "value": "server7"
-                }
-            ],
-            "startsAt": "2017-06-21T19:59:21.606078285Z",
-            "status": {
-                "state": "active"
-            },
-            "updatedAt": "2017-06-21T19:59:21.606082023Z"
+            "updatedAt": "2019-01-30T17:21:55.2594988Z"
         }
     ],
     "status": "success"

--- a/internal/mock/0.7.0/api/v1/status
+++ b/internal/mock/0.7.0/api/v1/status
@@ -83,16 +83,16 @@
         "configYAML": "global:\n  resolve_timeout: 5m\n  smtp_from: \"\"\n  smtp_smarthost: \"\"\n  smtp_auth_username: \"\"\n  smtp_auth_password: null\n  smtp_auth_secret: null\n  smtp_auth_identity: \"\"\n  smtp_require_tls: true\n  slack_api_url: null\n  pagerduty_url: https://events.pagerduty.com/generic/2010-04-15/create_event.json\n  hipchat_url: https://api.hipchat.com/\n  hipchat_auth_token: null\n  opsgenie_api_host: https://api.opsgenie.com/\n  victorops_api_url: https://alert.victorops.com/integrations/generic/20131114/alert/\nroute:\n  receiver: default\n  group_by:\n  - alertname\n  routes:\n  - receiver: by-cluster-service\n    group_by:\n    - alertname\n    - cluster\n    - service\n    match_re:\n      alertname:\n        regexp: {}\n    continue: true\n  - receiver: by-name\n    group_by:\n    - alertname\n    match_re:\n      alertname:\n        regexp: {}\n    continue: true\n  group_wait: 15s\n  group_interval: 35s\n  repeat_interval: 999h\ninhibit_rules:\n- source_match:\n    severity: critical\n  source_match_re: {}\n  target_match:\n    severity: warning\n  target_match_re: {}\n  equal:\n  - alertname\n  - cluster\n  - service\nreceivers:\n- name: default\n- name: by-cluster-service\n- name: by-name\ntemplates: []\n",
         "meshStatus": {
             "name": "02:42:ac:11:00:02",
-            "nickName": "defde95ab66b",
+            "nickName": "568fa1ec40a9",
             "peers": [
                 {
                     "name": "02:42:ac:11:00:02",
-                    "nickName": "defde95ab66b",
-                    "uid": 1904987398913295829
+                    "nickName": "568fa1ec40a9",
+                    "uid": 16131262871989611230
                 }
             ]
         },
-        "uptime": "2017-06-21T19:59:06.58791745Z",
+        "uptime": "2019-01-30T17:21:40.0500005Z",
         "versionInfo": {
             "branch": "master",
             "buildDate": "20170608-12:34:07",

--- a/internal/mock/0.7.0/metrics
+++ b/internal/mock/0.7.0/metrics
@@ -1,0 +1,409 @@
+# HELP alertmanager_alerts_invalid_total The total number of received alerts that were invalid.
+# TYPE alertmanager_alerts_invalid_total counter
+alertmanager_alerts_invalid_total 0
+# HELP alertmanager_alerts_received_total The total number of received alerts.
+# TYPE alertmanager_alerts_received_total counter
+alertmanager_alerts_received_total{status="firing"} 60
+# HELP alertmanager_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which alertmanager was built.
+# TYPE alertmanager_build_info gauge
+alertmanager_build_info{branch="master",goversion="go1.8.3",revision="fe105f4ed7617f11a9f941e84662aa9d2cfb9bf6",version="0.7.0"} 1
+# HELP alertmanager_config_hash Hash of the currently loaded alertmanager configuration.
+# TYPE alertmanager_config_hash gauge
+alertmanager_config_hash 6.2645753076152e+13
+# HELP alertmanager_config_last_reload_success_timestamp_seconds Timestamp of the last successful configuration reload.
+# TYPE alertmanager_config_last_reload_success_timestamp_seconds gauge
+alertmanager_config_last_reload_success_timestamp_seconds 1.5488689e+09
+# HELP alertmanager_config_last_reload_successful Whether the last configuration reload attempt was successful.
+# TYPE alertmanager_config_last_reload_successful gauge
+alertmanager_config_last_reload_successful 1
+# HELP alertmanager_nflog_gc_duration_seconds Duration of the last notification log garbage collection cycle.
+# TYPE alertmanager_nflog_gc_duration_seconds summary
+alertmanager_nflog_gc_duration_seconds{quantile="0.5"} NaN
+alertmanager_nflog_gc_duration_seconds{quantile="0.9"} NaN
+alertmanager_nflog_gc_duration_seconds{quantile="0.99"} NaN
+alertmanager_nflog_gc_duration_seconds_sum 0
+alertmanager_nflog_gc_duration_seconds_count 0
+# HELP alertmanager_nflog_queries_total Number of notification log queries were received.
+# TYPE alertmanager_nflog_queries_total counter
+alertmanager_nflog_queries_total 0
+# HELP alertmanager_nflog_query_duration_seconds Duration of notification log query evaluation.
+# TYPE alertmanager_nflog_query_duration_seconds histogram
+alertmanager_nflog_query_duration_seconds_bucket{le="0.005"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.01"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.025"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.05"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.1"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.25"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="1"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="2.5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="10"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="+Inf"} 0
+alertmanager_nflog_query_duration_seconds_sum 0
+alertmanager_nflog_query_duration_seconds_count 0
+# HELP alertmanager_nflog_query_errors_total Number notification log received queries that failed.
+# TYPE alertmanager_nflog_query_errors_total counter
+alertmanager_nflog_query_errors_total 0
+# HELP alertmanager_nflog_snapshot_duration_seconds Duration of the last notification log snapshot.
+# TYPE alertmanager_nflog_snapshot_duration_seconds summary
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.5"} NaN
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.9"} NaN
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.99"} NaN
+alertmanager_nflog_snapshot_duration_seconds_sum 0
+alertmanager_nflog_snapshot_duration_seconds_count 0
+# HELP alertmanager_silences_gc_duration_seconds Duration of the last silence garbage collection cycle.
+# TYPE alertmanager_silences_gc_duration_seconds summary
+alertmanager_silences_gc_duration_seconds{quantile="0.5"} NaN
+alertmanager_silences_gc_duration_seconds{quantile="0.9"} NaN
+alertmanager_silences_gc_duration_seconds{quantile="0.99"} NaN
+alertmanager_silences_gc_duration_seconds_sum 0
+alertmanager_silences_gc_duration_seconds_count 0
+# HELP alertmanager_silences_queries_total How many silence queries were received.
+# TYPE alertmanager_silences_queries_total counter
+alertmanager_silences_queries_total 48
+# HELP alertmanager_silences_query_duration_seconds Duration of silence query evaluation.
+# TYPE alertmanager_silences_query_duration_seconds histogram
+alertmanager_silences_query_duration_seconds_bucket{le="0.005"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.01"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.025"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.05"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.1"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.25"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.5"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="1"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="2.5"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="5"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="10"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="+Inf"} 48
+alertmanager_silences_query_duration_seconds_sum 0.0019314000000000002
+alertmanager_silences_query_duration_seconds_count 48
+# HELP alertmanager_silences_query_errors_total How many silence received queries did not succeed.
+# TYPE alertmanager_silences_query_errors_total counter
+alertmanager_silences_query_errors_total 0
+# HELP alertmanager_silences_snapshot_duration_seconds Duration of the last silence snapshot.
+# TYPE alertmanager_silences_snapshot_duration_seconds summary
+alertmanager_silences_snapshot_duration_seconds{quantile="0.5"} NaN
+alertmanager_silences_snapshot_duration_seconds{quantile="0.9"} NaN
+alertmanager_silences_snapshot_duration_seconds{quantile="0.99"} NaN
+alertmanager_silences_snapshot_duration_seconds_sum 0
+alertmanager_silences_snapshot_duration_seconds_count 0
+# HELP go_gc_duration_seconds A summary of the GC invocation durations.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0"} 0.0032637
+go_gc_duration_seconds{quantile="0.25"} 0.0032637
+go_gc_duration_seconds{quantile="0.5"} 0.0032637
+go_gc_duration_seconds{quantile="0.75"} 0.0032637
+go_gc_duration_seconds{quantile="1"} 0.0032637
+go_gc_duration_seconds_sum 0.0032637
+go_gc_duration_seconds_count 1
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 47
+# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+# TYPE go_memstats_alloc_bytes gauge
+go_memstats_alloc_bytes 4.683544e+06
+# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
+# TYPE go_memstats_alloc_bytes_total counter
+go_memstats_alloc_bytes_total 5.315256e+06
+# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
+# TYPE go_memstats_buck_hash_sys_bytes gauge
+go_memstats_buck_hash_sys_bytes 1.443273e+06
+# HELP go_memstats_frees_total Total number of frees.
+# TYPE go_memstats_frees_total counter
+go_memstats_frees_total 5134
+# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+# TYPE go_memstats_gc_sys_bytes gauge
+go_memstats_gc_sys_bytes 352256
+# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
+# TYPE go_memstats_heap_alloc_bytes gauge
+go_memstats_heap_alloc_bytes 4.683544e+06
+# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
+# TYPE go_memstats_heap_idle_bytes gauge
+go_memstats_heap_idle_bytes 352256
+# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
+# TYPE go_memstats_heap_inuse_bytes gauge
+go_memstats_heap_inuse_bytes 5.251072e+06
+# HELP go_memstats_heap_objects Number of allocated objects.
+# TYPE go_memstats_heap_objects gauge
+go_memstats_heap_objects 17620
+# HELP go_memstats_heap_released_bytes_total Total number of heap bytes released to OS.
+# TYPE go_memstats_heap_released_bytes_total counter
+go_memstats_heap_released_bytes_total 0
+# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
+# TYPE go_memstats_heap_sys_bytes gauge
+go_memstats_heap_sys_bytes 5.603328e+06
+# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
+# TYPE go_memstats_last_gc_time_seconds gauge
+go_memstats_last_gc_time_seconds 1.5488689000719728e+09
+# HELP go_memstats_lookups_total Total number of pointer lookups.
+# TYPE go_memstats_lookups_total counter
+go_memstats_lookups_total 32
+# HELP go_memstats_mallocs_total Total number of mallocs.
+# TYPE go_memstats_mallocs_total counter
+go_memstats_mallocs_total 22754
+# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
+# TYPE go_memstats_mcache_inuse_bytes gauge
+go_memstats_mcache_inuse_bytes 2400
+# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
+# TYPE go_memstats_mcache_sys_bytes gauge
+go_memstats_mcache_sys_bytes 16384
+# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
+# TYPE go_memstats_mspan_inuse_bytes gauge
+go_memstats_mspan_inuse_bytes 59280
+# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
+# TYPE go_memstats_mspan_sys_bytes gauge
+go_memstats_mspan_sys_bytes 65536
+# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
+# TYPE go_memstats_next_gc_bytes gauge
+go_memstats_next_gc_bytes 6.410048e+06
+# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
+# TYPE go_memstats_other_sys_bytes gauge
+go_memstats_other_sys_bytes 750383
+# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
+# TYPE go_memstats_stack_inuse_bytes gauge
+go_memstats_stack_inuse_bytes 688128
+# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
+# TYPE go_memstats_stack_sys_bytes gauge
+go_memstats_stack_sys_bytes 688128
+# HELP go_memstats_sys_bytes Number of bytes obtained by system. Sum of all system allocations.
+# TYPE go_memstats_sys_bytes gauge
+go_memstats_sys_bytes 8.919288e+06
+# HELP http_request_duration_microseconds The HTTP request latencies in microseconds.
+# TYPE http_request_duration_microseconds summary
+http_request_duration_microseconds{handler="add_alerts",quantile="0.5"} 621.6
+http_request_duration_microseconds{handler="add_alerts",quantile="0.9"} 838.7
+http_request_duration_microseconds{handler="add_alerts",quantile="0.99"} 838.7
+http_request_duration_microseconds_sum{handler="add_alerts"} 4150.2
+http_request_duration_microseconds_count{handler="add_alerts"} 5
+http_request_duration_microseconds{handler="add_silence",quantile="0.5"} 205.4
+http_request_duration_microseconds{handler="add_silence",quantile="0.9"} 613.9
+http_request_duration_microseconds{handler="add_silence",quantile="0.99"} 613.9
+http_request_duration_microseconds_sum{handler="add_silence"} 1828.1
+http_request_duration_microseconds_count{handler="add_silence"} 3
+http_request_duration_microseconds{handler="alert_groups",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="alert_groups",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="alert_groups",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="alert_groups"} 0
+http_request_duration_microseconds_count{handler="alert_groups"} 0
+http_request_duration_microseconds{handler="app",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="app",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="app",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="app"} 0
+http_request_duration_microseconds_count{handler="app"} 0
+http_request_duration_microseconds{handler="del_silence",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="del_silence",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="del_silence",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="del_silence"} 0
+http_request_duration_microseconds_count{handler="del_silence"} 0
+http_request_duration_microseconds{handler="get_silence",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="get_silence",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="get_silence",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="get_silence"} 0
+http_request_duration_microseconds_count{handler="get_silence"} 0
+http_request_duration_microseconds{handler="index",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="index",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="index",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="index"} 0
+http_request_duration_microseconds_count{handler="index"} 0
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="legacy_add_alerts"} 0
+http_request_duration_microseconds_count{handler="legacy_add_alerts"} 0
+http_request_duration_microseconds{handler="lib_files",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="lib_files",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="lib_files",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="lib_files"} 0
+http_request_duration_microseconds_count{handler="lib_files"} 0
+http_request_duration_microseconds{handler="list_alerts",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="list_alerts",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="list_alerts",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="list_alerts"} 0
+http_request_duration_microseconds_count{handler="list_alerts"} 0
+http_request_duration_microseconds{handler="list_silences",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="list_silences",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="list_silences",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="list_silences"} 0
+http_request_duration_microseconds_count{handler="list_silences"} 0
+http_request_duration_microseconds{handler="options",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="options",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="options",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="options"} 0
+http_request_duration_microseconds_count{handler="options"} 0
+http_request_duration_microseconds{handler="prometheus",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="prometheus",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="prometheus",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="prometheus"} 0
+http_request_duration_microseconds_count{handler="prometheus"} 0
+http_request_duration_microseconds{handler="status",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="status",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="status",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="status"} 0
+http_request_duration_microseconds_count{handler="status"} 0
+# HELP http_request_size_bytes The HTTP request sizes in bytes.
+# TYPE http_request_size_bytes summary
+http_request_size_bytes{handler="add_alerts",quantile="0.5"} 2719
+http_request_size_bytes{handler="add_alerts",quantile="0.9"} 2719
+http_request_size_bytes{handler="add_alerts",quantile="0.99"} 2719
+http_request_size_bytes_sum{handler="add_alerts"} 13595
+http_request_size_bytes_count{handler="add_alerts"} 5
+http_request_size_bytes{handler="add_silence",quantile="0.5"} 358
+http_request_size_bytes{handler="add_silence",quantile="0.9"} 360
+http_request_size_bytes{handler="add_silence",quantile="0.99"} 360
+http_request_size_bytes_sum{handler="add_silence"} 1164
+http_request_size_bytes_count{handler="add_silence"} 3
+http_request_size_bytes{handler="alert_groups",quantile="0.5"} NaN
+http_request_size_bytes{handler="alert_groups",quantile="0.9"} NaN
+http_request_size_bytes{handler="alert_groups",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="alert_groups"} 0
+http_request_size_bytes_count{handler="alert_groups"} 0
+http_request_size_bytes{handler="app",quantile="0.5"} NaN
+http_request_size_bytes{handler="app",quantile="0.9"} NaN
+http_request_size_bytes{handler="app",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="app"} 0
+http_request_size_bytes_count{handler="app"} 0
+http_request_size_bytes{handler="del_silence",quantile="0.5"} NaN
+http_request_size_bytes{handler="del_silence",quantile="0.9"} NaN
+http_request_size_bytes{handler="del_silence",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="del_silence"} 0
+http_request_size_bytes_count{handler="del_silence"} 0
+http_request_size_bytes{handler="get_silence",quantile="0.5"} NaN
+http_request_size_bytes{handler="get_silence",quantile="0.9"} NaN
+http_request_size_bytes{handler="get_silence",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="get_silence"} 0
+http_request_size_bytes_count{handler="get_silence"} 0
+http_request_size_bytes{handler="index",quantile="0.5"} NaN
+http_request_size_bytes{handler="index",quantile="0.9"} NaN
+http_request_size_bytes{handler="index",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="index"} 0
+http_request_size_bytes_count{handler="index"} 0
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="legacy_add_alerts"} 0
+http_request_size_bytes_count{handler="legacy_add_alerts"} 0
+http_request_size_bytes{handler="lib_files",quantile="0.5"} NaN
+http_request_size_bytes{handler="lib_files",quantile="0.9"} NaN
+http_request_size_bytes{handler="lib_files",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="lib_files"} 0
+http_request_size_bytes_count{handler="lib_files"} 0
+http_request_size_bytes{handler="list_alerts",quantile="0.5"} NaN
+http_request_size_bytes{handler="list_alerts",quantile="0.9"} NaN
+http_request_size_bytes{handler="list_alerts",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="list_alerts"} 0
+http_request_size_bytes_count{handler="list_alerts"} 0
+http_request_size_bytes{handler="list_silences",quantile="0.5"} NaN
+http_request_size_bytes{handler="list_silences",quantile="0.9"} NaN
+http_request_size_bytes{handler="list_silences",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="list_silences"} 0
+http_request_size_bytes_count{handler="list_silences"} 0
+http_request_size_bytes{handler="options",quantile="0.5"} NaN
+http_request_size_bytes{handler="options",quantile="0.9"} NaN
+http_request_size_bytes{handler="options",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="options"} 0
+http_request_size_bytes_count{handler="options"} 0
+http_request_size_bytes{handler="prometheus",quantile="0.5"} NaN
+http_request_size_bytes{handler="prometheus",quantile="0.9"} NaN
+http_request_size_bytes{handler="prometheus",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="prometheus"} 0
+http_request_size_bytes_count{handler="prometheus"} 0
+http_request_size_bytes{handler="status",quantile="0.5"} NaN
+http_request_size_bytes{handler="status",quantile="0.9"} NaN
+http_request_size_bytes{handler="status",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="status"} 0
+http_request_size_bytes_count{handler="status"} 0
+# HELP http_requests_total Total number of HTTP requests made.
+# TYPE http_requests_total counter
+http_requests_total{code="200",handler="add_alerts",method="post"} 5
+http_requests_total{code="200",handler="add_silence",method="post"} 3
+# HELP http_response_size_bytes The HTTP response sizes in bytes.
+# TYPE http_response_size_bytes summary
+http_response_size_bytes{handler="add_alerts",quantile="0.5"} 20
+http_response_size_bytes{handler="add_alerts",quantile="0.9"} 20
+http_response_size_bytes{handler="add_alerts",quantile="0.99"} 20
+http_response_size_bytes_sum{handler="add_alerts"} 100
+http_response_size_bytes_count{handler="add_alerts"} 5
+http_response_size_bytes{handler="add_silence",quantile="0.5"} 80
+http_response_size_bytes{handler="add_silence",quantile="0.9"} 80
+http_response_size_bytes{handler="add_silence",quantile="0.99"} 80
+http_response_size_bytes_sum{handler="add_silence"} 240
+http_response_size_bytes_count{handler="add_silence"} 3
+http_response_size_bytes{handler="alert_groups",quantile="0.5"} NaN
+http_response_size_bytes{handler="alert_groups",quantile="0.9"} NaN
+http_response_size_bytes{handler="alert_groups",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="alert_groups"} 0
+http_response_size_bytes_count{handler="alert_groups"} 0
+http_response_size_bytes{handler="app",quantile="0.5"} NaN
+http_response_size_bytes{handler="app",quantile="0.9"} NaN
+http_response_size_bytes{handler="app",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="app"} 0
+http_response_size_bytes_count{handler="app"} 0
+http_response_size_bytes{handler="del_silence",quantile="0.5"} NaN
+http_response_size_bytes{handler="del_silence",quantile="0.9"} NaN
+http_response_size_bytes{handler="del_silence",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="del_silence"} 0
+http_response_size_bytes_count{handler="del_silence"} 0
+http_response_size_bytes{handler="get_silence",quantile="0.5"} NaN
+http_response_size_bytes{handler="get_silence",quantile="0.9"} NaN
+http_response_size_bytes{handler="get_silence",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="get_silence"} 0
+http_response_size_bytes_count{handler="get_silence"} 0
+http_response_size_bytes{handler="index",quantile="0.5"} NaN
+http_response_size_bytes{handler="index",quantile="0.9"} NaN
+http_response_size_bytes{handler="index",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="index"} 0
+http_response_size_bytes_count{handler="index"} 0
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="legacy_add_alerts"} 0
+http_response_size_bytes_count{handler="legacy_add_alerts"} 0
+http_response_size_bytes{handler="lib_files",quantile="0.5"} NaN
+http_response_size_bytes{handler="lib_files",quantile="0.9"} NaN
+http_response_size_bytes{handler="lib_files",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="lib_files"} 0
+http_response_size_bytes_count{handler="lib_files"} 0
+http_response_size_bytes{handler="list_alerts",quantile="0.5"} NaN
+http_response_size_bytes{handler="list_alerts",quantile="0.9"} NaN
+http_response_size_bytes{handler="list_alerts",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="list_alerts"} 0
+http_response_size_bytes_count{handler="list_alerts"} 0
+http_response_size_bytes{handler="list_silences",quantile="0.5"} NaN
+http_response_size_bytes{handler="list_silences",quantile="0.9"} NaN
+http_response_size_bytes{handler="list_silences",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="list_silences"} 0
+http_response_size_bytes_count{handler="list_silences"} 0
+http_response_size_bytes{handler="options",quantile="0.5"} NaN
+http_response_size_bytes{handler="options",quantile="0.9"} NaN
+http_response_size_bytes{handler="options",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="options"} 0
+http_response_size_bytes_count{handler="options"} 0
+http_response_size_bytes{handler="prometheus",quantile="0.5"} NaN
+http_response_size_bytes{handler="prometheus",quantile="0.9"} NaN
+http_response_size_bytes{handler="prometheus",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="prometheus"} 0
+http_response_size_bytes_count{handler="prometheus"} 0
+http_response_size_bytes{handler="status",quantile="0.5"} NaN
+http_response_size_bytes{handler="status",quantile="0.9"} NaN
+http_response_size_bytes{handler="status",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="status"} 0
+http_response_size_bytes_count{handler="status"} 0
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 0.15
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+process_max_fds 1.048576e+06
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+process_open_fds 8
+# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes 1.0612736e+07
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds 1.54886889922e+09
+# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE process_virtual_memory_bytes gauge
+process_virtual_memory_bytes 1.9070976e+07

--- a/internal/mock/0.7.1/api/v1/alerts/groups
+++ b/internal/mock/0.7.1/api/v1/alerts/groups
@@ -17,7 +17,7 @@
                                 "instance": "server5",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T20:00:30.104861185Z",
+                            "startsAt": "2019-01-30T17:23:06.1129933Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -59,11 +59,11 @@
                                 "instance": "web1",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T20:00:30.104861185Z",
+                            "startsAt": "2019-01-30T17:23:06.1129933Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "0804764c-6163-4c64-b0a9-08feebe2db4b"
+                                    "c4c0d6f5-0ce0-40a4-976d-384908f5f8f9"
                                 ],
                                 "state": "suppressed"
                             }
@@ -80,7 +80,7 @@
                                 "instance": "web2",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T20:00:30.104861185Z",
+                            "startsAt": "2019-01-30T17:23:06.1129933Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -110,83 +110,6 @@
                     "alerts": [
                         {
                             "annotations": {
-                                "summary": "Example summary",
-                                "url": "http://localhost/example.html"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "prod",
-                                "instance": "server1",
-                                "job": "node_ping"
-                            },
-                            "startsAt": "2017-06-21T20:00:30.104861185Z",
-                            "status": {
-                                "inhibitedBy": [],
-                                "silencedBy": [],
-                                "state": "active"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "prod",
-                                "instance": "server2",
-                                "job": "node_ping"
-                            },
-                            "startsAt": "2017-06-21T20:00:30.104861185Z",
-                            "status": {
-                                "inhibitedBy": [],
-                                "silencedBy": [],
-                                "state": "active"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "staging",
-                                "instance": "server3",
-                                "job": "node_ping"
-                            },
-                            "startsAt": "2017-06-21T20:00:30.104861185Z",
-                            "status": {
-                                "inhibitedBy": [],
-                                "silencedBy": [],
-                                "state": "active"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "staging",
-                                "instance": "server4",
-                                "job": "node_ping"
-                            },
-                            "startsAt": "2017-06-21T20:00:30.104861185Z",
-                            "status": {
-                                "inhibitedBy": [],
-                                "silencedBy": [],
-                                "state": "active"
-                            }
-                        },
-                        {
-                            "annotations": {
                                 "summary": "Example summary"
                             },
                             "endsAt": "0001-01-01T00:00:00Z",
@@ -197,7 +120,7 @@
                                 "instance": "server5",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T20:00:30.104861185Z",
+                            "startsAt": "2019-01-30T17:23:06.1129933Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -216,11 +139,11 @@
                                 "instance": "server6",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T20:00:30.104861185Z",
+                            "startsAt": "2019-01-30T17:23:06.1129933Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "168f139d-77e4-41d6-afb5-8fe2cfd0cc9d"
+                                    "c88ce975-330a-43f6-80f1-765bc0c13204"
                                 ],
                                 "state": "suppressed"
                             }
@@ -237,12 +160,12 @@
                                 "instance": "server7",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T20:00:30.104861185Z",
+                            "startsAt": "2019-01-30T17:23:06.1129933Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "168f139d-77e4-41d6-afb5-8fe2cfd0cc9d",
-                                    "378eaa69-097d-41c4-a8c2-fe6568c3abfc"
+                                    "c88ce975-330a-43f6-80f1-765bc0c13204",
+                                    "149e3545-eb75-4dbc-8d11-8fcad98866d7"
                                 ],
                                 "state": "suppressed"
                             }
@@ -259,13 +182,90 @@
                                 "instance": "server8",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T20:00:30.104861185Z",
+                            "startsAt": "2019-01-30T17:23:06.1129933Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "168f139d-77e4-41d6-afb5-8fe2cfd0cc9d"
+                                    "c88ce975-330a-43f6-80f1-765bc0c13204"
                                 ],
                                 "state": "suppressed"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary",
+                                "url": "http://localhost/example.html"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "prod",
+                                "instance": "server1",
+                                "job": "node_ping"
+                            },
+                            "startsAt": "2019-01-30T17:23:06.1129933Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "prod",
+                                "instance": "server2",
+                                "job": "node_ping"
+                            },
+                            "startsAt": "2019-01-30T17:23:06.1129933Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "staging",
+                                "instance": "server3",
+                                "job": "node_ping"
+                            },
+                            "startsAt": "2019-01-30T17:23:06.1129933Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "staging",
+                                "instance": "server4",
+                                "job": "node_ping"
+                            },
+                            "startsAt": "2019-01-30T17:23:06.1129933Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
                             }
                         }
                     ],
@@ -302,7 +302,7 @@
                                 "instance": "server2",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T20:00:30.104861185Z",
+                            "startsAt": "2019-01-30T17:23:06.1129933Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -343,7 +343,7 @@
                                 "instance": "server5",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T20:00:30.104861185Z",
+                            "startsAt": "2019-01-30T17:23:06.1129933Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -376,6 +376,25 @@
                     "alerts": [
                         {
                             "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "HTTP_Probe_Failed",
+                                "cluster": "dev",
+                                "instance": "web2",
+                                "job": "node_exporter"
+                            },
+                            "startsAt": "2019-01-30T17:23:06.1129933Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
                                 "help": "Example help annotation",
                                 "summary": "Example summary",
                                 "url": "http://localhost/example.html"
@@ -388,40 +407,21 @@
                                 "instance": "web1",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T20:00:30.104861185Z",
+                            "startsAt": "2019-01-30T17:23:06.1129933Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "0804764c-6163-4c64-b0a9-08feebe2db4b"
+                                    "c4c0d6f5-0ce0-40a4-976d-384908f5f8f9"
                                 ],
                                 "state": "suppressed"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "HTTP_Probe_Failed",
-                                "cluster": "dev",
-                                "instance": "web2",
-                                "job": "node_exporter"
-                            },
-                            "startsAt": "2017-06-21T20:00:30.104861185Z",
-                            "status": {
-                                "inhibitedBy": [],
-                                "silencedBy": [],
-                                "state": "active"
                             }
                         }
                     ],
                     "routeOpts": {
                         "groupBy": [
+                            "alertname",
                             "cluster",
-                            "service",
-                            "alertname"
+                            "service"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,
@@ -449,15 +449,36 @@
                             "labels": {
                                 "alertname": "Host_Down",
                                 "cluster": "dev",
-                                "instance": "server7",
+                                "instance": "server6",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T20:00:30.104861185Z",
+                            "startsAt": "2019-01-30T17:23:06.1129933Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "168f139d-77e4-41d6-afb5-8fe2cfd0cc9d",
-                                    "378eaa69-097d-41c4-a8c2-fe6568c3abfc"
+                                    "c88ce975-330a-43f6-80f1-765bc0c13204"
+                                ],
+                                "state": "suppressed"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "dev",
+                                "instance": "server7",
+                                "job": "node_ping"
+                            },
+                            "startsAt": "2019-01-30T17:23:06.1129933Z",
+                            "status": {
+                                "inhibitedBy": null,
+                                "silencedBy": [
+                                    "c88ce975-330a-43f6-80f1-765bc0c13204",
+                                    "149e3545-eb75-4dbc-8d11-8fcad98866d7"
                                 ],
                                 "state": "suppressed"
                             }
@@ -474,32 +495,11 @@
                                 "instance": "server8",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T20:00:30.104861185Z",
+                            "startsAt": "2019-01-30T17:23:06.1129933Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "168f139d-77e4-41d6-afb5-8fe2cfd0cc9d"
-                                ],
-                                "state": "suppressed"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "dev",
-                                "instance": "server6",
-                                "job": "node_ping"
-                            },
-                            "startsAt": "2017-06-21T20:00:30.104861185Z",
-                            "status": {
-                                "inhibitedBy": null,
-                                "silencedBy": [
-                                    "168f139d-77e4-41d6-afb5-8fe2cfd0cc9d"
+                                    "c88ce975-330a-43f6-80f1-765bc0c13204"
                                 ],
                                 "state": "suppressed"
                             }
@@ -541,7 +541,7 @@
                                 "instance": "server1",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T20:00:30.104861185Z",
+                            "startsAt": "2019-01-30T17:23:06.1129933Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -560,7 +560,7 @@
                                 "instance": "server2",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T20:00:30.104861185Z",
+                            "startsAt": "2019-01-30T17:23:06.1129933Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -570,9 +570,9 @@
                     ],
                     "routeOpts": {
                         "groupBy": [
-                            "service",
                             "alertname",
-                            "cluster"
+                            "cluster",
+                            "service"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,
@@ -600,10 +600,29 @@
                             "labels": {
                                 "alertname": "Host_Down",
                                 "cluster": "staging",
+                                "instance": "server5",
+                                "job": "node_ping"
+                            },
+                            "startsAt": "2019-01-30T17:23:06.1129933Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "staging",
                                 "instance": "server3",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T20:00:30.104861185Z",
+                            "startsAt": "2019-01-30T17:23:06.1129933Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -622,26 +641,7 @@
                                 "instance": "server4",
                                 "job": "node_ping"
                             },
-                            "startsAt": "2017-06-21T20:00:30.104861185Z",
-                            "status": {
-                                "inhibitedBy": [],
-                                "silencedBy": [],
-                                "state": "active"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "staging",
-                                "instance": "server5",
-                                "job": "node_ping"
-                            },
-                            "startsAt": "2017-06-21T20:00:30.104861185Z",
+                            "startsAt": "2019-01-30T17:23:06.1129933Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -685,7 +685,7 @@
                                 "instance": "server2",
                                 "job": "node_exporter"
                             },
-                            "startsAt": "2017-06-21T20:00:30.104861185Z",
+                            "startsAt": "2019-01-30T17:23:06.1129933Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -695,9 +695,9 @@
                     ],
                     "routeOpts": {
                         "groupBy": [
+                            "alertname",
                             "cluster",
-                            "service",
-                            "alertname"
+                            "service"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,

--- a/internal/mock/0.7.1/api/v1/silences
+++ b/internal/mock/0.7.1/api/v1/silences
@@ -4,7 +4,7 @@
             "comment": "Silenced server7",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "378eaa69-097d-41c4-a8c2-fe6568c3abfc",
+            "id": "149e3545-eb75-4dbc-8d11-8fcad98866d7",
             "matchers": [
                 {
                     "isRegex": false,
@@ -12,17 +12,17 @@
                     "value": "server7"
                 }
             ],
-            "startsAt": "2017-06-21T20:00:30.102974561Z",
+            "startsAt": "2019-01-30T17:23:06.1089717Z",
             "status": {
                 "state": "active"
             },
-            "updatedAt": "2017-06-21T20:00:30.102978028Z"
+            "updatedAt": "2019-01-30T17:23:06.1089877Z"
         },
         {
             "comment": "Silenced instance",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "0804764c-6163-4c64-b0a9-08feebe2db4b",
+            "id": "c4c0d6f5-0ce0-40a4-976d-384908f5f8f9",
             "matchers": [
                 {
                     "isRegex": false,
@@ -30,17 +30,17 @@
                     "value": "web1"
                 }
             ],
-            "startsAt": "2017-06-21T20:00:30.099033238Z",
+            "startsAt": "2019-01-30T17:23:06.1009435Z",
             "status": {
                 "state": "active"
             },
-            "updatedAt": "2017-06-21T20:00:30.099037947Z"
+            "updatedAt": "2019-01-30T17:23:06.1009539Z"
         },
         {
             "comment": "Silenced Host_Down alerts in the dev cluster",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "168f139d-77e4-41d6-afb5-8fe2cfd0cc9d",
+            "id": "c88ce975-330a-43f6-80f1-765bc0c13204",
             "matchers": [
                 {
                     "isRegex": false,
@@ -53,11 +53,11 @@
                     "value": "dev"
                 }
             ],
-            "startsAt": "2017-06-21T20:00:30.101324168Z",
+            "startsAt": "2019-01-30T17:23:06.1050629Z",
             "status": {
                 "state": "active"
             },
-            "updatedAt": "2017-06-21T20:00:30.101327768Z"
+            "updatedAt": "2019-01-30T17:23:06.1050772Z"
         }
     ],
     "status": "success"

--- a/internal/mock/0.7.1/api/v1/status
+++ b/internal/mock/0.7.1/api/v1/status
@@ -83,16 +83,16 @@
         "configYAML": "global:\n  resolve_timeout: 5m\n  smtp_from: \"\"\n  smtp_smarthost: \"\"\n  smtp_auth_username: \"\"\n  smtp_auth_password: null\n  smtp_auth_secret: null\n  smtp_auth_identity: \"\"\n  smtp_require_tls: true\n  slack_api_url: null\n  pagerduty_url: https://events.pagerduty.com/generic/2010-04-15/create_event.json\n  hipchat_url: https://api.hipchat.com/\n  hipchat_auth_token: null\n  opsgenie_api_host: https://api.opsgenie.com/\n  victorops_api_url: https://alert.victorops.com/integrations/generic/20131114/alert/\nroute:\n  receiver: default\n  group_by:\n  - alertname\n  routes:\n  - receiver: by-cluster-service\n    group_by:\n    - alertname\n    - cluster\n    - service\n    match_re:\n      alertname:\n        regexp: {}\n    continue: true\n  - receiver: by-name\n    group_by:\n    - alertname\n    match_re:\n      alertname:\n        regexp: {}\n    continue: true\n  group_wait: 15s\n  group_interval: 35s\n  repeat_interval: 999h\ninhibit_rules:\n- source_match:\n    severity: critical\n  source_match_re: {}\n  target_match:\n    severity: warning\n  target_match_re: {}\n  equal:\n  - alertname\n  - cluster\n  - service\nreceivers:\n- name: default\n- name: by-cluster-service\n- name: by-name\ntemplates: []\n",
         "meshStatus": {
             "name": "02:42:ac:11:00:02",
-            "nickName": "604ff4d14f78",
+            "nickName": "f63d7b534aec",
             "peers": [
                 {
                     "name": "02:42:ac:11:00:02",
-                    "nickName": "604ff4d14f78",
-                    "uid": 356874118448200805
+                    "nickName": "f63d7b534aec",
+                    "uid": 4063438291908688060
                 }
             ]
         },
-        "uptime": "2017-06-21T20:00:15.251363956Z",
+        "uptime": "2019-01-30T17:22:50.9317886Z",
         "versionInfo": {
             "branch": "master",
             "buildDate": "20170609-15:31:09",

--- a/internal/mock/0.7.1/metrics
+++ b/internal/mock/0.7.1/metrics
@@ -1,0 +1,409 @@
+# HELP alertmanager_alerts_invalid_total The total number of received alerts that were invalid.
+# TYPE alertmanager_alerts_invalid_total counter
+alertmanager_alerts_invalid_total 0
+# HELP alertmanager_alerts_received_total The total number of received alerts.
+# TYPE alertmanager_alerts_received_total counter
+alertmanager_alerts_received_total{status="firing"} 60
+# HELP alertmanager_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which alertmanager was built.
+# TYPE alertmanager_build_info gauge
+alertmanager_build_info{branch="master",goversion="go1.8.3",revision="ab4138299b94c78dc554ea96e2ab28d04b048059",version="0.7.1"} 1
+# HELP alertmanager_config_hash Hash of the currently loaded alertmanager configuration.
+# TYPE alertmanager_config_hash gauge
+alertmanager_config_hash 6.2645753076152e+13
+# HELP alertmanager_config_last_reload_success_timestamp_seconds Timestamp of the last successful configuration reload.
+# TYPE alertmanager_config_last_reload_success_timestamp_seconds gauge
+alertmanager_config_last_reload_success_timestamp_seconds 1.54886897e+09
+# HELP alertmanager_config_last_reload_successful Whether the last configuration reload attempt was successful.
+# TYPE alertmanager_config_last_reload_successful gauge
+alertmanager_config_last_reload_successful 1
+# HELP alertmanager_nflog_gc_duration_seconds Duration of the last notification log garbage collection cycle.
+# TYPE alertmanager_nflog_gc_duration_seconds summary
+alertmanager_nflog_gc_duration_seconds{quantile="0.5"} NaN
+alertmanager_nflog_gc_duration_seconds{quantile="0.9"} NaN
+alertmanager_nflog_gc_duration_seconds{quantile="0.99"} NaN
+alertmanager_nflog_gc_duration_seconds_sum 0
+alertmanager_nflog_gc_duration_seconds_count 0
+# HELP alertmanager_nflog_queries_total Number of notification log queries were received.
+# TYPE alertmanager_nflog_queries_total counter
+alertmanager_nflog_queries_total 0
+# HELP alertmanager_nflog_query_duration_seconds Duration of notification log query evaluation.
+# TYPE alertmanager_nflog_query_duration_seconds histogram
+alertmanager_nflog_query_duration_seconds_bucket{le="0.005"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.01"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.025"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.05"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.1"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.25"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="1"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="2.5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="10"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="+Inf"} 0
+alertmanager_nflog_query_duration_seconds_sum 0
+alertmanager_nflog_query_duration_seconds_count 0
+# HELP alertmanager_nflog_query_errors_total Number notification log received queries that failed.
+# TYPE alertmanager_nflog_query_errors_total counter
+alertmanager_nflog_query_errors_total 0
+# HELP alertmanager_nflog_snapshot_duration_seconds Duration of the last notification log snapshot.
+# TYPE alertmanager_nflog_snapshot_duration_seconds summary
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.5"} NaN
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.9"} NaN
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.99"} NaN
+alertmanager_nflog_snapshot_duration_seconds_sum 0
+alertmanager_nflog_snapshot_duration_seconds_count 0
+# HELP alertmanager_silences_gc_duration_seconds Duration of the last silence garbage collection cycle.
+# TYPE alertmanager_silences_gc_duration_seconds summary
+alertmanager_silences_gc_duration_seconds{quantile="0.5"} NaN
+alertmanager_silences_gc_duration_seconds{quantile="0.9"} NaN
+alertmanager_silences_gc_duration_seconds{quantile="0.99"} NaN
+alertmanager_silences_gc_duration_seconds_sum 0
+alertmanager_silences_gc_duration_seconds_count 0
+# HELP alertmanager_silences_queries_total How many silence queries were received.
+# TYPE alertmanager_silences_queries_total counter
+alertmanager_silences_queries_total 48
+# HELP alertmanager_silences_query_duration_seconds Duration of silence query evaluation.
+# TYPE alertmanager_silences_query_duration_seconds histogram
+alertmanager_silences_query_duration_seconds_bucket{le="0.005"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.01"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.025"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.05"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.1"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.25"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.5"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="1"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="2.5"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="5"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="10"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="+Inf"} 48
+alertmanager_silences_query_duration_seconds_sum 0.0018244999999999993
+alertmanager_silences_query_duration_seconds_count 48
+# HELP alertmanager_silences_query_errors_total How many silence received queries did not succeed.
+# TYPE alertmanager_silences_query_errors_total counter
+alertmanager_silences_query_errors_total 0
+# HELP alertmanager_silences_snapshot_duration_seconds Duration of the last silence snapshot.
+# TYPE alertmanager_silences_snapshot_duration_seconds summary
+alertmanager_silences_snapshot_duration_seconds{quantile="0.5"} NaN
+alertmanager_silences_snapshot_duration_seconds{quantile="0.9"} NaN
+alertmanager_silences_snapshot_duration_seconds{quantile="0.99"} NaN
+alertmanager_silences_snapshot_duration_seconds_sum 0
+alertmanager_silences_snapshot_duration_seconds_count 0
+# HELP go_gc_duration_seconds A summary of the GC invocation durations.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0"} 0.0005662
+go_gc_duration_seconds{quantile="0.25"} 0.0005662
+go_gc_duration_seconds{quantile="0.5"} 0.0005662
+go_gc_duration_seconds{quantile="0.75"} 0.0005662
+go_gc_duration_seconds{quantile="1"} 0.0005662
+go_gc_duration_seconds_sum 0.0005662
+go_gc_duration_seconds_count 1
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 36
+# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+# TYPE go_memstats_alloc_bytes gauge
+go_memstats_alloc_bytes 4.783424e+06
+# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
+# TYPE go_memstats_alloc_bytes_total counter
+go_memstats_alloc_bytes_total 5.415424e+06
+# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
+# TYPE go_memstats_buck_hash_sys_bytes gauge
+go_memstats_buck_hash_sys_bytes 1.443305e+06
+# HELP go_memstats_frees_total Total number of frees.
+# TYPE go_memstats_frees_total counter
+go_memstats_frees_total 5406
+# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+# TYPE go_memstats_gc_sys_bytes gauge
+go_memstats_gc_sys_bytes 358400
+# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
+# TYPE go_memstats_heap_alloc_bytes gauge
+go_memstats_heap_alloc_bytes 4.783424e+06
+# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
+# TYPE go_memstats_heap_idle_bytes gauge
+go_memstats_heap_idle_bytes 221184
+# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
+# TYPE go_memstats_heap_inuse_bytes gauge
+go_memstats_heap_inuse_bytes 5.349376e+06
+# HELP go_memstats_heap_objects Number of allocated objects.
+# TYPE go_memstats_heap_objects gauge
+go_memstats_heap_objects 18562
+# HELP go_memstats_heap_released_bytes_total Total number of heap bytes released to OS.
+# TYPE go_memstats_heap_released_bytes_total counter
+go_memstats_heap_released_bytes_total 0
+# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
+# TYPE go_memstats_heap_sys_bytes gauge
+go_memstats_heap_sys_bytes 5.57056e+06
+# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
+# TYPE go_memstats_last_gc_time_seconds gauge
+go_memstats_last_gc_time_seconds 1.54886897094507e+09
+# HELP go_memstats_lookups_total Total number of pointer lookups.
+# TYPE go_memstats_lookups_total counter
+go_memstats_lookups_total 40
+# HELP go_memstats_mallocs_total Total number of mallocs.
+# TYPE go_memstats_mallocs_total counter
+go_memstats_mallocs_total 23968
+# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
+# TYPE go_memstats_mcache_inuse_bytes gauge
+go_memstats_mcache_inuse_bytes 2400
+# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
+# TYPE go_memstats_mcache_sys_bytes gauge
+go_memstats_mcache_sys_bytes 16384
+# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
+# TYPE go_memstats_mspan_inuse_bytes gauge
+go_memstats_mspan_inuse_bytes 60648
+# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
+# TYPE go_memstats_mspan_sys_bytes gauge
+go_memstats_mspan_sys_bytes 65536
+# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
+# TYPE go_memstats_next_gc_bytes gauge
+go_memstats_next_gc_bytes 6.41632e+06
+# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
+# TYPE go_memstats_other_sys_bytes gauge
+go_memstats_other_sys_bytes 744207
+# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
+# TYPE go_memstats_stack_inuse_bytes gauge
+go_memstats_stack_inuse_bytes 720896
+# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
+# TYPE go_memstats_stack_sys_bytes gauge
+go_memstats_stack_sys_bytes 720896
+# HELP go_memstats_sys_bytes Number of bytes obtained by system. Sum of all system allocations.
+# TYPE go_memstats_sys_bytes gauge
+go_memstats_sys_bytes 8.919288e+06
+# HELP http_request_duration_microseconds The HTTP request latencies in microseconds.
+# TYPE http_request_duration_microseconds summary
+http_request_duration_microseconds{handler="add_alerts",quantile="0.5"} 419.1
+http_request_duration_microseconds{handler="add_alerts",quantile="0.9"} 803.9
+http_request_duration_microseconds{handler="add_alerts",quantile="0.99"} 803.9
+http_request_duration_microseconds_sum{handler="add_alerts"} 8147.7
+http_request_duration_microseconds_count{handler="add_alerts"} 5
+http_request_duration_microseconds{handler="add_silence",quantile="0.5"} 166.3
+http_request_duration_microseconds{handler="add_silence",quantile="0.9"} 199.1
+http_request_duration_microseconds{handler="add_silence",quantile="0.99"} 199.1
+http_request_duration_microseconds_sum{handler="add_silence"} 719.5000000000001
+http_request_duration_microseconds_count{handler="add_silence"} 3
+http_request_duration_microseconds{handler="alert_groups",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="alert_groups",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="alert_groups",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="alert_groups"} 0
+http_request_duration_microseconds_count{handler="alert_groups"} 0
+http_request_duration_microseconds{handler="app",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="app",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="app",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="app"} 0
+http_request_duration_microseconds_count{handler="app"} 0
+http_request_duration_microseconds{handler="del_silence",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="del_silence",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="del_silence",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="del_silence"} 0
+http_request_duration_microseconds_count{handler="del_silence"} 0
+http_request_duration_microseconds{handler="get_silence",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="get_silence",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="get_silence",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="get_silence"} 0
+http_request_duration_microseconds_count{handler="get_silence"} 0
+http_request_duration_microseconds{handler="index",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="index",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="index",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="index"} 0
+http_request_duration_microseconds_count{handler="index"} 0
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="legacy_add_alerts"} 0
+http_request_duration_microseconds_count{handler="legacy_add_alerts"} 0
+http_request_duration_microseconds{handler="lib_files",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="lib_files",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="lib_files",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="lib_files"} 0
+http_request_duration_microseconds_count{handler="lib_files"} 0
+http_request_duration_microseconds{handler="list_alerts",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="list_alerts",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="list_alerts",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="list_alerts"} 0
+http_request_duration_microseconds_count{handler="list_alerts"} 0
+http_request_duration_microseconds{handler="list_silences",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="list_silences",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="list_silences",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="list_silences"} 0
+http_request_duration_microseconds_count{handler="list_silences"} 0
+http_request_duration_microseconds{handler="options",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="options",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="options",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="options"} 0
+http_request_duration_microseconds_count{handler="options"} 0
+http_request_duration_microseconds{handler="prometheus",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="prometheus",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="prometheus",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="prometheus"} 0
+http_request_duration_microseconds_count{handler="prometheus"} 0
+http_request_duration_microseconds{handler="status",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="status",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="status",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="status"} 0
+http_request_duration_microseconds_count{handler="status"} 0
+# HELP http_request_size_bytes The HTTP request sizes in bytes.
+# TYPE http_request_size_bytes summary
+http_request_size_bytes{handler="add_alerts",quantile="0.5"} 2719
+http_request_size_bytes{handler="add_alerts",quantile="0.9"} 2719
+http_request_size_bytes{handler="add_alerts",quantile="0.99"} 2719
+http_request_size_bytes_sum{handler="add_alerts"} 13595
+http_request_size_bytes_count{handler="add_alerts"} 5
+http_request_size_bytes{handler="add_silence",quantile="0.5"} 358
+http_request_size_bytes{handler="add_silence",quantile="0.9"} 360
+http_request_size_bytes{handler="add_silence",quantile="0.99"} 360
+http_request_size_bytes_sum{handler="add_silence"} 1164
+http_request_size_bytes_count{handler="add_silence"} 3
+http_request_size_bytes{handler="alert_groups",quantile="0.5"} NaN
+http_request_size_bytes{handler="alert_groups",quantile="0.9"} NaN
+http_request_size_bytes{handler="alert_groups",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="alert_groups"} 0
+http_request_size_bytes_count{handler="alert_groups"} 0
+http_request_size_bytes{handler="app",quantile="0.5"} NaN
+http_request_size_bytes{handler="app",quantile="0.9"} NaN
+http_request_size_bytes{handler="app",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="app"} 0
+http_request_size_bytes_count{handler="app"} 0
+http_request_size_bytes{handler="del_silence",quantile="0.5"} NaN
+http_request_size_bytes{handler="del_silence",quantile="0.9"} NaN
+http_request_size_bytes{handler="del_silence",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="del_silence"} 0
+http_request_size_bytes_count{handler="del_silence"} 0
+http_request_size_bytes{handler="get_silence",quantile="0.5"} NaN
+http_request_size_bytes{handler="get_silence",quantile="0.9"} NaN
+http_request_size_bytes{handler="get_silence",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="get_silence"} 0
+http_request_size_bytes_count{handler="get_silence"} 0
+http_request_size_bytes{handler="index",quantile="0.5"} NaN
+http_request_size_bytes{handler="index",quantile="0.9"} NaN
+http_request_size_bytes{handler="index",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="index"} 0
+http_request_size_bytes_count{handler="index"} 0
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="legacy_add_alerts"} 0
+http_request_size_bytes_count{handler="legacy_add_alerts"} 0
+http_request_size_bytes{handler="lib_files",quantile="0.5"} NaN
+http_request_size_bytes{handler="lib_files",quantile="0.9"} NaN
+http_request_size_bytes{handler="lib_files",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="lib_files"} 0
+http_request_size_bytes_count{handler="lib_files"} 0
+http_request_size_bytes{handler="list_alerts",quantile="0.5"} NaN
+http_request_size_bytes{handler="list_alerts",quantile="0.9"} NaN
+http_request_size_bytes{handler="list_alerts",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="list_alerts"} 0
+http_request_size_bytes_count{handler="list_alerts"} 0
+http_request_size_bytes{handler="list_silences",quantile="0.5"} NaN
+http_request_size_bytes{handler="list_silences",quantile="0.9"} NaN
+http_request_size_bytes{handler="list_silences",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="list_silences"} 0
+http_request_size_bytes_count{handler="list_silences"} 0
+http_request_size_bytes{handler="options",quantile="0.5"} NaN
+http_request_size_bytes{handler="options",quantile="0.9"} NaN
+http_request_size_bytes{handler="options",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="options"} 0
+http_request_size_bytes_count{handler="options"} 0
+http_request_size_bytes{handler="prometheus",quantile="0.5"} NaN
+http_request_size_bytes{handler="prometheus",quantile="0.9"} NaN
+http_request_size_bytes{handler="prometheus",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="prometheus"} 0
+http_request_size_bytes_count{handler="prometheus"} 0
+http_request_size_bytes{handler="status",quantile="0.5"} NaN
+http_request_size_bytes{handler="status",quantile="0.9"} NaN
+http_request_size_bytes{handler="status",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="status"} 0
+http_request_size_bytes_count{handler="status"} 0
+# HELP http_requests_total Total number of HTTP requests made.
+# TYPE http_requests_total counter
+http_requests_total{code="200",handler="add_alerts",method="post"} 5
+http_requests_total{code="200",handler="add_silence",method="post"} 3
+# HELP http_response_size_bytes The HTTP response sizes in bytes.
+# TYPE http_response_size_bytes summary
+http_response_size_bytes{handler="add_alerts",quantile="0.5"} 20
+http_response_size_bytes{handler="add_alerts",quantile="0.9"} 20
+http_response_size_bytes{handler="add_alerts",quantile="0.99"} 20
+http_response_size_bytes_sum{handler="add_alerts"} 100
+http_response_size_bytes_count{handler="add_alerts"} 5
+http_response_size_bytes{handler="add_silence",quantile="0.5"} 80
+http_response_size_bytes{handler="add_silence",quantile="0.9"} 80
+http_response_size_bytes{handler="add_silence",quantile="0.99"} 80
+http_response_size_bytes_sum{handler="add_silence"} 240
+http_response_size_bytes_count{handler="add_silence"} 3
+http_response_size_bytes{handler="alert_groups",quantile="0.5"} NaN
+http_response_size_bytes{handler="alert_groups",quantile="0.9"} NaN
+http_response_size_bytes{handler="alert_groups",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="alert_groups"} 0
+http_response_size_bytes_count{handler="alert_groups"} 0
+http_response_size_bytes{handler="app",quantile="0.5"} NaN
+http_response_size_bytes{handler="app",quantile="0.9"} NaN
+http_response_size_bytes{handler="app",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="app"} 0
+http_response_size_bytes_count{handler="app"} 0
+http_response_size_bytes{handler="del_silence",quantile="0.5"} NaN
+http_response_size_bytes{handler="del_silence",quantile="0.9"} NaN
+http_response_size_bytes{handler="del_silence",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="del_silence"} 0
+http_response_size_bytes_count{handler="del_silence"} 0
+http_response_size_bytes{handler="get_silence",quantile="0.5"} NaN
+http_response_size_bytes{handler="get_silence",quantile="0.9"} NaN
+http_response_size_bytes{handler="get_silence",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="get_silence"} 0
+http_response_size_bytes_count{handler="get_silence"} 0
+http_response_size_bytes{handler="index",quantile="0.5"} NaN
+http_response_size_bytes{handler="index",quantile="0.9"} NaN
+http_response_size_bytes{handler="index",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="index"} 0
+http_response_size_bytes_count{handler="index"} 0
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="legacy_add_alerts"} 0
+http_response_size_bytes_count{handler="legacy_add_alerts"} 0
+http_response_size_bytes{handler="lib_files",quantile="0.5"} NaN
+http_response_size_bytes{handler="lib_files",quantile="0.9"} NaN
+http_response_size_bytes{handler="lib_files",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="lib_files"} 0
+http_response_size_bytes_count{handler="lib_files"} 0
+http_response_size_bytes{handler="list_alerts",quantile="0.5"} NaN
+http_response_size_bytes{handler="list_alerts",quantile="0.9"} NaN
+http_response_size_bytes{handler="list_alerts",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="list_alerts"} 0
+http_response_size_bytes_count{handler="list_alerts"} 0
+http_response_size_bytes{handler="list_silences",quantile="0.5"} NaN
+http_response_size_bytes{handler="list_silences",quantile="0.9"} NaN
+http_response_size_bytes{handler="list_silences",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="list_silences"} 0
+http_response_size_bytes_count{handler="list_silences"} 0
+http_response_size_bytes{handler="options",quantile="0.5"} NaN
+http_response_size_bytes{handler="options",quantile="0.9"} NaN
+http_response_size_bytes{handler="options",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="options"} 0
+http_response_size_bytes_count{handler="options"} 0
+http_response_size_bytes{handler="prometheus",quantile="0.5"} NaN
+http_response_size_bytes{handler="prometheus",quantile="0.9"} NaN
+http_response_size_bytes{handler="prometheus",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="prometheus"} 0
+http_response_size_bytes_count{handler="prometheus"} 0
+http_response_size_bytes{handler="status",quantile="0.5"} NaN
+http_response_size_bytes{handler="status",quantile="0.9"} NaN
+http_response_size_bytes{handler="status",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="status"} 0
+http_response_size_bytes_count{handler="status"} 0
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 0.11
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+process_max_fds 1.048576e+06
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+process_open_fds 8
+# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes 1.0121216e+07
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds 1.54886897027e+09
+# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE process_virtual_memory_bytes gauge
+process_virtual_memory_bytes 1.9070976e+07

--- a/internal/mock/0.8.0/api/v1/alerts/groups
+++ b/internal/mock/0.8.0/api/v1/alerts/groups
@@ -18,7 +18,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "startsAt": "2019-01-30T17:24:18.1958227Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -61,11 +61,11 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "startsAt": "2019-01-30T17:24:18.1958227Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "c5d3eb33-90eb-4432-8cb8-8b4ee7147583"
+                                    "a997b5bd-8380-412c-8636-4550ccbb61aa"
                                 ],
                                 "state": "suppressed"
                             }
@@ -83,7 +83,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "startsAt": "2019-01-30T17:24:18.1958227Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -119,59 +119,17 @@
                             "generatorURL": "localhost/prometheus",
                             "labels": {
                                 "alertname": "Host_Down",
-                                "cluster": "staging",
-                                "instance": "server5",
-                                "job": "node_ping"
-                            },
-                            "receivers": null,
-                            "startsAt": "2017-07-22T01:07:54.32189391Z",
-                            "status": {
-                                "inhibitedBy": [],
-                                "silencedBy": [],
-                                "state": "active"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "dev",
-                                "instance": "server6",
-                                "job": "node_ping"
-                            },
-                            "receivers": null,
-                            "startsAt": "2017-07-22T01:07:54.32189391Z",
-                            "status": {
-                                "inhibitedBy": null,
-                                "silencedBy": [
-                                    "dde04358-fe29-46b9-8a0c-f26e055b3a6a"
-                                ],
-                                "state": "suppressed"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
                                 "cluster": "dev",
                                 "instance": "server7",
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "startsAt": "2019-01-30T17:24:18.1958227Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "dde04358-fe29-46b9-8a0c-f26e055b3a6a",
-                                    "ac1f139b-e42b-4e22-9732-715d17e6223c"
+                                    "3158f572-62df-430c-99b0-29de6d683087",
+                                    "b50937a4-7429-4415-a740-b19c8634baf0"
                                 ],
                                 "state": "suppressed"
                             }
@@ -189,11 +147,11 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "startsAt": "2019-01-30T17:24:18.1958227Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "dde04358-fe29-46b9-8a0c-f26e055b3a6a"
+                                    "3158f572-62df-430c-99b0-29de6d683087"
                                 ],
                                 "state": "suppressed"
                             }
@@ -212,7 +170,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "startsAt": "2019-01-30T17:24:18.1958227Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -232,7 +190,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "startsAt": "2019-01-30T17:24:18.1958227Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -252,7 +210,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "startsAt": "2019-01-30T17:24:18.1958227Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -272,11 +230,53 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "startsAt": "2019-01-30T17:24:18.1958227Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
                                 "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "staging",
+                                "instance": "server5",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:24:18.1958227Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "dev",
+                                "instance": "server6",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:24:18.1958227Z",
+                            "status": {
+                                "inhibitedBy": null,
+                                "silencedBy": [
+                                    "3158f572-62df-430c-99b0-29de6d683087"
+                                ],
+                                "state": "suppressed"
                             }
                         }
                     ],
@@ -314,7 +314,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "startsAt": "2019-01-30T17:24:18.1958227Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -356,7 +356,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "startsAt": "2019-01-30T17:24:18.1958227Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -366,9 +366,9 @@
                     ],
                     "routeOpts": {
                         "groupBy": [
-                            "alertname",
                             "cluster",
-                            "service"
+                            "service",
+                            "alertname"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,
@@ -402,11 +402,11 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "startsAt": "2019-01-30T17:24:18.1958227Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "c5d3eb33-90eb-4432-8cb8-8b4ee7147583"
+                                    "a997b5bd-8380-412c-8636-4550ccbb61aa"
                                 ],
                                 "state": "suppressed"
                             }
@@ -424,7 +424,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "startsAt": "2019-01-30T17:24:18.1958227Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -468,11 +468,11 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "startsAt": "2019-01-30T17:24:18.1958227Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "dde04358-fe29-46b9-8a0c-f26e055b3a6a"
+                                    "3158f572-62df-430c-99b0-29de6d683087"
                                 ],
                                 "state": "suppressed"
                             }
@@ -490,12 +490,12 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "startsAt": "2019-01-30T17:24:18.1958227Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "dde04358-fe29-46b9-8a0c-f26e055b3a6a",
-                                    "ac1f139b-e42b-4e22-9732-715d17e6223c"
+                                    "3158f572-62df-430c-99b0-29de6d683087",
+                                    "b50937a4-7429-4415-a740-b19c8634baf0"
                                 ],
                                 "state": "suppressed"
                             }
@@ -513,11 +513,11 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "startsAt": "2019-01-30T17:24:18.1958227Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "dde04358-fe29-46b9-8a0c-f26e055b3a6a"
+                                    "3158f572-62df-430c-99b0-29de6d683087"
                                 ],
                                 "state": "suppressed"
                             }
@@ -525,9 +525,9 @@
                     ],
                     "routeOpts": {
                         "groupBy": [
-                            "service",
                             "alertname",
-                            "cluster"
+                            "cluster",
+                            "service"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,
@@ -548,26 +548,6 @@
                     "alerts": [
                         {
                             "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "prod",
-                                "instance": "server2",
-                                "job": "node_ping"
-                            },
-                            "receivers": null,
-                            "startsAt": "2017-07-22T01:07:54.32189391Z",
-                            "status": {
-                                "inhibitedBy": [],
-                                "silencedBy": [],
-                                "state": "active"
-                            }
-                        },
-                        {
-                            "annotations": {
                                 "summary": "Example summary",
                                 "url": "http://localhost/example.html"
                             },
@@ -580,7 +560,27 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "startsAt": "2019-01-30T17:24:18.1958227Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "prod",
+                                "instance": "server2",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:24:18.1958227Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -620,11 +620,31 @@
                             "labels": {
                                 "alertname": "Host_Down",
                                 "cluster": "staging",
+                                "instance": "server5",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:24:18.1958227Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "staging",
                                 "instance": "server3",
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "startsAt": "2019-01-30T17:24:18.1958227Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -644,27 +664,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-07-22T01:07:54.32189391Z",
-                            "status": {
-                                "inhibitedBy": [],
-                                "silencedBy": [],
-                                "state": "active"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "staging",
-                                "instance": "server5",
-                                "job": "node_ping"
-                            },
-                            "receivers": null,
-                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "startsAt": "2019-01-30T17:24:18.1958227Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -709,7 +709,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-07-22T01:07:54.32189391Z",
+                            "startsAt": "2019-01-30T17:24:18.1958227Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],

--- a/internal/mock/0.8.0/api/v1/silences
+++ b/internal/mock/0.8.0/api/v1/silences
@@ -4,7 +4,7 @@
             "comment": "Silenced instance",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "c5d3eb33-90eb-4432-8cb8-8b4ee7147583",
+            "id": "a997b5bd-8380-412c-8636-4550ccbb61aa",
             "matchers": [
                 {
                     "isRegex": false,
@@ -12,17 +12,17 @@
                     "value": "web1"
                 }
             ],
-            "startsAt": "2017-07-22T01:07:54.312124563Z",
+            "startsAt": "2019-01-30T17:24:18.1824813Z",
             "status": {
                 "state": "active"
             },
-            "updatedAt": "2017-07-22T01:07:54.312131495Z"
+            "updatedAt": "2019-01-30T17:24:18.1825908Z"
         },
         {
             "comment": "Silenced Host_Down alerts in the dev cluster",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "dde04358-fe29-46b9-8a0c-f26e055b3a6a",
+            "id": "3158f572-62df-430c-99b0-29de6d683087",
             "matchers": [
                 {
                     "isRegex": false,
@@ -35,17 +35,17 @@
                     "value": "dev"
                 }
             ],
-            "startsAt": "2017-07-22T01:07:54.314514791Z",
+            "startsAt": "2019-01-30T17:24:18.1875437Z",
             "status": {
                 "state": "active"
             },
-            "updatedAt": "2017-07-22T01:07:54.314518694Z"
+            "updatedAt": "2019-01-30T17:24:18.1875589Z"
         },
         {
             "comment": "Silenced server7",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "ac1f139b-e42b-4e22-9732-715d17e6223c",
+            "id": "b50937a4-7429-4415-a740-b19c8634baf0",
             "matchers": [
                 {
                     "isRegex": false,
@@ -53,11 +53,11 @@
                     "value": "server7"
                 }
             ],
-            "startsAt": "2017-07-22T01:07:54.316475956Z",
+            "startsAt": "2019-01-30T17:24:18.1915198Z",
             "status": {
                 "state": "active"
             },
-            "updatedAt": "2017-07-22T01:07:54.316480733Z"
+            "updatedAt": "2019-01-30T17:24:18.1915361Z"
         }
     ],
     "status": "success"

--- a/internal/mock/0.8.0/api/v1/status
+++ b/internal/mock/0.8.0/api/v1/status
@@ -73,16 +73,16 @@
         "configYAML": "global:\n  resolve_timeout: 5m\n  smtp_require_tls: true\n  pagerduty_url: https://events.pagerduty.com/generic/2010-04-15/create_event.json\n  hipchat_url: https://api.hipchat.com/\n  opsgenie_api_host: https://api.opsgenie.com/\n  victorops_api_url: https://alert.victorops.com/integrations/generic/20131114/alert/\nroute:\n  receiver: default\n  group_by:\n  - alertname\n  routes:\n  - receiver: by-cluster-service\n    group_by:\n    - alertname\n    - cluster\n    - service\n    match_re:\n      alertname: ^(?:.*)$\n    continue: true\n  - receiver: by-name\n    group_by:\n    - alertname\n    match_re:\n      alertname: ^(?:.*)$\n    continue: true\n  group_wait: 15s\n  group_interval: 35s\n  repeat_interval: 999h\ninhibit_rules:\n- source_match:\n    severity: critical\n  target_match:\n    severity: warning\n  equal:\n  - alertname\n  - cluster\n  - service\nreceivers:\n- name: default\n- name: by-cluster-service\n- name: by-name\ntemplates: []\n",
         "meshStatus": {
             "name": "02:42:ac:11:00:02",
-            "nickName": "eaa7828032f9",
+            "nickName": "c18605c56a02",
             "peers": [
                 {
                     "name": "02:42:ac:11:00:02",
-                    "nickName": "eaa7828032f9",
-                    "uid": 6874768980588183501
+                    "nickName": "c18605c56a02",
+                    "uid": 11041846661399629740
                 }
             ]
         },
-        "uptime": "2017-07-22T01:07:38.96080204Z",
+        "uptime": "2019-01-30T17:24:03.0430734Z",
         "versionInfo": {
             "branch": "HEAD",
             "buildDate": "20170720-14:14:06",

--- a/internal/mock/0.8.0/metrics
+++ b/internal/mock/0.8.0/metrics
@@ -1,0 +1,424 @@
+# HELP alertmanager_alerts_invalid_total The total number of received alerts that were invalid.
+# TYPE alertmanager_alerts_invalid_total counter
+alertmanager_alerts_invalid_total 0
+# HELP alertmanager_alerts_received_total The total number of received alerts.
+# TYPE alertmanager_alerts_received_total counter
+alertmanager_alerts_received_total{status="firing"} 60
+# HELP alertmanager_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which alertmanager was built.
+# TYPE alertmanager_build_info gauge
+alertmanager_build_info{branch="HEAD",goversion="go1.8.3",revision="74e7e48d24bddd2e2a80c7840af9b2de271cc74c",version="0.8.0"} 1
+# HELP alertmanager_config_hash Hash of the currently loaded alertmanager configuration.
+# TYPE alertmanager_config_hash gauge
+alertmanager_config_hash 6.2645753076152e+13
+# HELP alertmanager_config_last_reload_success_timestamp_seconds Timestamp of the last successful configuration reload.
+# TYPE alertmanager_config_last_reload_success_timestamp_seconds gauge
+alertmanager_config_last_reload_success_timestamp_seconds 1.548869043e+09
+# HELP alertmanager_config_last_reload_successful Whether the last configuration reload attempt was successful.
+# TYPE alertmanager_config_last_reload_successful gauge
+alertmanager_config_last_reload_successful 1
+# HELP alertmanager_nflog_gc_duration_seconds Duration of the last notification log garbage collection cycle.
+# TYPE alertmanager_nflog_gc_duration_seconds summary
+alertmanager_nflog_gc_duration_seconds{quantile="0.5"} NaN
+alertmanager_nflog_gc_duration_seconds{quantile="0.9"} NaN
+alertmanager_nflog_gc_duration_seconds{quantile="0.99"} NaN
+alertmanager_nflog_gc_duration_seconds_sum 0
+alertmanager_nflog_gc_duration_seconds_count 0
+# HELP alertmanager_nflog_queries_total Number of notification log queries were received.
+# TYPE alertmanager_nflog_queries_total counter
+alertmanager_nflog_queries_total 0
+# HELP alertmanager_nflog_query_duration_seconds Duration of notification log query evaluation.
+# TYPE alertmanager_nflog_query_duration_seconds histogram
+alertmanager_nflog_query_duration_seconds_bucket{le="0.005"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.01"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.025"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.05"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.1"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.25"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="1"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="2.5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="10"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="+Inf"} 0
+alertmanager_nflog_query_duration_seconds_sum 0
+alertmanager_nflog_query_duration_seconds_count 0
+# HELP alertmanager_nflog_query_errors_total Number notification log received queries that failed.
+# TYPE alertmanager_nflog_query_errors_total counter
+alertmanager_nflog_query_errors_total 0
+# HELP alertmanager_nflog_snapshot_duration_seconds Duration of the last notification log snapshot.
+# TYPE alertmanager_nflog_snapshot_duration_seconds summary
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.5"} NaN
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.9"} NaN
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.99"} NaN
+alertmanager_nflog_snapshot_duration_seconds_sum 0
+alertmanager_nflog_snapshot_duration_seconds_count 0
+# HELP alertmanager_silences_gc_duration_seconds Duration of the last silence garbage collection cycle.
+# TYPE alertmanager_silences_gc_duration_seconds summary
+alertmanager_silences_gc_duration_seconds{quantile="0.5"} NaN
+alertmanager_silences_gc_duration_seconds{quantile="0.9"} NaN
+alertmanager_silences_gc_duration_seconds{quantile="0.99"} NaN
+alertmanager_silences_gc_duration_seconds_sum 0
+alertmanager_silences_gc_duration_seconds_count 0
+# HELP alertmanager_silences_queries_total How many silence queries were received.
+# TYPE alertmanager_silences_queries_total counter
+alertmanager_silences_queries_total 48
+# HELP alertmanager_silences_query_duration_seconds Duration of silence query evaluation.
+# TYPE alertmanager_silences_query_duration_seconds histogram
+alertmanager_silences_query_duration_seconds_bucket{le="0.005"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.01"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.025"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.05"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.1"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.25"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.5"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="1"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="2.5"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="5"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="10"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="+Inf"} 48
+alertmanager_silences_query_duration_seconds_sum 0.0017787
+alertmanager_silences_query_duration_seconds_count 48
+# HELP alertmanager_silences_query_errors_total How many silence received queries did not succeed.
+# TYPE alertmanager_silences_query_errors_total counter
+alertmanager_silences_query_errors_total 0
+# HELP alertmanager_silences_snapshot_duration_seconds Duration of the last silence snapshot.
+# TYPE alertmanager_silences_snapshot_duration_seconds summary
+alertmanager_silences_snapshot_duration_seconds{quantile="0.5"} NaN
+alertmanager_silences_snapshot_duration_seconds{quantile="0.9"} NaN
+alertmanager_silences_snapshot_duration_seconds{quantile="0.99"} NaN
+alertmanager_silences_snapshot_duration_seconds_sum 0
+alertmanager_silences_snapshot_duration_seconds_count 0
+# HELP go_gc_duration_seconds A summary of the GC invocation durations.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0"} 0.0030985
+go_gc_duration_seconds{quantile="0.25"} 0.0030985
+go_gc_duration_seconds{quantile="0.5"} 0.0030985
+go_gc_duration_seconds{quantile="0.75"} 0.0030985
+go_gc_duration_seconds{quantile="1"} 0.0030985
+go_gc_duration_seconds_sum 0.0030985
+go_gc_duration_seconds_count 1
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 40
+# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+# TYPE go_memstats_alloc_bytes gauge
+go_memstats_alloc_bytes 5.007392e+06
+# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
+# TYPE go_memstats_alloc_bytes_total counter
+go_memstats_alloc_bytes_total 5.638512e+06
+# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
+# TYPE go_memstats_buck_hash_sys_bytes gauge
+go_memstats_buck_hash_sys_bytes 1.445036e+06
+# HELP go_memstats_frees_total Total number of frees.
+# TYPE go_memstats_frees_total counter
+go_memstats_frees_total 5391
+# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+# TYPE go_memstats_gc_sys_bytes gauge
+go_memstats_gc_sys_bytes 391168
+# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
+# TYPE go_memstats_heap_alloc_bytes gauge
+go_memstats_heap_alloc_bytes 5.007392e+06
+# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
+# TYPE go_memstats_heap_idle_bytes gauge
+go_memstats_heap_idle_bytes 876544
+# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
+# TYPE go_memstats_heap_inuse_bytes gauge
+go_memstats_heap_inuse_bytes 5.709824e+06
+# HELP go_memstats_heap_objects Number of allocated objects.
+# TYPE go_memstats_heap_objects gauge
+go_memstats_heap_objects 18748
+# HELP go_memstats_heap_released_bytes_total Total number of heap bytes released to OS.
+# TYPE go_memstats_heap_released_bytes_total counter
+go_memstats_heap_released_bytes_total 0
+# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
+# TYPE go_memstats_heap_sys_bytes gauge
+go_memstats_heap_sys_bytes 6.586368e+06
+# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
+# TYPE go_memstats_last_gc_time_seconds gauge
+go_memstats_last_gc_time_seconds 1.548869043056876e+09
+# HELP go_memstats_lookups_total Total number of pointer lookups.
+# TYPE go_memstats_lookups_total counter
+go_memstats_lookups_total 40
+# HELP go_memstats_mallocs_total Total number of mallocs.
+# TYPE go_memstats_mallocs_total counter
+go_memstats_mallocs_total 24139
+# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
+# TYPE go_memstats_mcache_inuse_bytes gauge
+go_memstats_mcache_inuse_bytes 2400
+# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
+# TYPE go_memstats_mcache_sys_bytes gauge
+go_memstats_mcache_sys_bytes 16384
+# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
+# TYPE go_memstats_mspan_inuse_bytes gauge
+go_memstats_mspan_inuse_bytes 62776
+# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
+# TYPE go_memstats_mspan_sys_bytes gauge
+go_memstats_mspan_sys_bytes 65536
+# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
+# TYPE go_memstats_next_gc_bytes gauge
+go_memstats_next_gc_bytes 7.601888e+06
+# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
+# TYPE go_memstats_other_sys_bytes gauge
+go_memstats_other_sys_bytes 742476
+# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
+# TYPE go_memstats_stack_inuse_bytes gauge
+go_memstats_stack_inuse_bytes 753664
+# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
+# TYPE go_memstats_stack_sys_bytes gauge
+go_memstats_stack_sys_bytes 753664
+# HELP go_memstats_sys_bytes Number of bytes obtained by system. Sum of all system allocations.
+# TYPE go_memstats_sys_bytes gauge
+go_memstats_sys_bytes 1.0000632e+07
+# HELP http_request_duration_microseconds The HTTP request latencies in microseconds.
+# TYPE http_request_duration_microseconds summary
+http_request_duration_microseconds{handler="add_alerts",quantile="0.5"} 564.3
+http_request_duration_microseconds{handler="add_alerts",quantile="0.9"} 1017.1
+http_request_duration_microseconds{handler="add_alerts",quantile="0.99"} 1017.1
+http_request_duration_microseconds_sum{handler="add_alerts"} 4407.4
+http_request_duration_microseconds_count{handler="add_alerts"} 5
+http_request_duration_microseconds{handler="add_silence",quantile="0.5"} 185.9
+http_request_duration_microseconds{handler="add_silence",quantile="0.9"} 517
+http_request_duration_microseconds{handler="add_silence",quantile="0.99"} 517
+http_request_duration_microseconds_sum{handler="add_silence"} 1387.4
+http_request_duration_microseconds_count{handler="add_silence"} 3
+http_request_duration_microseconds{handler="alert_groups",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="alert_groups",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="alert_groups",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="alert_groups"} 0
+http_request_duration_microseconds_count{handler="alert_groups"} 0
+http_request_duration_microseconds{handler="app",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="app",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="app",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="app"} 0
+http_request_duration_microseconds_count{handler="app"} 0
+http_request_duration_microseconds{handler="del_silence",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="del_silence",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="del_silence",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="del_silence"} 0
+http_request_duration_microseconds_count{handler="del_silence"} 0
+http_request_duration_microseconds{handler="get_silence",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="get_silence",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="get_silence",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="get_silence"} 0
+http_request_duration_microseconds_count{handler="get_silence"} 0
+http_request_duration_microseconds{handler="index",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="index",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="index",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="index"} 0
+http_request_duration_microseconds_count{handler="index"} 0
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="legacy_add_alerts"} 0
+http_request_duration_microseconds_count{handler="legacy_add_alerts"} 0
+http_request_duration_microseconds{handler="lib_files",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="lib_files",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="lib_files",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="lib_files"} 0
+http_request_duration_microseconds_count{handler="lib_files"} 0
+http_request_duration_microseconds{handler="list_alerts",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="list_alerts",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="list_alerts",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="list_alerts"} 0
+http_request_duration_microseconds_count{handler="list_alerts"} 0
+http_request_duration_microseconds{handler="list_silences",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="list_silences",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="list_silences",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="list_silences"} 0
+http_request_duration_microseconds_count{handler="list_silences"} 0
+http_request_duration_microseconds{handler="options",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="options",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="options",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="options"} 0
+http_request_duration_microseconds_count{handler="options"} 0
+http_request_duration_microseconds{handler="prometheus",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="prometheus",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="prometheus",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="prometheus"} 0
+http_request_duration_microseconds_count{handler="prometheus"} 0
+http_request_duration_microseconds{handler="receivers",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="receivers",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="receivers",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="receivers"} 0
+http_request_duration_microseconds_count{handler="receivers"} 0
+http_request_duration_microseconds{handler="status",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="status",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="status",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="status"} 0
+http_request_duration_microseconds_count{handler="status"} 0
+# HELP http_request_size_bytes The HTTP request sizes in bytes.
+# TYPE http_request_size_bytes summary
+http_request_size_bytes{handler="add_alerts",quantile="0.5"} 2719
+http_request_size_bytes{handler="add_alerts",quantile="0.9"} 2719
+http_request_size_bytes{handler="add_alerts",quantile="0.99"} 2719
+http_request_size_bytes_sum{handler="add_alerts"} 13595
+http_request_size_bytes_count{handler="add_alerts"} 5
+http_request_size_bytes{handler="add_silence",quantile="0.5"} 358
+http_request_size_bytes{handler="add_silence",quantile="0.9"} 360
+http_request_size_bytes{handler="add_silence",quantile="0.99"} 360
+http_request_size_bytes_sum{handler="add_silence"} 1164
+http_request_size_bytes_count{handler="add_silence"} 3
+http_request_size_bytes{handler="alert_groups",quantile="0.5"} NaN
+http_request_size_bytes{handler="alert_groups",quantile="0.9"} NaN
+http_request_size_bytes{handler="alert_groups",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="alert_groups"} 0
+http_request_size_bytes_count{handler="alert_groups"} 0
+http_request_size_bytes{handler="app",quantile="0.5"} NaN
+http_request_size_bytes{handler="app",quantile="0.9"} NaN
+http_request_size_bytes{handler="app",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="app"} 0
+http_request_size_bytes_count{handler="app"} 0
+http_request_size_bytes{handler="del_silence",quantile="0.5"} NaN
+http_request_size_bytes{handler="del_silence",quantile="0.9"} NaN
+http_request_size_bytes{handler="del_silence",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="del_silence"} 0
+http_request_size_bytes_count{handler="del_silence"} 0
+http_request_size_bytes{handler="get_silence",quantile="0.5"} NaN
+http_request_size_bytes{handler="get_silence",quantile="0.9"} NaN
+http_request_size_bytes{handler="get_silence",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="get_silence"} 0
+http_request_size_bytes_count{handler="get_silence"} 0
+http_request_size_bytes{handler="index",quantile="0.5"} NaN
+http_request_size_bytes{handler="index",quantile="0.9"} NaN
+http_request_size_bytes{handler="index",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="index"} 0
+http_request_size_bytes_count{handler="index"} 0
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="legacy_add_alerts"} 0
+http_request_size_bytes_count{handler="legacy_add_alerts"} 0
+http_request_size_bytes{handler="lib_files",quantile="0.5"} NaN
+http_request_size_bytes{handler="lib_files",quantile="0.9"} NaN
+http_request_size_bytes{handler="lib_files",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="lib_files"} 0
+http_request_size_bytes_count{handler="lib_files"} 0
+http_request_size_bytes{handler="list_alerts",quantile="0.5"} NaN
+http_request_size_bytes{handler="list_alerts",quantile="0.9"} NaN
+http_request_size_bytes{handler="list_alerts",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="list_alerts"} 0
+http_request_size_bytes_count{handler="list_alerts"} 0
+http_request_size_bytes{handler="list_silences",quantile="0.5"} NaN
+http_request_size_bytes{handler="list_silences",quantile="0.9"} NaN
+http_request_size_bytes{handler="list_silences",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="list_silences"} 0
+http_request_size_bytes_count{handler="list_silences"} 0
+http_request_size_bytes{handler="options",quantile="0.5"} NaN
+http_request_size_bytes{handler="options",quantile="0.9"} NaN
+http_request_size_bytes{handler="options",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="options"} 0
+http_request_size_bytes_count{handler="options"} 0
+http_request_size_bytes{handler="prometheus",quantile="0.5"} NaN
+http_request_size_bytes{handler="prometheus",quantile="0.9"} NaN
+http_request_size_bytes{handler="prometheus",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="prometheus"} 0
+http_request_size_bytes_count{handler="prometheus"} 0
+http_request_size_bytes{handler="receivers",quantile="0.5"} NaN
+http_request_size_bytes{handler="receivers",quantile="0.9"} NaN
+http_request_size_bytes{handler="receivers",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="receivers"} 0
+http_request_size_bytes_count{handler="receivers"} 0
+http_request_size_bytes{handler="status",quantile="0.5"} NaN
+http_request_size_bytes{handler="status",quantile="0.9"} NaN
+http_request_size_bytes{handler="status",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="status"} 0
+http_request_size_bytes_count{handler="status"} 0
+# HELP http_requests_total Total number of HTTP requests made.
+# TYPE http_requests_total counter
+http_requests_total{code="200",handler="add_alerts",method="post"} 5
+http_requests_total{code="200",handler="add_silence",method="post"} 3
+# HELP http_response_size_bytes The HTTP response sizes in bytes.
+# TYPE http_response_size_bytes summary
+http_response_size_bytes{handler="add_alerts",quantile="0.5"} 20
+http_response_size_bytes{handler="add_alerts",quantile="0.9"} 20
+http_response_size_bytes{handler="add_alerts",quantile="0.99"} 20
+http_response_size_bytes_sum{handler="add_alerts"} 100
+http_response_size_bytes_count{handler="add_alerts"} 5
+http_response_size_bytes{handler="add_silence",quantile="0.5"} 80
+http_response_size_bytes{handler="add_silence",quantile="0.9"} 80
+http_response_size_bytes{handler="add_silence",quantile="0.99"} 80
+http_response_size_bytes_sum{handler="add_silence"} 240
+http_response_size_bytes_count{handler="add_silence"} 3
+http_response_size_bytes{handler="alert_groups",quantile="0.5"} NaN
+http_response_size_bytes{handler="alert_groups",quantile="0.9"} NaN
+http_response_size_bytes{handler="alert_groups",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="alert_groups"} 0
+http_response_size_bytes_count{handler="alert_groups"} 0
+http_response_size_bytes{handler="app",quantile="0.5"} NaN
+http_response_size_bytes{handler="app",quantile="0.9"} NaN
+http_response_size_bytes{handler="app",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="app"} 0
+http_response_size_bytes_count{handler="app"} 0
+http_response_size_bytes{handler="del_silence",quantile="0.5"} NaN
+http_response_size_bytes{handler="del_silence",quantile="0.9"} NaN
+http_response_size_bytes{handler="del_silence",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="del_silence"} 0
+http_response_size_bytes_count{handler="del_silence"} 0
+http_response_size_bytes{handler="get_silence",quantile="0.5"} NaN
+http_response_size_bytes{handler="get_silence",quantile="0.9"} NaN
+http_response_size_bytes{handler="get_silence",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="get_silence"} 0
+http_response_size_bytes_count{handler="get_silence"} 0
+http_response_size_bytes{handler="index",quantile="0.5"} NaN
+http_response_size_bytes{handler="index",quantile="0.9"} NaN
+http_response_size_bytes{handler="index",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="index"} 0
+http_response_size_bytes_count{handler="index"} 0
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="legacy_add_alerts"} 0
+http_response_size_bytes_count{handler="legacy_add_alerts"} 0
+http_response_size_bytes{handler="lib_files",quantile="0.5"} NaN
+http_response_size_bytes{handler="lib_files",quantile="0.9"} NaN
+http_response_size_bytes{handler="lib_files",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="lib_files"} 0
+http_response_size_bytes_count{handler="lib_files"} 0
+http_response_size_bytes{handler="list_alerts",quantile="0.5"} NaN
+http_response_size_bytes{handler="list_alerts",quantile="0.9"} NaN
+http_response_size_bytes{handler="list_alerts",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="list_alerts"} 0
+http_response_size_bytes_count{handler="list_alerts"} 0
+http_response_size_bytes{handler="list_silences",quantile="0.5"} NaN
+http_response_size_bytes{handler="list_silences",quantile="0.9"} NaN
+http_response_size_bytes{handler="list_silences",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="list_silences"} 0
+http_response_size_bytes_count{handler="list_silences"} 0
+http_response_size_bytes{handler="options",quantile="0.5"} NaN
+http_response_size_bytes{handler="options",quantile="0.9"} NaN
+http_response_size_bytes{handler="options",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="options"} 0
+http_response_size_bytes_count{handler="options"} 0
+http_response_size_bytes{handler="prometheus",quantile="0.5"} NaN
+http_response_size_bytes{handler="prometheus",quantile="0.9"} NaN
+http_response_size_bytes{handler="prometheus",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="prometheus"} 0
+http_response_size_bytes_count{handler="prometheus"} 0
+http_response_size_bytes{handler="receivers",quantile="0.5"} NaN
+http_response_size_bytes{handler="receivers",quantile="0.9"} NaN
+http_response_size_bytes{handler="receivers",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="receivers"} 0
+http_response_size_bytes_count{handler="receivers"} 0
+http_response_size_bytes{handler="status",quantile="0.5"} NaN
+http_response_size_bytes{handler="status",quantile="0.9"} NaN
+http_response_size_bytes{handler="status",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="status"} 0
+http_response_size_bytes_count{handler="status"} 0
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 0.11
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+process_max_fds 1.048576e+06
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+process_open_fds 8
+# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes 9.945088e+06
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds 1.54886904245e+09
+# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE process_virtual_memory_bytes gauge
+process_virtual_memory_bytes 2.0160512e+07

--- a/internal/mock/0.9.0/api/v1/alerts/groups
+++ b/internal/mock/0.9.0/api/v1/alerts/groups
@@ -19,7 +19,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-09-29T02:07:50.640170478Z",
+                            "startsAt": "2019-01-30T17:25:30.5774137Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -63,11 +63,11 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-09-29T02:07:50.640170478Z",
+                            "startsAt": "2019-01-30T17:25:30.5774137Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "7ff2f1c7-a5d6-4a6c-a110-e68cc7b94c99"
+                                    "db1e36d5-417c-4b81-98d4-71acacefe08f"
                                 ],
                                 "state": "suppressed"
                             }
@@ -86,7 +86,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-09-29T02:07:50.640170478Z",
+                            "startsAt": "2019-01-30T17:25:30.5774137Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -119,75 +119,6 @@
                                 "summary": "Example summary"
                             },
                             "endsAt": "0001-01-01T00:00:00Z",
-                            "fingerprint": "44497481566cd3c7",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "dev",
-                                "instance": "server7",
-                                "job": "node_ping"
-                            },
-                            "receivers": null,
-                            "startsAt": "2017-09-29T02:07:50.640170478Z",
-                            "status": {
-                                "inhibitedBy": null,
-                                "silencedBy": [
-                                    "6fcaeee5-ed55-4d8b-8dfb-e21c01396c1a",
-                                    "bf098baf-fbcb-457e-afc8-f08aa7116161"
-                                ],
-                                "state": "suppressed"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "fingerprint": "af9d8f2f0ccb3970",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "dev",
-                                "instance": "server8",
-                                "job": "node_ping"
-                            },
-                            "receivers": null,
-                            "startsAt": "2017-09-29T02:07:50.640170478Z",
-                            "status": {
-                                "inhibitedBy": null,
-                                "silencedBy": [
-                                    "6fcaeee5-ed55-4d8b-8dfb-e21c01396c1a"
-                                ],
-                                "state": "suppressed"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary",
-                                "url": "http://localhost/example.html"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "fingerprint": "d0aee2649e71388b",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "prod",
-                                "instance": "server1",
-                                "job": "node_ping"
-                            },
-                            "receivers": null,
-                            "startsAt": "2017-09-29T02:07:50.640170478Z",
-                            "status": {
-                                "inhibitedBy": [],
-                                "silencedBy": [],
-                                "state": "active"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
                             "fingerprint": "3bdb8b68bdce2ae0",
                             "generatorURL": "localhost/prometheus",
                             "labels": {
@@ -197,7 +128,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-09-29T02:07:50.640170478Z",
+                            "startsAt": "2019-01-30T17:25:30.5774137Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -218,7 +149,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-09-29T02:07:50.640170478Z",
+                            "startsAt": "2019-01-30T17:25:30.5774137Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -239,7 +170,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-09-29T02:07:50.640170478Z",
+                            "startsAt": "2019-01-30T17:25:30.5774137Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -260,7 +191,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-09-29T02:07:50.640170478Z",
+                            "startsAt": "2019-01-30T17:25:30.5774137Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -281,13 +212,82 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-09-29T02:07:50.640170478Z",
+                            "startsAt": "2019-01-30T17:25:30.5774137Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "6fcaeee5-ed55-4d8b-8dfb-e21c01396c1a"
+                                    "05e8db14-64d7-4044-9f95-c8d663803228"
                                 ],
                                 "state": "suppressed"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "fingerprint": "44497481566cd3c7",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "dev",
+                                "instance": "server7",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:25:30.5774137Z",
+                            "status": {
+                                "inhibitedBy": null,
+                                "silencedBy": [
+                                    "05e8db14-64d7-4044-9f95-c8d663803228",
+                                    "0fd19846-7672-4360-84fe-4be7da273537"
+                                ],
+                                "state": "suppressed"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "fingerprint": "af9d8f2f0ccb3970",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "dev",
+                                "instance": "server8",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:25:30.5774137Z",
+                            "status": {
+                                "inhibitedBy": null,
+                                "silencedBy": [
+                                    "05e8db14-64d7-4044-9f95-c8d663803228"
+                                ],
+                                "state": "suppressed"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary",
+                                "url": "http://localhost/example.html"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "fingerprint": "d0aee2649e71388b",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "prod",
+                                "instance": "server1",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:25:30.5774137Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
                             }
                         }
                     ],
@@ -326,7 +326,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-09-29T02:07:50.640170478Z",
+                            "startsAt": "2019-01-30T17:25:30.5774137Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -369,7 +369,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-09-29T02:07:50.640170478Z",
+                            "startsAt": "2019-01-30T17:25:30.5774137Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -416,11 +416,11 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-09-29T02:07:50.640170478Z",
+                            "startsAt": "2019-01-30T17:25:30.5774137Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "7ff2f1c7-a5d6-4a6c-a110-e68cc7b94c99"
+                                    "db1e36d5-417c-4b81-98d4-71acacefe08f"
                                 ],
                                 "state": "suppressed"
                             }
@@ -439,7 +439,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-09-29T02:07:50.640170478Z",
+                            "startsAt": "2019-01-30T17:25:30.5774137Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -484,11 +484,11 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-09-29T02:07:50.640170478Z",
+                            "startsAt": "2019-01-30T17:25:30.5774137Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "6fcaeee5-ed55-4d8b-8dfb-e21c01396c1a"
+                                    "05e8db14-64d7-4044-9f95-c8d663803228"
                                 ],
                                 "state": "suppressed"
                             }
@@ -507,12 +507,12 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-09-29T02:07:50.640170478Z",
+                            "startsAt": "2019-01-30T17:25:30.5774137Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "6fcaeee5-ed55-4d8b-8dfb-e21c01396c1a",
-                                    "bf098baf-fbcb-457e-afc8-f08aa7116161"
+                                    "05e8db14-64d7-4044-9f95-c8d663803228",
+                                    "0fd19846-7672-4360-84fe-4be7da273537"
                                 ],
                                 "state": "suppressed"
                             }
@@ -531,11 +531,11 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-09-29T02:07:50.640170478Z",
+                            "startsAt": "2019-01-30T17:25:30.5774137Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "6fcaeee5-ed55-4d8b-8dfb-e21c01396c1a"
+                                    "05e8db14-64d7-4044-9f95-c8d663803228"
                                 ],
                                 "state": "suppressed"
                             }
@@ -543,9 +543,9 @@
                     ],
                     "routeOpts": {
                         "groupBy": [
-                            "alertname",
                             "cluster",
-                            "service"
+                            "service",
+                            "alertname"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,
@@ -579,7 +579,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-09-29T02:07:50.640170478Z",
+                            "startsAt": "2019-01-30T17:25:30.5774137Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -600,7 +600,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-09-29T02:07:50.640170478Z",
+                            "startsAt": "2019-01-30T17:25:30.5774137Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -645,7 +645,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-09-29T02:07:50.640170478Z",
+                            "startsAt": "2019-01-30T17:25:30.5774137Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -666,7 +666,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-09-29T02:07:50.640170478Z",
+                            "startsAt": "2019-01-30T17:25:30.5774137Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -687,7 +687,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-09-29T02:07:50.640170478Z",
+                            "startsAt": "2019-01-30T17:25:30.5774137Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -733,7 +733,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-09-29T02:07:50.640170478Z",
+                            "startsAt": "2019-01-30T17:25:30.5774137Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -743,9 +743,9 @@
                     ],
                     "routeOpts": {
                         "groupBy": [
+                            "service",
                             "alertname",
-                            "cluster",
-                            "service"
+                            "cluster"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,

--- a/internal/mock/0.9.0/api/v1/silences
+++ b/internal/mock/0.9.0/api/v1/silences
@@ -4,7 +4,7 @@
             "comment": "Silenced instance",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "7ff2f1c7-a5d6-4a6c-a110-e68cc7b94c99",
+            "id": "db1e36d5-417c-4b81-98d4-71acacefe08f",
             "matchers": [
                 {
                     "isRegex": false,
@@ -12,17 +12,17 @@
                     "value": "web1"
                 }
             ],
-            "startsAt": "2017-09-29T02:07:50.633726389Z",
+            "startsAt": "2019-01-30T17:25:30.5661641Z",
             "status": {
                 "state": "active"
             },
-            "updatedAt": "2017-09-29T02:07:50.633731461Z"
+            "updatedAt": "2019-01-30T17:25:30.5661799Z"
         },
         {
             "comment": "Silenced Host_Down alerts in the dev cluster",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "6fcaeee5-ed55-4d8b-8dfb-e21c01396c1a",
+            "id": "05e8db14-64d7-4044-9f95-c8d663803228",
             "matchers": [
                 {
                     "isRegex": false,
@@ -35,17 +35,17 @@
                     "value": "dev"
                 }
             ],
-            "startsAt": "2017-09-29T02:07:50.636330086Z",
+            "startsAt": "2019-01-30T17:25:30.5700833Z",
             "status": {
                 "state": "active"
             },
-            "updatedAt": "2017-09-29T02:07:50.636333492Z"
+            "updatedAt": "2019-01-30T17:25:30.5700925Z"
         },
         {
             "comment": "Silenced server7",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "bf098baf-fbcb-457e-afc8-f08aa7116161",
+            "id": "0fd19846-7672-4360-84fe-4be7da273537",
             "matchers": [
                 {
                     "isRegex": false,
@@ -53,11 +53,11 @@
                     "value": "server7"
                 }
             ],
-            "startsAt": "2017-09-29T02:07:50.638188974Z",
+            "startsAt": "2019-01-30T17:25:30.5734742Z",
             "status": {
                 "state": "active"
             },
-            "updatedAt": "2017-09-29T02:07:50.638192237Z"
+            "updatedAt": "2019-01-30T17:25:30.5734844Z"
         }
     ],
     "status": "success"

--- a/internal/mock/0.9.0/api/v1/status
+++ b/internal/mock/0.9.0/api/v1/status
@@ -73,16 +73,16 @@
         "configYAML": "global:\n  resolve_timeout: 5m\n  smtp_require_tls: true\n  pagerduty_url: https://events.pagerduty.com/generic/2010-04-15/create_event.json\n  hipchat_url: https://api.hipchat.com/\n  opsgenie_api_host: https://api.opsgenie.com/\n  victorops_api_url: https://alert.victorops.com/integrations/generic/20131114/alert/\nroute:\n  receiver: default\n  group_by:\n  - alertname\n  routes:\n  - receiver: by-cluster-service\n    group_by:\n    - alertname\n    - cluster\n    - service\n    match_re:\n      alertname: ^(?:.*)$\n    continue: true\n  - receiver: by-name\n    group_by:\n    - alertname\n    match_re:\n      alertname: ^(?:.*)$\n    continue: true\n  group_wait: 15s\n  group_interval: 35s\n  repeat_interval: 999h\ninhibit_rules:\n- source_match:\n    severity: critical\n  target_match:\n    severity: warning\n  equal:\n  - alertname\n  - cluster\n  - service\nreceivers:\n- name: default\n- name: by-cluster-service\n- name: by-name\ntemplates: []\n",
         "meshStatus": {
             "name": "02:42:ac:11:00:02",
-            "nickName": "0cf0c90fe49a",
+            "nickName": "f3f23aaec9f7",
             "peers": [
                 {
                     "name": "02:42:ac:11:00:02",
-                    "nickName": "0cf0c90fe49a",
-                    "uid": 13114587996239835091
+                    "nickName": "f3f23aaec9f7",
+                    "uid": 12803494263609231963
                 }
             ]
         },
-        "uptime": "2017-09-29T02:07:35.471991754Z",
+        "uptime": "2019-01-30T17:25:15.3904147Z",
         "versionInfo": {
             "branch": "HEAD",
             "buildDate": "20170928-09:18:44",

--- a/internal/mock/0.9.0/metrics
+++ b/internal/mock/0.9.0/metrics
@@ -1,0 +1,424 @@
+# HELP alertmanager_alerts_invalid_total The total number of received alerts that were invalid.
+# TYPE alertmanager_alerts_invalid_total counter
+alertmanager_alerts_invalid_total 0
+# HELP alertmanager_alerts_received_total The total number of received alerts.
+# TYPE alertmanager_alerts_received_total counter
+alertmanager_alerts_received_total{status="firing"} 60
+# HELP alertmanager_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which alertmanager was built.
+# TYPE alertmanager_build_info gauge
+alertmanager_build_info{branch="HEAD",goversion="go1.8.3",revision="1535a52116eeb188403c0273aca0d25552b5c859",version="0.9.0"} 1
+# HELP alertmanager_config_hash Hash of the currently loaded alertmanager configuration.
+# TYPE alertmanager_config_hash gauge
+alertmanager_config_hash 6.2645753076152e+13
+# HELP alertmanager_config_last_reload_success_timestamp_seconds Timestamp of the last successful configuration reload.
+# TYPE alertmanager_config_last_reload_success_timestamp_seconds gauge
+alertmanager_config_last_reload_success_timestamp_seconds 1.548869115e+09
+# HELP alertmanager_config_last_reload_successful Whether the last configuration reload attempt was successful.
+# TYPE alertmanager_config_last_reload_successful gauge
+alertmanager_config_last_reload_successful 1
+# HELP alertmanager_nflog_gc_duration_seconds Duration of the last notification log garbage collection cycle.
+# TYPE alertmanager_nflog_gc_duration_seconds summary
+alertmanager_nflog_gc_duration_seconds{quantile="0.5"} NaN
+alertmanager_nflog_gc_duration_seconds{quantile="0.9"} NaN
+alertmanager_nflog_gc_duration_seconds{quantile="0.99"} NaN
+alertmanager_nflog_gc_duration_seconds_sum 0
+alertmanager_nflog_gc_duration_seconds_count 0
+# HELP alertmanager_nflog_queries_total Number of notification log queries were received.
+# TYPE alertmanager_nflog_queries_total counter
+alertmanager_nflog_queries_total 0
+# HELP alertmanager_nflog_query_duration_seconds Duration of notification log query evaluation.
+# TYPE alertmanager_nflog_query_duration_seconds histogram
+alertmanager_nflog_query_duration_seconds_bucket{le="0.005"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.01"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.025"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.05"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.1"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.25"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="1"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="2.5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="10"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="+Inf"} 0
+alertmanager_nflog_query_duration_seconds_sum 0
+alertmanager_nflog_query_duration_seconds_count 0
+# HELP alertmanager_nflog_query_errors_total Number notification log received queries that failed.
+# TYPE alertmanager_nflog_query_errors_total counter
+alertmanager_nflog_query_errors_total 0
+# HELP alertmanager_nflog_snapshot_duration_seconds Duration of the last notification log snapshot.
+# TYPE alertmanager_nflog_snapshot_duration_seconds summary
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.5"} NaN
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.9"} NaN
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.99"} NaN
+alertmanager_nflog_snapshot_duration_seconds_sum 0
+alertmanager_nflog_snapshot_duration_seconds_count 0
+# HELP alertmanager_silences_gc_duration_seconds Duration of the last silence garbage collection cycle.
+# TYPE alertmanager_silences_gc_duration_seconds summary
+alertmanager_silences_gc_duration_seconds{quantile="0.5"} NaN
+alertmanager_silences_gc_duration_seconds{quantile="0.9"} NaN
+alertmanager_silences_gc_duration_seconds{quantile="0.99"} NaN
+alertmanager_silences_gc_duration_seconds_sum 0
+alertmanager_silences_gc_duration_seconds_count 0
+# HELP alertmanager_silences_queries_total How many silence queries were received.
+# TYPE alertmanager_silences_queries_total counter
+alertmanager_silences_queries_total 48
+# HELP alertmanager_silences_query_duration_seconds Duration of silence query evaluation.
+# TYPE alertmanager_silences_query_duration_seconds histogram
+alertmanager_silences_query_duration_seconds_bucket{le="0.005"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.01"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.025"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.05"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.1"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.25"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.5"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="1"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="2.5"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="5"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="10"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="+Inf"} 48
+alertmanager_silences_query_duration_seconds_sum 0.0015087000000000002
+alertmanager_silences_query_duration_seconds_count 48
+# HELP alertmanager_silences_query_errors_total How many silence received queries did not succeed.
+# TYPE alertmanager_silences_query_errors_total counter
+alertmanager_silences_query_errors_total 0
+# HELP alertmanager_silences_snapshot_duration_seconds Duration of the last silence snapshot.
+# TYPE alertmanager_silences_snapshot_duration_seconds summary
+alertmanager_silences_snapshot_duration_seconds{quantile="0.5"} NaN
+alertmanager_silences_snapshot_duration_seconds{quantile="0.9"} NaN
+alertmanager_silences_snapshot_duration_seconds{quantile="0.99"} NaN
+alertmanager_silences_snapshot_duration_seconds_sum 0
+alertmanager_silences_snapshot_duration_seconds_count 0
+# HELP go_gc_duration_seconds A summary of the GC invocation durations.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0"} 0.0006092
+go_gc_duration_seconds{quantile="0.25"} 0.0006092
+go_gc_duration_seconds{quantile="0.5"} 0.0006092
+go_gc_duration_seconds{quantile="0.75"} 0.0006092
+go_gc_duration_seconds{quantile="1"} 0.0006092
+go_gc_duration_seconds_sum 0.0006092
+go_gc_duration_seconds_count 1
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 65
+# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+# TYPE go_memstats_alloc_bytes gauge
+go_memstats_alloc_bytes 4.917296e+06
+# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
+# TYPE go_memstats_alloc_bytes_total counter
+go_memstats_alloc_bytes_total 5.550088e+06
+# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
+# TYPE go_memstats_buck_hash_sys_bytes gauge
+go_memstats_buck_hash_sys_bytes 1.44394e+06
+# HELP go_memstats_frees_total Total number of frees.
+# TYPE go_memstats_frees_total counter
+go_memstats_frees_total 5224
+# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+# TYPE go_memstats_gc_sys_bytes gauge
+go_memstats_gc_sys_bytes 389120
+# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
+# TYPE go_memstats_heap_alloc_bytes gauge
+go_memstats_heap_alloc_bytes 4.917296e+06
+# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
+# TYPE go_memstats_heap_idle_bytes gauge
+go_memstats_heap_idle_bytes 1.007616e+06
+# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
+# TYPE go_memstats_heap_inuse_bytes gauge
+go_memstats_heap_inuse_bytes 5.578752e+06
+# HELP go_memstats_heap_objects Number of allocated objects.
+# TYPE go_memstats_heap_objects gauge
+go_memstats_heap_objects 18094
+# HELP go_memstats_heap_released_bytes_total Total number of heap bytes released to OS.
+# TYPE go_memstats_heap_released_bytes_total counter
+go_memstats_heap_released_bytes_total 0
+# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
+# TYPE go_memstats_heap_sys_bytes gauge
+go_memstats_heap_sys_bytes 6.586368e+06
+# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
+# TYPE go_memstats_last_gc_time_seconds gauge
+go_memstats_last_gc_time_seconds 1.5488691154000401e+09
+# HELP go_memstats_lookups_total Total number of pointer lookups.
+# TYPE go_memstats_lookups_total counter
+go_memstats_lookups_total 32
+# HELP go_memstats_mallocs_total Total number of mallocs.
+# TYPE go_memstats_mallocs_total counter
+go_memstats_mallocs_total 23318
+# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
+# TYPE go_memstats_mcache_inuse_bytes gauge
+go_memstats_mcache_inuse_bytes 2400
+# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
+# TYPE go_memstats_mcache_sys_bytes gauge
+go_memstats_mcache_sys_bytes 16384
+# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
+# TYPE go_memstats_mspan_inuse_bytes gauge
+go_memstats_mspan_inuse_bytes 61104
+# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
+# TYPE go_memstats_mspan_sys_bytes gauge
+go_memstats_mspan_sys_bytes 65536
+# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
+# TYPE go_memstats_next_gc_bytes gauge
+go_memstats_next_gc_bytes 7.171136e+06
+# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
+# TYPE go_memstats_other_sys_bytes gauge
+go_memstats_other_sys_bytes 745620
+# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
+# TYPE go_memstats_stack_inuse_bytes gauge
+go_memstats_stack_inuse_bytes 753664
+# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
+# TYPE go_memstats_stack_sys_bytes gauge
+go_memstats_stack_sys_bytes 753664
+# HELP go_memstats_sys_bytes Number of bytes obtained by system. Sum of all system allocations.
+# TYPE go_memstats_sys_bytes gauge
+go_memstats_sys_bytes 1.0000632e+07
+# HELP http_request_duration_microseconds The HTTP request latencies in microseconds.
+# TYPE http_request_duration_microseconds summary
+http_request_duration_microseconds{handler="add_alerts",quantile="0.5"} 606.8
+http_request_duration_microseconds{handler="add_alerts",quantile="0.9"} 869.7
+http_request_duration_microseconds{handler="add_alerts",quantile="0.99"} 869.7
+http_request_duration_microseconds_sum{handler="add_alerts"} 4175.700000000001
+http_request_duration_microseconds_count{handler="add_alerts"} 5
+http_request_duration_microseconds{handler="add_silence",quantile="0.5"} 151.4
+http_request_duration_microseconds{handler="add_silence",quantile="0.9"} 183.3
+http_request_duration_microseconds{handler="add_silence",quantile="0.99"} 183.3
+http_request_duration_microseconds_sum{handler="add_silence"} 711.5
+http_request_duration_microseconds_count{handler="add_silence"} 3
+http_request_duration_microseconds{handler="alert_groups",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="alert_groups",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="alert_groups",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="alert_groups"} 0
+http_request_duration_microseconds_count{handler="alert_groups"} 0
+http_request_duration_microseconds{handler="app",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="app",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="app",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="app"} 0
+http_request_duration_microseconds_count{handler="app"} 0
+http_request_duration_microseconds{handler="del_silence",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="del_silence",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="del_silence",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="del_silence"} 0
+http_request_duration_microseconds_count{handler="del_silence"} 0
+http_request_duration_microseconds{handler="get_silence",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="get_silence",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="get_silence",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="get_silence"} 0
+http_request_duration_microseconds_count{handler="get_silence"} 0
+http_request_duration_microseconds{handler="index",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="index",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="index",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="index"} 0
+http_request_duration_microseconds_count{handler="index"} 0
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="legacy_add_alerts"} 0
+http_request_duration_microseconds_count{handler="legacy_add_alerts"} 0
+http_request_duration_microseconds{handler="lib_files",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="lib_files",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="lib_files",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="lib_files"} 0
+http_request_duration_microseconds_count{handler="lib_files"} 0
+http_request_duration_microseconds{handler="list_alerts",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="list_alerts",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="list_alerts",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="list_alerts"} 0
+http_request_duration_microseconds_count{handler="list_alerts"} 0
+http_request_duration_microseconds{handler="list_silences",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="list_silences",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="list_silences",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="list_silences"} 0
+http_request_duration_microseconds_count{handler="list_silences"} 0
+http_request_duration_microseconds{handler="options",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="options",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="options",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="options"} 0
+http_request_duration_microseconds_count{handler="options"} 0
+http_request_duration_microseconds{handler="prometheus",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="prometheus",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="prometheus",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="prometheus"} 0
+http_request_duration_microseconds_count{handler="prometheus"} 0
+http_request_duration_microseconds{handler="receivers",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="receivers",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="receivers",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="receivers"} 0
+http_request_duration_microseconds_count{handler="receivers"} 0
+http_request_duration_microseconds{handler="status",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="status",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="status",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="status"} 0
+http_request_duration_microseconds_count{handler="status"} 0
+# HELP http_request_size_bytes The HTTP request sizes in bytes.
+# TYPE http_request_size_bytes summary
+http_request_size_bytes{handler="add_alerts",quantile="0.5"} 2719
+http_request_size_bytes{handler="add_alerts",quantile="0.9"} 2719
+http_request_size_bytes{handler="add_alerts",quantile="0.99"} 2719
+http_request_size_bytes_sum{handler="add_alerts"} 13595
+http_request_size_bytes_count{handler="add_alerts"} 5
+http_request_size_bytes{handler="add_silence",quantile="0.5"} 358
+http_request_size_bytes{handler="add_silence",quantile="0.9"} 360
+http_request_size_bytes{handler="add_silence",quantile="0.99"} 360
+http_request_size_bytes_sum{handler="add_silence"} 1164
+http_request_size_bytes_count{handler="add_silence"} 3
+http_request_size_bytes{handler="alert_groups",quantile="0.5"} NaN
+http_request_size_bytes{handler="alert_groups",quantile="0.9"} NaN
+http_request_size_bytes{handler="alert_groups",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="alert_groups"} 0
+http_request_size_bytes_count{handler="alert_groups"} 0
+http_request_size_bytes{handler="app",quantile="0.5"} NaN
+http_request_size_bytes{handler="app",quantile="0.9"} NaN
+http_request_size_bytes{handler="app",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="app"} 0
+http_request_size_bytes_count{handler="app"} 0
+http_request_size_bytes{handler="del_silence",quantile="0.5"} NaN
+http_request_size_bytes{handler="del_silence",quantile="0.9"} NaN
+http_request_size_bytes{handler="del_silence",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="del_silence"} 0
+http_request_size_bytes_count{handler="del_silence"} 0
+http_request_size_bytes{handler="get_silence",quantile="0.5"} NaN
+http_request_size_bytes{handler="get_silence",quantile="0.9"} NaN
+http_request_size_bytes{handler="get_silence",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="get_silence"} 0
+http_request_size_bytes_count{handler="get_silence"} 0
+http_request_size_bytes{handler="index",quantile="0.5"} NaN
+http_request_size_bytes{handler="index",quantile="0.9"} NaN
+http_request_size_bytes{handler="index",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="index"} 0
+http_request_size_bytes_count{handler="index"} 0
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="legacy_add_alerts"} 0
+http_request_size_bytes_count{handler="legacy_add_alerts"} 0
+http_request_size_bytes{handler="lib_files",quantile="0.5"} NaN
+http_request_size_bytes{handler="lib_files",quantile="0.9"} NaN
+http_request_size_bytes{handler="lib_files",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="lib_files"} 0
+http_request_size_bytes_count{handler="lib_files"} 0
+http_request_size_bytes{handler="list_alerts",quantile="0.5"} NaN
+http_request_size_bytes{handler="list_alerts",quantile="0.9"} NaN
+http_request_size_bytes{handler="list_alerts",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="list_alerts"} 0
+http_request_size_bytes_count{handler="list_alerts"} 0
+http_request_size_bytes{handler="list_silences",quantile="0.5"} NaN
+http_request_size_bytes{handler="list_silences",quantile="0.9"} NaN
+http_request_size_bytes{handler="list_silences",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="list_silences"} 0
+http_request_size_bytes_count{handler="list_silences"} 0
+http_request_size_bytes{handler="options",quantile="0.5"} NaN
+http_request_size_bytes{handler="options",quantile="0.9"} NaN
+http_request_size_bytes{handler="options",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="options"} 0
+http_request_size_bytes_count{handler="options"} 0
+http_request_size_bytes{handler="prometheus",quantile="0.5"} NaN
+http_request_size_bytes{handler="prometheus",quantile="0.9"} NaN
+http_request_size_bytes{handler="prometheus",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="prometheus"} 0
+http_request_size_bytes_count{handler="prometheus"} 0
+http_request_size_bytes{handler="receivers",quantile="0.5"} NaN
+http_request_size_bytes{handler="receivers",quantile="0.9"} NaN
+http_request_size_bytes{handler="receivers",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="receivers"} 0
+http_request_size_bytes_count{handler="receivers"} 0
+http_request_size_bytes{handler="status",quantile="0.5"} NaN
+http_request_size_bytes{handler="status",quantile="0.9"} NaN
+http_request_size_bytes{handler="status",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="status"} 0
+http_request_size_bytes_count{handler="status"} 0
+# HELP http_requests_total Total number of HTTP requests made.
+# TYPE http_requests_total counter
+http_requests_total{code="200",handler="add_alerts",method="post"} 5
+http_requests_total{code="200",handler="add_silence",method="post"} 3
+# HELP http_response_size_bytes The HTTP response sizes in bytes.
+# TYPE http_response_size_bytes summary
+http_response_size_bytes{handler="add_alerts",quantile="0.5"} 20
+http_response_size_bytes{handler="add_alerts",quantile="0.9"} 20
+http_response_size_bytes{handler="add_alerts",quantile="0.99"} 20
+http_response_size_bytes_sum{handler="add_alerts"} 100
+http_response_size_bytes_count{handler="add_alerts"} 5
+http_response_size_bytes{handler="add_silence",quantile="0.5"} 80
+http_response_size_bytes{handler="add_silence",quantile="0.9"} 80
+http_response_size_bytes{handler="add_silence",quantile="0.99"} 80
+http_response_size_bytes_sum{handler="add_silence"} 240
+http_response_size_bytes_count{handler="add_silence"} 3
+http_response_size_bytes{handler="alert_groups",quantile="0.5"} NaN
+http_response_size_bytes{handler="alert_groups",quantile="0.9"} NaN
+http_response_size_bytes{handler="alert_groups",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="alert_groups"} 0
+http_response_size_bytes_count{handler="alert_groups"} 0
+http_response_size_bytes{handler="app",quantile="0.5"} NaN
+http_response_size_bytes{handler="app",quantile="0.9"} NaN
+http_response_size_bytes{handler="app",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="app"} 0
+http_response_size_bytes_count{handler="app"} 0
+http_response_size_bytes{handler="del_silence",quantile="0.5"} NaN
+http_response_size_bytes{handler="del_silence",quantile="0.9"} NaN
+http_response_size_bytes{handler="del_silence",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="del_silence"} 0
+http_response_size_bytes_count{handler="del_silence"} 0
+http_response_size_bytes{handler="get_silence",quantile="0.5"} NaN
+http_response_size_bytes{handler="get_silence",quantile="0.9"} NaN
+http_response_size_bytes{handler="get_silence",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="get_silence"} 0
+http_response_size_bytes_count{handler="get_silence"} 0
+http_response_size_bytes{handler="index",quantile="0.5"} NaN
+http_response_size_bytes{handler="index",quantile="0.9"} NaN
+http_response_size_bytes{handler="index",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="index"} 0
+http_response_size_bytes_count{handler="index"} 0
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="legacy_add_alerts"} 0
+http_response_size_bytes_count{handler="legacy_add_alerts"} 0
+http_response_size_bytes{handler="lib_files",quantile="0.5"} NaN
+http_response_size_bytes{handler="lib_files",quantile="0.9"} NaN
+http_response_size_bytes{handler="lib_files",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="lib_files"} 0
+http_response_size_bytes_count{handler="lib_files"} 0
+http_response_size_bytes{handler="list_alerts",quantile="0.5"} NaN
+http_response_size_bytes{handler="list_alerts",quantile="0.9"} NaN
+http_response_size_bytes{handler="list_alerts",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="list_alerts"} 0
+http_response_size_bytes_count{handler="list_alerts"} 0
+http_response_size_bytes{handler="list_silences",quantile="0.5"} NaN
+http_response_size_bytes{handler="list_silences",quantile="0.9"} NaN
+http_response_size_bytes{handler="list_silences",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="list_silences"} 0
+http_response_size_bytes_count{handler="list_silences"} 0
+http_response_size_bytes{handler="options",quantile="0.5"} NaN
+http_response_size_bytes{handler="options",quantile="0.9"} NaN
+http_response_size_bytes{handler="options",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="options"} 0
+http_response_size_bytes_count{handler="options"} 0
+http_response_size_bytes{handler="prometheus",quantile="0.5"} NaN
+http_response_size_bytes{handler="prometheus",quantile="0.9"} NaN
+http_response_size_bytes{handler="prometheus",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="prometheus"} 0
+http_response_size_bytes_count{handler="prometheus"} 0
+http_response_size_bytes{handler="receivers",quantile="0.5"} NaN
+http_response_size_bytes{handler="receivers",quantile="0.9"} NaN
+http_response_size_bytes{handler="receivers",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="receivers"} 0
+http_response_size_bytes_count{handler="receivers"} 0
+http_response_size_bytes{handler="status",quantile="0.5"} NaN
+http_response_size_bytes{handler="status",quantile="0.9"} NaN
+http_response_size_bytes{handler="status",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="status"} 0
+http_response_size_bytes_count{handler="status"} 0
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 0.11
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+process_max_fds 1.048576e+06
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+process_open_fds 8
+# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes 1.1005952e+07
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds 1.54886911388e+09
+# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE process_virtual_memory_bytes gauge
+process_virtual_memory_bytes 2.0168704e+07

--- a/internal/mock/0.9.1/api/v1/alerts/groups
+++ b/internal/mock/0.9.1/api/v1/alerts/groups
@@ -19,7 +19,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-10-02T16:01:01.80239748Z",
+                            "startsAt": "2019-01-30T17:26:41.8209205Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -49,6 +49,27 @@
                     "alerts": [
                         {
                             "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "fingerprint": "5cb0dd95e7f3d9c0",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "HTTP_Probe_Failed",
+                                "cluster": "dev",
+                                "instance": "web2",
+                                "job": "node_exporter"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:26:41.8209205Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
                                 "help": "Example help annotation",
                                 "summary": "Example summary",
                                 "url": "http://localhost/example.html"
@@ -63,34 +84,13 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-10-02T16:01:01.80239748Z",
+                            "startsAt": "2019-01-30T17:26:41.8209205Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "4a5260d7-00ad-4360-a5dd-0899cae6a3d9"
+                                    "3061a5f6-77b5-488d-99a2-6de08a63dc3c"
                                 ],
                                 "state": "suppressed"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "fingerprint": "5cb0dd95e7f3d9c0",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "HTTP_Probe_Failed",
-                                "cluster": "dev",
-                                "instance": "web2",
-                                "job": "node_exporter"
-                            },
-                            "receivers": null,
-                            "startsAt": "2017-10-02T16:01:01.80239748Z",
-                            "status": {
-                                "inhibitedBy": [],
-                                "silencedBy": [],
-                                "state": "active"
                             }
                         }
                     ],
@@ -119,6 +119,27 @@
                                 "summary": "Example summary"
                             },
                             "endsAt": "0001-01-01T00:00:00Z",
+                            "fingerprint": "3bdb8b68bdce2ae0",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "prod",
+                                "instance": "server2",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:26:41.8209205Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
                             "fingerprint": "24e4121619386f95",
                             "generatorURL": "localhost/prometheus",
                             "labels": {
@@ -128,7 +149,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-10-02T16:01:01.80239748Z",
+                            "startsAt": "2019-01-30T17:26:41.8209205Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -149,7 +170,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-10-02T16:01:01.80239748Z",
+                            "startsAt": "2019-01-30T17:26:41.8209205Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -170,7 +191,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-10-02T16:01:01.80239748Z",
+                            "startsAt": "2019-01-30T17:26:41.8209205Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -191,11 +212,11 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-10-02T16:01:01.80239748Z",
+                            "startsAt": "2019-01-30T17:26:41.8209205Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "fb4b9562-b25f-4038-acf5-87ecd1b79d38"
+                                    "04184ee5-4d31-4080-8fe1-6fed238369f0"
                                 ],
                                 "state": "suppressed"
                             }
@@ -214,12 +235,12 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-10-02T16:01:01.80239748Z",
+                            "startsAt": "2019-01-30T17:26:41.8209205Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "fb4b9562-b25f-4038-acf5-87ecd1b79d38",
-                                    "814fece5-30cc-46bd-979b-76d58737b1ca"
+                                    "04184ee5-4d31-4080-8fe1-6fed238369f0",
+                                    "6e342416-38b0-4bc7-98af-0e5b695cc1b3"
                                 ],
                                 "state": "suppressed"
                             }
@@ -238,11 +259,11 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-10-02T16:01:01.80239748Z",
+                            "startsAt": "2019-01-30T17:26:41.8209205Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "fb4b9562-b25f-4038-acf5-87ecd1b79d38"
+                                    "04184ee5-4d31-4080-8fe1-6fed238369f0"
                                 ],
                                 "state": "suppressed"
                             }
@@ -262,28 +283,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-10-02T16:01:01.80239748Z",
-                            "status": {
-                                "inhibitedBy": [],
-                                "silencedBy": [],
-                                "state": "active"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "fingerprint": "3bdb8b68bdce2ae0",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "prod",
-                                "instance": "server2",
-                                "job": "node_ping"
-                            },
-                            "receivers": null,
-                            "startsAt": "2017-10-02T16:01:01.80239748Z",
+                            "startsAt": "2019-01-30T17:26:41.8209205Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -326,7 +326,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-10-02T16:01:01.80239748Z",
+                            "startsAt": "2019-01-30T17:26:41.8209205Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -369,7 +369,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-10-02T16:01:01.80239748Z",
+                            "startsAt": "2019-01-30T17:26:41.8209205Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -402,27 +402,6 @@
                     "alerts": [
                         {
                             "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "fingerprint": "5cb0dd95e7f3d9c0",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "HTTP_Probe_Failed",
-                                "cluster": "dev",
-                                "instance": "web2",
-                                "job": "node_exporter"
-                            },
-                            "receivers": null,
-                            "startsAt": "2017-10-02T16:01:01.80239748Z",
-                            "status": {
-                                "inhibitedBy": [],
-                                "silencedBy": [],
-                                "state": "active"
-                            }
-                        },
-                        {
-                            "annotations": {
                                 "help": "Example help annotation",
                                 "summary": "Example summary",
                                 "url": "http://localhost/example.html"
@@ -437,13 +416,34 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-10-02T16:01:01.80239748Z",
+                            "startsAt": "2019-01-30T17:26:41.8209205Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "4a5260d7-00ad-4360-a5dd-0899cae6a3d9"
+                                    "3061a5f6-77b5-488d-99a2-6de08a63dc3c"
                                 ],
                                 "state": "suppressed"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
+                            "fingerprint": "5cb0dd95e7f3d9c0",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "HTTP_Probe_Failed",
+                                "cluster": "dev",
+                                "instance": "web2",
+                                "job": "node_exporter"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:26:41.8209205Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
                             }
                         }
                     ],
@@ -475,6 +475,29 @@
                                 "summary": "Example summary"
                             },
                             "endsAt": "0001-01-01T00:00:00Z",
+                            "fingerprint": "af9d8f2f0ccb3970",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "dev",
+                                "instance": "server8",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:26:41.8209205Z",
+                            "status": {
+                                "inhibitedBy": null,
+                                "silencedBy": [
+                                    "04184ee5-4d31-4080-8fe1-6fed238369f0"
+                                ],
+                                "state": "suppressed"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
                             "fingerprint": "0967807e4073b606",
                             "generatorURL": "localhost/prometheus",
                             "labels": {
@@ -484,11 +507,11 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-10-02T16:01:01.80239748Z",
+                            "startsAt": "2019-01-30T17:26:41.8209205Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "fb4b9562-b25f-4038-acf5-87ecd1b79d38"
+                                    "04184ee5-4d31-4080-8fe1-6fed238369f0"
                                 ],
                                 "state": "suppressed"
                             }
@@ -507,35 +530,12 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-10-02T16:01:01.80239748Z",
+                            "startsAt": "2019-01-30T17:26:41.8209205Z",
                             "status": {
                                 "inhibitedBy": null,
                                 "silencedBy": [
-                                    "fb4b9562-b25f-4038-acf5-87ecd1b79d38",
-                                    "814fece5-30cc-46bd-979b-76d58737b1ca"
-                                ],
-                                "state": "suppressed"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "fingerprint": "af9d8f2f0ccb3970",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "dev",
-                                "instance": "server8",
-                                "job": "node_ping"
-                            },
-                            "receivers": null,
-                            "startsAt": "2017-10-02T16:01:01.80239748Z",
-                            "status": {
-                                "inhibitedBy": null,
-                                "silencedBy": [
-                                    "fb4b9562-b25f-4038-acf5-87ecd1b79d38"
+                                    "04184ee5-4d31-4080-8fe1-6fed238369f0",
+                                    "6e342416-38b0-4bc7-98af-0e5b695cc1b3"
                                 ],
                                 "state": "suppressed"
                             }
@@ -579,7 +579,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-10-02T16:01:01.80239748Z",
+                            "startsAt": "2019-01-30T17:26:41.8209205Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -600,7 +600,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-10-02T16:01:01.80239748Z",
+                            "startsAt": "2019-01-30T17:26:41.8209205Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -610,9 +610,9 @@
                     ],
                     "routeOpts": {
                         "groupBy": [
-                            "service",
                             "alertname",
-                            "cluster"
+                            "cluster",
+                            "service"
                         ],
                         "groupInterval": 35000000000,
                         "groupWait": 15000000000,
@@ -636,6 +636,27 @@
                                 "summary": "Example summary"
                             },
                             "endsAt": "0001-01-01T00:00:00Z",
+                            "fingerprint": "24e4121619386f95",
+                            "generatorURL": "localhost/prometheus",
+                            "labels": {
+                                "alertname": "Host_Down",
+                                "cluster": "staging",
+                                "instance": "server3",
+                                "job": "node_ping"
+                            },
+                            "receivers": null,
+                            "startsAt": "2019-01-30T17:26:41.8209205Z",
+                            "status": {
+                                "inhibitedBy": [],
+                                "silencedBy": [],
+                                "state": "active"
+                            }
+                        },
+                        {
+                            "annotations": {
+                                "summary": "Example summary"
+                            },
+                            "endsAt": "0001-01-01T00:00:00Z",
                             "fingerprint": "d9067fcc9686d942",
                             "generatorURL": "localhost/prometheus",
                             "labels": {
@@ -645,7 +666,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-10-02T16:01:01.80239748Z",
+                            "startsAt": "2019-01-30T17:26:41.8209205Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -666,28 +687,7 @@
                                 "job": "node_ping"
                             },
                             "receivers": null,
-                            "startsAt": "2017-10-02T16:01:01.80239748Z",
-                            "status": {
-                                "inhibitedBy": [],
-                                "silencedBy": [],
-                                "state": "active"
-                            }
-                        },
-                        {
-                            "annotations": {
-                                "summary": "Example summary"
-                            },
-                            "endsAt": "0001-01-01T00:00:00Z",
-                            "fingerprint": "24e4121619386f95",
-                            "generatorURL": "localhost/prometheus",
-                            "labels": {
-                                "alertname": "Host_Down",
-                                "cluster": "staging",
-                                "instance": "server3",
-                                "job": "node_ping"
-                            },
-                            "receivers": null,
-                            "startsAt": "2017-10-02T16:01:01.80239748Z",
+                            "startsAt": "2019-01-30T17:26:41.8209205Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],
@@ -733,7 +733,7 @@
                                 "job": "node_exporter"
                             },
                             "receivers": null,
-                            "startsAt": "2017-10-02T16:01:01.80239748Z",
+                            "startsAt": "2019-01-30T17:26:41.8209205Z",
                             "status": {
                                 "inhibitedBy": [],
                                 "silencedBy": [],

--- a/internal/mock/0.9.1/api/v1/silences
+++ b/internal/mock/0.9.1/api/v1/silences
@@ -4,7 +4,7 @@
             "comment": "Silenced instance",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "4a5260d7-00ad-4360-a5dd-0899cae6a3d9",
+            "id": "3061a5f6-77b5-488d-99a2-6de08a63dc3c",
             "matchers": [
                 {
                     "isRegex": false,
@@ -12,17 +12,17 @@
                     "value": "web1"
                 }
             ],
-            "startsAt": "2017-10-02T16:01:01.794397064Z",
+            "startsAt": "2019-01-30T17:26:41.8083131Z",
             "status": {
                 "state": "active"
             },
-            "updatedAt": "2017-10-02T16:01:01.794405438Z"
+            "updatedAt": "2019-01-30T17:26:41.8083385Z"
         },
         {
             "comment": "Silenced Host_Down alerts in the dev cluster",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "fb4b9562-b25f-4038-acf5-87ecd1b79d38",
+            "id": "04184ee5-4d31-4080-8fe1-6fed238369f0",
             "matchers": [
                 {
                     "isRegex": false,
@@ -35,17 +35,17 @@
                     "value": "dev"
                 }
             ],
-            "startsAt": "2017-10-02T16:01:01.797468963Z",
+            "startsAt": "2019-01-30T17:26:41.813131Z",
             "status": {
                 "state": "active"
             },
-            "updatedAt": "2017-10-02T16:01:01.797474143Z"
+            "updatedAt": "2019-01-30T17:26:41.8131487Z"
         },
         {
             "comment": "Silenced server7",
             "createdBy": "john@example.com",
             "endsAt": "2063-01-01T00:00:00Z",
-            "id": "814fece5-30cc-46bd-979b-76d58737b1ca",
+            "id": "6e342416-38b0-4bc7-98af-0e5b695cc1b3",
             "matchers": [
                 {
                     "isRegex": false,
@@ -53,11 +53,11 @@
                     "value": "server7"
                 }
             ],
-            "startsAt": "2017-10-02T16:01:01.799545901Z",
+            "startsAt": "2019-01-30T17:26:41.8168937Z",
             "status": {
                 "state": "active"
             },
-            "updatedAt": "2017-10-02T16:01:01.799551207Z"
+            "updatedAt": "2019-01-30T17:26:41.8169161Z"
         }
     ],
     "status": "success"

--- a/internal/mock/0.9.1/api/v1/status
+++ b/internal/mock/0.9.1/api/v1/status
@@ -73,16 +73,16 @@
         "configYAML": "global:\n  resolve_timeout: 5m\n  smtp_require_tls: true\n  pagerduty_url: https://events.pagerduty.com/generic/2010-04-15/create_event.json\n  hipchat_url: https://api.hipchat.com/\n  opsgenie_api_host: https://api.opsgenie.com/\n  victorops_api_url: https://alert.victorops.com/integrations/generic/20131114/alert/\nroute:\n  receiver: default\n  group_by:\n  - alertname\n  routes:\n  - receiver: by-cluster-service\n    group_by:\n    - alertname\n    - cluster\n    - service\n    match_re:\n      alertname: ^(?:.*)$\n    continue: true\n  - receiver: by-name\n    group_by:\n    - alertname\n    match_re:\n      alertname: ^(?:.*)$\n    continue: true\n  group_wait: 15s\n  group_interval: 35s\n  repeat_interval: 999h\ninhibit_rules:\n- source_match:\n    severity: critical\n  target_match:\n    severity: warning\n  equal:\n  - alertname\n  - cluster\n  - service\nreceivers:\n- name: default\n- name: by-cluster-service\n- name: by-name\ntemplates: []\n",
         "meshStatus": {
             "name": "02:42:ac:11:00:02",
-            "nickName": "3e1798e98d1f",
+            "nickName": "2e6944c9dc72",
             "peers": [
                 {
                     "name": "02:42:ac:11:00:02",
-                    "nickName": "3e1798e98d1f",
-                    "uid": 14551164321217568
+                    "nickName": "2e6944c9dc72",
+                    "uid": 9437896516128275487
                 }
             ]
         },
-        "uptime": "2017-10-02T16:00:46.653917105Z",
+        "uptime": "2019-01-30T17:26:26.6360918Z",
         "versionInfo": {
             "branch": "HEAD",
             "buildDate": "20170929-12:59:03",

--- a/internal/mock/0.9.1/metrics
+++ b/internal/mock/0.9.1/metrics
@@ -1,0 +1,424 @@
+# HELP alertmanager_alerts_invalid_total The total number of received alerts that were invalid.
+# TYPE alertmanager_alerts_invalid_total counter
+alertmanager_alerts_invalid_total 0
+# HELP alertmanager_alerts_received_total The total number of received alerts.
+# TYPE alertmanager_alerts_received_total counter
+alertmanager_alerts_received_total{status="firing"} 60
+# HELP alertmanager_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which alertmanager was built.
+# TYPE alertmanager_build_info gauge
+alertmanager_build_info{branch="HEAD",goversion="go1.9",revision="9f5f4b2a516d35cfaf196530b277f1d109254569",version="0.9.1"} 1
+# HELP alertmanager_config_hash Hash of the currently loaded alertmanager configuration.
+# TYPE alertmanager_config_hash gauge
+alertmanager_config_hash 6.2645753076152e+13
+# HELP alertmanager_config_last_reload_success_timestamp_seconds Timestamp of the last successful configuration reload.
+# TYPE alertmanager_config_last_reload_success_timestamp_seconds gauge
+alertmanager_config_last_reload_success_timestamp_seconds 1.548869186e+09
+# HELP alertmanager_config_last_reload_successful Whether the last configuration reload attempt was successful.
+# TYPE alertmanager_config_last_reload_successful gauge
+alertmanager_config_last_reload_successful 1
+# HELP alertmanager_nflog_gc_duration_seconds Duration of the last notification log garbage collection cycle.
+# TYPE alertmanager_nflog_gc_duration_seconds summary
+alertmanager_nflog_gc_duration_seconds{quantile="0.5"} NaN
+alertmanager_nflog_gc_duration_seconds{quantile="0.9"} NaN
+alertmanager_nflog_gc_duration_seconds{quantile="0.99"} NaN
+alertmanager_nflog_gc_duration_seconds_sum 0
+alertmanager_nflog_gc_duration_seconds_count 0
+# HELP alertmanager_nflog_queries_total Number of notification log queries were received.
+# TYPE alertmanager_nflog_queries_total counter
+alertmanager_nflog_queries_total 0
+# HELP alertmanager_nflog_query_duration_seconds Duration of notification log query evaluation.
+# TYPE alertmanager_nflog_query_duration_seconds histogram
+alertmanager_nflog_query_duration_seconds_bucket{le="0.005"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.01"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.025"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.05"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.1"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.25"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="0.5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="1"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="2.5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="5"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="10"} 0
+alertmanager_nflog_query_duration_seconds_bucket{le="+Inf"} 0
+alertmanager_nflog_query_duration_seconds_sum 0
+alertmanager_nflog_query_duration_seconds_count 0
+# HELP alertmanager_nflog_query_errors_total Number notification log received queries that failed.
+# TYPE alertmanager_nflog_query_errors_total counter
+alertmanager_nflog_query_errors_total 0
+# HELP alertmanager_nflog_snapshot_duration_seconds Duration of the last notification log snapshot.
+# TYPE alertmanager_nflog_snapshot_duration_seconds summary
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.5"} NaN
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.9"} NaN
+alertmanager_nflog_snapshot_duration_seconds{quantile="0.99"} NaN
+alertmanager_nflog_snapshot_duration_seconds_sum 0
+alertmanager_nflog_snapshot_duration_seconds_count 0
+# HELP alertmanager_silences_gc_duration_seconds Duration of the last silence garbage collection cycle.
+# TYPE alertmanager_silences_gc_duration_seconds summary
+alertmanager_silences_gc_duration_seconds{quantile="0.5"} NaN
+alertmanager_silences_gc_duration_seconds{quantile="0.9"} NaN
+alertmanager_silences_gc_duration_seconds{quantile="0.99"} NaN
+alertmanager_silences_gc_duration_seconds_sum 0
+alertmanager_silences_gc_duration_seconds_count 0
+# HELP alertmanager_silences_queries_total How many silence queries were received.
+# TYPE alertmanager_silences_queries_total counter
+alertmanager_silences_queries_total 48
+# HELP alertmanager_silences_query_duration_seconds Duration of silence query evaluation.
+# TYPE alertmanager_silences_query_duration_seconds histogram
+alertmanager_silences_query_duration_seconds_bucket{le="0.005"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.01"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.025"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.05"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.1"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.25"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="0.5"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="1"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="2.5"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="5"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="10"} 48
+alertmanager_silences_query_duration_seconds_bucket{le="+Inf"} 48
+alertmanager_silences_query_duration_seconds_sum 0.0034855999999999984
+alertmanager_silences_query_duration_seconds_count 48
+# HELP alertmanager_silences_query_errors_total How many silence received queries did not succeed.
+# TYPE alertmanager_silences_query_errors_total counter
+alertmanager_silences_query_errors_total 0
+# HELP alertmanager_silences_snapshot_duration_seconds Duration of the last silence snapshot.
+# TYPE alertmanager_silences_snapshot_duration_seconds summary
+alertmanager_silences_snapshot_duration_seconds{quantile="0.5"} NaN
+alertmanager_silences_snapshot_duration_seconds{quantile="0.9"} NaN
+alertmanager_silences_snapshot_duration_seconds{quantile="0.99"} NaN
+alertmanager_silences_snapshot_duration_seconds_sum 0
+alertmanager_silences_snapshot_duration_seconds_count 0
+# HELP go_gc_duration_seconds A summary of the GC invocation durations.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0"} 0.0003423
+go_gc_duration_seconds{quantile="0.25"} 0.0003423
+go_gc_duration_seconds{quantile="0.5"} 0.0003423
+go_gc_duration_seconds{quantile="0.75"} 0.0003423
+go_gc_duration_seconds{quantile="1"} 0.0003423
+go_gc_duration_seconds_sum 0.0003423
+go_gc_duration_seconds_count 1
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 62
+# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+# TYPE go_memstats_alloc_bytes gauge
+go_memstats_alloc_bytes 4.998808e+06
+# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
+# TYPE go_memstats_alloc_bytes_total counter
+go_memstats_alloc_bytes_total 5.570112e+06
+# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
+# TYPE go_memstats_buck_hash_sys_bytes gauge
+go_memstats_buck_hash_sys_bytes 1.444872e+06
+# HELP go_memstats_frees_total Total number of frees.
+# TYPE go_memstats_frees_total counter
+go_memstats_frees_total 4557
+# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+# TYPE go_memstats_gc_sys_bytes gauge
+go_memstats_gc_sys_bytes 471040
+# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
+# TYPE go_memstats_heap_alloc_bytes gauge
+go_memstats_heap_alloc_bytes 4.998808e+06
+# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
+# TYPE go_memstats_heap_idle_bytes gauge
+go_memstats_heap_idle_bytes 655360
+# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
+# TYPE go_memstats_heap_inuse_bytes gauge
+go_memstats_heap_inuse_bytes 5.89824e+06
+# HELP go_memstats_heap_objects Number of allocated objects.
+# TYPE go_memstats_heap_objects gauge
+go_memstats_heap_objects 19021
+# HELP go_memstats_heap_released_bytes_total Total number of heap bytes released to OS.
+# TYPE go_memstats_heap_released_bytes_total counter
+go_memstats_heap_released_bytes_total 0
+# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
+# TYPE go_memstats_heap_sys_bytes gauge
+go_memstats_heap_sys_bytes 6.5536e+06
+# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
+# TYPE go_memstats_last_gc_time_seconds gauge
+go_memstats_last_gc_time_seconds 1.5488692518897934e+09
+# HELP go_memstats_lookups_total Total number of pointer lookups.
+# TYPE go_memstats_lookups_total counter
+go_memstats_lookups_total 40
+# HELP go_memstats_mallocs_total Total number of mallocs.
+# TYPE go_memstats_mallocs_total counter
+go_memstats_mallocs_total 23578
+# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
+# TYPE go_memstats_mcache_inuse_bytes gauge
+go_memstats_mcache_inuse_bytes 3472
+# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
+# TYPE go_memstats_mcache_sys_bytes gauge
+go_memstats_mcache_sys_bytes 16384
+# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
+# TYPE go_memstats_mspan_inuse_bytes gauge
+go_memstats_mspan_inuse_bytes 67032
+# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
+# TYPE go_memstats_mspan_sys_bytes gauge
+go_memstats_mspan_sys_bytes 81920
+# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
+# TYPE go_memstats_next_gc_bytes gauge
+go_memstats_next_gc_bytes 8.987392e+06
+# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
+# TYPE go_memstats_other_sys_bytes gauge
+go_memstats_other_sys_bytes 744688
+# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
+# TYPE go_memstats_stack_inuse_bytes gauge
+go_memstats_stack_inuse_bytes 753664
+# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
+# TYPE go_memstats_stack_sys_bytes gauge
+go_memstats_stack_sys_bytes 753664
+# HELP go_memstats_sys_bytes Number of bytes obtained by system. Sum of all system allocations.
+# TYPE go_memstats_sys_bytes gauge
+go_memstats_sys_bytes 1.0066168e+07
+# HELP http_request_duration_microseconds The HTTP request latencies in microseconds.
+# TYPE http_request_duration_microseconds summary
+http_request_duration_microseconds{handler="add_alerts",quantile="0.5"} 588.7
+http_request_duration_microseconds{handler="add_alerts",quantile="0.9"} 800.9
+http_request_duration_microseconds{handler="add_alerts",quantile="0.99"} 800.9
+http_request_duration_microseconds_sum{handler="add_alerts"} 3668.4
+http_request_duration_microseconds_count{handler="add_alerts"} 5
+http_request_duration_microseconds{handler="add_silence",quantile="0.5"} 185.3
+http_request_duration_microseconds{handler="add_silence",quantile="0.9"} 347
+http_request_duration_microseconds{handler="add_silence",quantile="0.99"} 347
+http_request_duration_microseconds_sum{handler="add_silence"} 999.5
+http_request_duration_microseconds_count{handler="add_silence"} 3
+http_request_duration_microseconds{handler="alert_groups",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="alert_groups",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="alert_groups",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="alert_groups"} 0
+http_request_duration_microseconds_count{handler="alert_groups"} 0
+http_request_duration_microseconds{handler="app",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="app",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="app",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="app"} 0
+http_request_duration_microseconds_count{handler="app"} 0
+http_request_duration_microseconds{handler="del_silence",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="del_silence",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="del_silence",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="del_silence"} 0
+http_request_duration_microseconds_count{handler="del_silence"} 0
+http_request_duration_microseconds{handler="get_silence",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="get_silence",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="get_silence",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="get_silence"} 0
+http_request_duration_microseconds_count{handler="get_silence"} 0
+http_request_duration_microseconds{handler="index",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="index",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="index",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="index"} 0
+http_request_duration_microseconds_count{handler="index"} 0
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="legacy_add_alerts"} 0
+http_request_duration_microseconds_count{handler="legacy_add_alerts"} 0
+http_request_duration_microseconds{handler="lib_files",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="lib_files",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="lib_files",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="lib_files"} 0
+http_request_duration_microseconds_count{handler="lib_files"} 0
+http_request_duration_microseconds{handler="list_alerts",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="list_alerts",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="list_alerts",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="list_alerts"} 0
+http_request_duration_microseconds_count{handler="list_alerts"} 0
+http_request_duration_microseconds{handler="list_silences",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="list_silences",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="list_silences",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="list_silences"} 0
+http_request_duration_microseconds_count{handler="list_silences"} 0
+http_request_duration_microseconds{handler="options",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="options",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="options",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="options"} 0
+http_request_duration_microseconds_count{handler="options"} 0
+http_request_duration_microseconds{handler="prometheus",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="prometheus",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="prometheus",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="prometheus"} 0
+http_request_duration_microseconds_count{handler="prometheus"} 0
+http_request_duration_microseconds{handler="receivers",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="receivers",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="receivers",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="receivers"} 0
+http_request_duration_microseconds_count{handler="receivers"} 0
+http_request_duration_microseconds{handler="status",quantile="0.5"} NaN
+http_request_duration_microseconds{handler="status",quantile="0.9"} NaN
+http_request_duration_microseconds{handler="status",quantile="0.99"} NaN
+http_request_duration_microseconds_sum{handler="status"} 0
+http_request_duration_microseconds_count{handler="status"} 0
+# HELP http_request_size_bytes The HTTP request sizes in bytes.
+# TYPE http_request_size_bytes summary
+http_request_size_bytes{handler="add_alerts",quantile="0.5"} 2719
+http_request_size_bytes{handler="add_alerts",quantile="0.9"} 2719
+http_request_size_bytes{handler="add_alerts",quantile="0.99"} 2719
+http_request_size_bytes_sum{handler="add_alerts"} 13595
+http_request_size_bytes_count{handler="add_alerts"} 5
+http_request_size_bytes{handler="add_silence",quantile="0.5"} 358
+http_request_size_bytes{handler="add_silence",quantile="0.9"} 360
+http_request_size_bytes{handler="add_silence",quantile="0.99"} 360
+http_request_size_bytes_sum{handler="add_silence"} 1164
+http_request_size_bytes_count{handler="add_silence"} 3
+http_request_size_bytes{handler="alert_groups",quantile="0.5"} NaN
+http_request_size_bytes{handler="alert_groups",quantile="0.9"} NaN
+http_request_size_bytes{handler="alert_groups",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="alert_groups"} 0
+http_request_size_bytes_count{handler="alert_groups"} 0
+http_request_size_bytes{handler="app",quantile="0.5"} NaN
+http_request_size_bytes{handler="app",quantile="0.9"} NaN
+http_request_size_bytes{handler="app",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="app"} 0
+http_request_size_bytes_count{handler="app"} 0
+http_request_size_bytes{handler="del_silence",quantile="0.5"} NaN
+http_request_size_bytes{handler="del_silence",quantile="0.9"} NaN
+http_request_size_bytes{handler="del_silence",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="del_silence"} 0
+http_request_size_bytes_count{handler="del_silence"} 0
+http_request_size_bytes{handler="get_silence",quantile="0.5"} NaN
+http_request_size_bytes{handler="get_silence",quantile="0.9"} NaN
+http_request_size_bytes{handler="get_silence",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="get_silence"} 0
+http_request_size_bytes_count{handler="get_silence"} 0
+http_request_size_bytes{handler="index",quantile="0.5"} NaN
+http_request_size_bytes{handler="index",quantile="0.9"} NaN
+http_request_size_bytes{handler="index",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="index"} 0
+http_request_size_bytes_count{handler="index"} 0
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_request_size_bytes{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="legacy_add_alerts"} 0
+http_request_size_bytes_count{handler="legacy_add_alerts"} 0
+http_request_size_bytes{handler="lib_files",quantile="0.5"} NaN
+http_request_size_bytes{handler="lib_files",quantile="0.9"} NaN
+http_request_size_bytes{handler="lib_files",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="lib_files"} 0
+http_request_size_bytes_count{handler="lib_files"} 0
+http_request_size_bytes{handler="list_alerts",quantile="0.5"} NaN
+http_request_size_bytes{handler="list_alerts",quantile="0.9"} NaN
+http_request_size_bytes{handler="list_alerts",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="list_alerts"} 0
+http_request_size_bytes_count{handler="list_alerts"} 0
+http_request_size_bytes{handler="list_silences",quantile="0.5"} NaN
+http_request_size_bytes{handler="list_silences",quantile="0.9"} NaN
+http_request_size_bytes{handler="list_silences",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="list_silences"} 0
+http_request_size_bytes_count{handler="list_silences"} 0
+http_request_size_bytes{handler="options",quantile="0.5"} NaN
+http_request_size_bytes{handler="options",quantile="0.9"} NaN
+http_request_size_bytes{handler="options",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="options"} 0
+http_request_size_bytes_count{handler="options"} 0
+http_request_size_bytes{handler="prometheus",quantile="0.5"} NaN
+http_request_size_bytes{handler="prometheus",quantile="0.9"} NaN
+http_request_size_bytes{handler="prometheus",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="prometheus"} 0
+http_request_size_bytes_count{handler="prometheus"} 0
+http_request_size_bytes{handler="receivers",quantile="0.5"} NaN
+http_request_size_bytes{handler="receivers",quantile="0.9"} NaN
+http_request_size_bytes{handler="receivers",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="receivers"} 0
+http_request_size_bytes_count{handler="receivers"} 0
+http_request_size_bytes{handler="status",quantile="0.5"} NaN
+http_request_size_bytes{handler="status",quantile="0.9"} NaN
+http_request_size_bytes{handler="status",quantile="0.99"} NaN
+http_request_size_bytes_sum{handler="status"} 0
+http_request_size_bytes_count{handler="status"} 0
+# HELP http_requests_total Total number of HTTP requests made.
+# TYPE http_requests_total counter
+http_requests_total{code="200",handler="add_alerts",method="post"} 5
+http_requests_total{code="200",handler="add_silence",method="post"} 3
+# HELP http_response_size_bytes The HTTP response sizes in bytes.
+# TYPE http_response_size_bytes summary
+http_response_size_bytes{handler="add_alerts",quantile="0.5"} 20
+http_response_size_bytes{handler="add_alerts",quantile="0.9"} 20
+http_response_size_bytes{handler="add_alerts",quantile="0.99"} 20
+http_response_size_bytes_sum{handler="add_alerts"} 100
+http_response_size_bytes_count{handler="add_alerts"} 5
+http_response_size_bytes{handler="add_silence",quantile="0.5"} 80
+http_response_size_bytes{handler="add_silence",quantile="0.9"} 80
+http_response_size_bytes{handler="add_silence",quantile="0.99"} 80
+http_response_size_bytes_sum{handler="add_silence"} 240
+http_response_size_bytes_count{handler="add_silence"} 3
+http_response_size_bytes{handler="alert_groups",quantile="0.5"} NaN
+http_response_size_bytes{handler="alert_groups",quantile="0.9"} NaN
+http_response_size_bytes{handler="alert_groups",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="alert_groups"} 0
+http_response_size_bytes_count{handler="alert_groups"} 0
+http_response_size_bytes{handler="app",quantile="0.5"} NaN
+http_response_size_bytes{handler="app",quantile="0.9"} NaN
+http_response_size_bytes{handler="app",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="app"} 0
+http_response_size_bytes_count{handler="app"} 0
+http_response_size_bytes{handler="del_silence",quantile="0.5"} NaN
+http_response_size_bytes{handler="del_silence",quantile="0.9"} NaN
+http_response_size_bytes{handler="del_silence",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="del_silence"} 0
+http_response_size_bytes_count{handler="del_silence"} 0
+http_response_size_bytes{handler="get_silence",quantile="0.5"} NaN
+http_response_size_bytes{handler="get_silence",quantile="0.9"} NaN
+http_response_size_bytes{handler="get_silence",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="get_silence"} 0
+http_response_size_bytes_count{handler="get_silence"} 0
+http_response_size_bytes{handler="index",quantile="0.5"} NaN
+http_response_size_bytes{handler="index",quantile="0.9"} NaN
+http_response_size_bytes{handler="index",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="index"} 0
+http_response_size_bytes_count{handler="index"} 0
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.5"} NaN
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.9"} NaN
+http_response_size_bytes{handler="legacy_add_alerts",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="legacy_add_alerts"} 0
+http_response_size_bytes_count{handler="legacy_add_alerts"} 0
+http_response_size_bytes{handler="lib_files",quantile="0.5"} NaN
+http_response_size_bytes{handler="lib_files",quantile="0.9"} NaN
+http_response_size_bytes{handler="lib_files",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="lib_files"} 0
+http_response_size_bytes_count{handler="lib_files"} 0
+http_response_size_bytes{handler="list_alerts",quantile="0.5"} NaN
+http_response_size_bytes{handler="list_alerts",quantile="0.9"} NaN
+http_response_size_bytes{handler="list_alerts",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="list_alerts"} 0
+http_response_size_bytes_count{handler="list_alerts"} 0
+http_response_size_bytes{handler="list_silences",quantile="0.5"} NaN
+http_response_size_bytes{handler="list_silences",quantile="0.9"} NaN
+http_response_size_bytes{handler="list_silences",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="list_silences"} 0
+http_response_size_bytes_count{handler="list_silences"} 0
+http_response_size_bytes{handler="options",quantile="0.5"} NaN
+http_response_size_bytes{handler="options",quantile="0.9"} NaN
+http_response_size_bytes{handler="options",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="options"} 0
+http_response_size_bytes_count{handler="options"} 0
+http_response_size_bytes{handler="prometheus",quantile="0.5"} NaN
+http_response_size_bytes{handler="prometheus",quantile="0.9"} NaN
+http_response_size_bytes{handler="prometheus",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="prometheus"} 0
+http_response_size_bytes_count{handler="prometheus"} 0
+http_response_size_bytes{handler="receivers",quantile="0.5"} NaN
+http_response_size_bytes{handler="receivers",quantile="0.9"} NaN
+http_response_size_bytes{handler="receivers",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="receivers"} 0
+http_response_size_bytes_count{handler="receivers"} 0
+http_response_size_bytes{handler="status",quantile="0.5"} NaN
+http_response_size_bytes{handler="status",quantile="0.9"} NaN
+http_response_size_bytes{handler="status",quantile="0.99"} NaN
+http_response_size_bytes_sum{handler="status"} 0
+http_response_size_bytes_count{handler="status"} 0
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 0.11
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+process_max_fds 1.048576e+06
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+process_open_fds 8
+# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes 1.1624448e+07
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds 1.54886918516e+09
+# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE process_virtual_memory_bytes gauge
+process_virtual_memory_bytes 2.039808e+07

--- a/internal/mock/Makefile
+++ b/internal/mock/Makefile
@@ -19,6 +19,7 @@ VERSIONS := 0.4.0 0.4.1 0.4.2 0.5.0 0.5.1 0.6.0 0.6.2 0.7.0 0.7.1 0.8.0 0.9.0 0.
 	@python livemock.py
 	@mkdir -p $(CURDIR)/$(VERSION)/api/v1 $(CURDIR)/$(VERSION)/api/v1/alerts
 	@echo "Collecting API responses"
+	@curl --fail -s localhost:9093/metrics > $(CURDIR)/$(VERSION)/metrics
 	@curl --fail -s localhost:9093/api/v1/status | python -m json.tool > $(CURDIR)/$(VERSION)/api/v1/status
 	@curl --fail -s localhost:9093/api/v1/silences | python -m json.tool > $(CURDIR)/$(VERSION)/api/v1/silences
 	@curl --fail -s localhost:9093/api/v1/alerts/groups | python -m json.tool > $(CURDIR)/$(VERSION)/api/v1/alerts/groups

--- a/internal/mock/mock.go
+++ b/internal/mock/mock.go
@@ -15,7 +15,7 @@ import (
 func GetAbsoluteMockPath(filename string, version string) string {
 	_, f, _, _ := runtime.Caller(0)
 	cwd := filepath.Dir(f)
-	return path.Join(cwd, version, "api/v1", filename)
+	return path.Join(cwd, version, filename)
 }
 
 // RegisterURL for given url and return 200 status register mock http responder

--- a/internal/uri/uri_test.go
+++ b/internal/uri/uri_test.go
@@ -66,8 +66,8 @@ type fileTransportTest struct {
 
 var fileTransportTests = []fileTransportTest{
 	fileTransportTest{
-		uri:  fmt.Sprintf("file://%s", mock.GetAbsoluteMockPath("status", mock.ListAllMocks()[0])),
-		size: getFileSize(mock.GetAbsoluteMockPath("status", mock.ListAllMocks()[0])),
+		uri:  fmt.Sprintf("file://%s", mock.GetAbsoluteMockPath("api/v1/status", mock.ListAllMocks()[0])),
+		size: getFileSize(mock.GetAbsoluteMockPath("api/v1/status", mock.ListAllMocks()[0])),
 	},
 	fileTransportTest{
 		uri:    "file:///non-existing-file.abcdef",

--- a/internal/verprobe/verprobe.go
+++ b/internal/verprobe/verprobe.go
@@ -1,0 +1,41 @@
+package verprobe
+
+import (
+	"io"
+
+	"github.com/prometheus/common/expfmt"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	buildInfoMetric = "alertmanager_build_info"
+	versionLabel    = "version"
+)
+
+// Detect alertmanager version by reading metrics it exposes
+func Detect(r io.Reader) (string, error) {
+	parser := expfmt.TextParser{}
+
+	metrics, err := parser.TextToMetricFamilies(r)
+	if err != nil {
+		return "", err
+	}
+
+	version := ""
+	for name, m := range metrics {
+		if name == buildInfoMetric {
+			for _, v := range m.Metric {
+				for _, l := range v.Label {
+					if l.GetName() == versionLabel {
+						version = l.GetValue()
+						log.Infof("Upstream version: %s", version)
+						break
+					}
+				}
+			}
+		}
+	}
+
+	return version, nil
+}

--- a/views_test.go
+++ b/views_test.go
@@ -19,7 +19,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/gin-gonic/gin"
-	"gopkg.in/jarcoal/httpmock.v1"
+	httpmock "gopkg.in/jarcoal/httpmock.v1"
 )
 
 var upstreamSetup = false
@@ -77,9 +77,10 @@ func mockAlerts(version string) {
 
 	apiCache = cache.New(cache.NoExpiration, 10*time.Second)
 
-	mock.RegisterURL("http://localhost/api/v1/status", version, "status")
-	mock.RegisterURL("http://localhost/api/v1/silences", version, "silences")
-	mock.RegisterURL("http://localhost/api/v1/alerts/groups", version, "alerts/groups")
+	mock.RegisterURL("http://localhost/metrics", version, "metrics")
+	mock.RegisterURL("http://localhost/api/v1/status", version, "api/v1/status")
+	mock.RegisterURL("http://localhost/api/v1/silences", version, "api/v1/silences")
+	mock.RegisterURL("http://localhost/api/v1/alerts/groups", version, "api/v1/alerts/groups")
 
 	pullFromAlertmanager()
 }


### PR DESCRIPTION
We need to know upstream version to decide which API endpoints we can use, metrics don't change between versions so they allow us to do that without any prior knowlage or assumptions