### PR TITLE
chore(ci): disable codecov comments

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false


### PR DESCRIPTION
Those are noisy and most of them are no-op