### PR TITLE
fix(api): apply colors to the @alertmanager label

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -324,6 +324,8 @@ for `warning` and blue for `info`:
 labels:
   color:
     custom:
+      "@alertmanager":
+        prod: "#e6e"
       severity:
         info: "#87c4e0"
         warning: "#ffae42"

--- a/internal/alertmanager/models.go
+++ b/internal/alertmanager/models.go
@@ -322,6 +322,9 @@ func (am *Alertmanager) pullAlerts(version string) error {
 			}
 
 			transform.ColorLabel(colors, "@receiver", alert.Receiver)
+			for _, am := range alert.Alertmanager {
+				transform.ColorLabel(colors, "@alertmanager", am.Name)
+			}
 			for k, v := range alert.Labels {
 				transform.ColorLabel(colors, k, v)
 			}

--- a/views.go
+++ b/views.go
@@ -162,6 +162,17 @@ func alerts(c *gin.Context) {
 					}
 				}
 
+				if ck, foundKey := dedupedColors["@alertmanager"]; foundKey {
+					for _, am := range alert.Alertmanager {
+						if cv, foundVal := ck[am.Name]; foundVal {
+							if _, found := colors["@alertmanager"]; !found {
+								colors["@alertmanager"] = map[string]models.LabelColors{}
+							}
+							colors["@alertmanager"][am.Name] = cv
+						}
+					}
+				}
+
 				agCopy.StateCount[alert.State]++
 
 				for _, am := range alert.Alertmanager {


### PR DESCRIPTION
It's a fake label so it needs special code to inject the color information to the API response.

Fixes #421