### PR TITLE
chore(go): use /src as source dir when building Go code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
 FROM node:10.15.1-alpine as nodejs-builder
 RUN apk add --update make git
-COPY . /karma
-RUN make -C /karma ui
+COPY . /src
+RUN make -C /src ui
 
 FROM golang:1.12.0-alpine as go-builder
-COPY --from=nodejs-builder /karma /go/src/github.com/prymitive/karma
+COPY --from=nodejs-builder /src /src
 ARG VERSION
 RUN apk add --update make git
-RUN CGO_ENABLED=0 make -C /go/src/github.com/prymitive/karma VERSION="${VERSION:-dev}" karma
+RUN CGO_ENABLED=0 make -C /src VERSION="${VERSION:-dev}" karma
 
 FROM gcr.io/distroless/base
 COPY ./docs/dark.css /themes/dark.css
-COPY --from=go-builder /go/src/github.com/prymitive/karma/karma /karma
+COPY --from=go-builder /src/karma /karma
 EXPOSE 8080
 ENTRYPOINT ["/karma"]

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -1,13 +1,13 @@
 FROM node:10.15.1-alpine as nodejs-builder
 RUN apk add --update make git
-COPY . /karma
-RUN make -C /karma ui
+COPY . /src
+RUN make -C /src ui
 
 FROM golang:1.12.0-alpine as go-builder
-COPY --from=nodejs-builder /karma /go/src/github.com/prymitive/karma
+COPY --from=nodejs-builder /src /src
 ARG VERSION
 RUN apk add --update make git
-RUN CGO_ENABLED=0 make -C /go/src/github.com/prymitive/karma VERSION="${VERSION:-dev}" karma
+RUN CGO_ENABLED=0 make -C /src VERSION="${VERSION:-dev}" karma
 
 FROM alpine:3.9
 RUN apk add --update supervisor python && rm  -rf /tmp/* /var/cache/apk/*
@@ -15,7 +15,7 @@ COPY demo/supervisord.conf /etc/supervisord.conf
 COPY --from=prom/alertmanager:v0.15.3 /bin/alertmanager /alertmanager
 COPY demo/alertmanager.yaml /etc/alertmanager.yaml
 COPY demo/generator.py /generator.py
-COPY --from=go-builder /go/src/github.com/prymitive/karma/karma /karma
+COPY --from=go-builder /src/karma /karma
 COPY demo/karma.yaml /etc/karma.yaml
 COPY demo/custom.js /custom.js
 RUN adduser -D karma


### PR DESCRIPTION
Modules no longer require being inside the GOPATH, moving it outside ensures that we don't use anything from GOPATH anymore