### PR TITLE
feat(ui): set font-display swap policy

### DIFF
--- a/ui/src/Fonts.scss
+++ b/ui/src/Fonts.scss
@@ -3,6 +3,7 @@
 $web-font-path: "";
 
 @font-face {
+  font-display: swap;
   font-family: "Lato";
   font-weight: 400;
   font-style: normal;
@@ -12,6 +13,7 @@ $web-font-path: "";
 }
 
 @font-face {
+  font-display: swap;
   font-family: "Lato";
   font-weight: 400;
   font-style: italic;
@@ -23,6 +25,7 @@ $web-font-path: "";
 }
 
 @font-face {
+  font-display: swap;
   font-family: "Lato";
   font-weight: 700;
   font-style: normal;


### PR DESCRIPTION
This tells the browser to use a fallback font until Leto is loaded, which speeds up initial rendering, especially on slow clients