### PR TITLE
fix(ui): use current number of alerts in the count label

### DIFF
--- a/ui/src/Components/Grid/AlertGrid/AlertGroup/index.js
+++ b/ui/src/Components/Grid/AlertGrid/AlertGroup/index.js
@@ -197,7 +197,10 @@ const AlertGroup = observer(
                           tooltip="Show fewer alerts in this group"
                         />
                         <small className="text-muted mx-2">
-                          {this.renderConfig.alertsToRender}
+                          {Math.min(
+                            this.renderConfig.alertsToRender,
+                            group.alerts.length
+                          )}
                           {" of "}
                           {group.alerts.length}
                         </small>


### PR DESCRIPTION
alertsToRender can be higher than the number of alerts in a group if the number keeps changing. This means we might end up with 'Showing 30/10', so ensuring that we don't show a number higher than the actual group size will make it more accurate