### PR TITLE
chore(ci): drop Go modules env from heroku job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -159,7 +159,6 @@ jobs:
       # * deploy only once per PR - since we will deploy on branch job
       if: repo = prymitive/karma AND type != pull_request
       env:
-        - GO111MODULE=on
         # HEROKU_TOKEN, valid forever, needed to push docker image and release
         # it on heroku app
         - secure: "zr1fHhSIZQgA7wT8PALNyAhilCZBpvziL2zuC7LJvYy9PSHatV1B+/Tl5Ao1MGlqiD9wHdRXhw/Z7Ol7vR84LlEXIQv/PZvpYtdGrwP/dmwEzRi59puNHW/sDa5fU27U5bgGW9VPYKzQFGBIknRz9yEpGAsDqzWSRwEQofgnuF1Cv0JJXN/tcZs/fcXz4AhFSXRb8Rde2geHRVGlz3UnuECQ9LnzTI/xxIP/+YORvMpTcwJtQwq/NhucYXzms19XM94xz5IE/cwf8yV9YZalm867aR2yQJvkMmOaufSYoFgRrghqnpzEe1wyuZvAXkwwZErw5swBY3Zo1YkGUeU761g3v+Nh+dlVKFaBVYgDt9W9bb1QsK1Lbgix4UYSx8Tz06X83xz2f6hWXS1Yvju7yE7M1VmjAhevWW+ZpTf3vwOH2UeUHyAMOddggMSIRfaxC9W74Trt8zxKlM+8sQiaEE3c6Ea+ZJxq1baDJvHQPdfuj2844uKaAL7qNVuRNRPAa0bp0qkzLyl3f5P3XK54mM4vayBRCQ+qflq+XGXY5G8+LukUNnKMq/KuPZZ1A6pOr3kTj4qKaxAcxOJQq4/xc+zJaiQFkzfMj1//LKMyvrRtqMnPV+P3qtgMGzA4Z3JlHUOgPHgbZ9WTlpV5yi066Onro+j2NFehjY+FV6R2gOI="


### PR DESCRIPTION
Docker is used to build the image, no need to set GO111MODULE