### PR TITLE
feat(ui): use not-equal operator when user alt+clicks on a label

### DIFF
--- a/ui/src/Common/Query.js
+++ b/ui/src/Common/Query.js
@@ -1,5 +1,6 @@
 const QueryOperators = Object.freeze({
   Equal: "=",
+  NotEqual: "!=",
   Regex: "=~"
 });
 

--- a/ui/src/Components/Grid/AlertGrid/AlertGroup/Alert/__snapshots__/index.test.js.snap
+++ b/ui/src/Components/Grid/AlertGrid/AlertGroup/Alert/__snapshots__/index.test.js.snap
@@ -70,7 +70,7 @@ exports[`<Alert /> matches snapshot with showAlertmanagers=false showReceiver=fa
        style=\\"display: inline;\\"
        data-tooltipped
        aria-describedby=\\"tippy-tooltip-1\\"
-       data-original-title=\\"Click to only show alerts with this label\\"
+       data-original-title=\\"Click to only show alerts with this label or Alt+Click to hide them\\"
   >
     <span class=\\"components-label badge text-nowrap text-truncate mw-100 badge-warning components-label-dark components-label-with-hover\\">
       <span class=\\"components-label-name\\">
@@ -85,7 +85,7 @@ exports[`<Alert /> matches snapshot with showAlertmanagers=false showReceiver=fa
        style=\\"display: inline;\\"
        data-tooltipped
        aria-describedby=\\"tippy-tooltip-2\\"
-       data-original-title=\\"Click to only show alerts with this label\\"
+       data-original-title=\\"Click to only show alerts with this label or Alt+Click to hide them\\"
   >
     <span class=\\"components-label badge text-nowrap text-truncate mw-100 badge-warning components-label-dark components-label-with-hover\\">
       <span class=\\"components-label-name\\">

--- a/ui/src/Components/Grid/AlertGrid/AlertGroup/GroupFooter/__snapshots__/index.test.js.snap
+++ b/ui/src/Components/Grid/AlertGrid/AlertGroup/GroupFooter/__snapshots__/index.test.js.snap
@@ -48,7 +48,7 @@ exports[`<GroupFooter /> matches snapshot 1`] = `
        style=\\"display: inline;\\"
        data-tooltipped
        aria-describedby=\\"tippy-tooltip-1\\"
-       data-original-title=\\"Click to only show alerts with this label\\"
+       data-original-title=\\"Click to only show alerts with this label or Alt+Click to hide them\\"
   >
     <span class=\\"components-label badge text-nowrap text-truncate mw-100 badge-warning components-label-dark components-label-with-hover\\">
       <span class=\\"components-label-name\\">
@@ -63,7 +63,7 @@ exports[`<GroupFooter /> matches snapshot 1`] = `
        style=\\"display: inline;\\"
        data-tooltipped
        aria-describedby=\\"tippy-tooltip-2\\"
-       data-original-title=\\"Click to only show alerts with this label\\"
+       data-original-title=\\"Click to only show alerts with this label or Alt+Click to hide them\\"
   >
     <span class=\\"components-label badge text-nowrap text-truncate mw-100 badge-warning components-label-dark components-label-with-hover\\">
       <span class=\\"components-label-name\\">
@@ -78,7 +78,7 @@ exports[`<GroupFooter /> matches snapshot 1`] = `
        style=\\"display: inline;\\"
        data-tooltipped
        aria-describedby=\\"tippy-tooltip-3\\"
-       data-original-title=\\"Click to only show alerts with this label\\"
+       data-original-title=\\"Click to only show alerts with this label or Alt+Click to hide them\\"
   >
     <span class=\\"components-label badge text-nowrap text-truncate mw-100 badge-warning components-label-dark components-label-with-hover\\">
       <span class=\\"components-label-name\\">
@@ -93,7 +93,7 @@ exports[`<GroupFooter /> matches snapshot 1`] = `
        style=\\"display: inline;\\"
        data-tooltipped
        aria-describedby=\\"tippy-tooltip-4\\"
-       data-original-title=\\"Click to only show alerts with this label\\"
+       data-original-title=\\"Click to only show alerts with this label or Alt+Click to hide them\\"
   >
     <span class=\\"components-label badge text-nowrap text-truncate mw-100 badge-warning components-label-dark components-label-with-hover\\">
       <span class=\\"components-label-name\\">

--- a/ui/src/Components/Grid/AlertGrid/AlertGroup/Silence/__snapshots__/index.test.js.snap
+++ b/ui/src/Components/Grid/AlertGrid/AlertGroup/Silence/__snapshots__/index.test.js.snap
@@ -108,7 +108,7 @@ exports[`<Silence /> matches snapshot with expaned details 1`] = `
            style=\\"display: inline;\\"
            data-tooltipped
            aria-describedby=\\"tippy-tooltip-6\\"
-           data-original-title=\\"Click to only show alerts with this label\\"
+           data-original-title=\\"Click to only show alerts with this label or Alt+Click to hide them\\"
       >
         <span class=\\"components-label badge text-nowrap text-truncate mw-100 badge-warning components-label-dark components-label-with-hover\\">
           <span class=\\"components-label-name\\">

--- a/ui/src/Components/Labels/BaseLabel/index.js
+++ b/ui/src/Components/Labels/BaseLabel/index.js
@@ -73,12 +73,15 @@ class BaseLabel extends Component {
   }
 
   handleClick = event => {
+    // left click       => apply foo=bar filter
+    // left click + alt => apply foo!=bar filter
+    const operator =
+      event.altKey === true ? QueryOperators.NotEqual : QueryOperators.Equal;
+
     event.preventDefault();
 
     const { name, value, alertStore } = this.props;
-    alertStore.filters.addFilter(
-      FormatQuery(name, QueryOperators.Equal, value)
-    );
+    alertStore.filters.addFilter(FormatQuery(name, operator, value));
   };
 }
 

--- a/ui/src/Components/Labels/FilteringCounterBadge/index.js
+++ b/ui/src/Components/Labels/FilteringCounterBadge/index.js
@@ -32,7 +32,9 @@ const FilteringCounterBadge = inject("alertStore")(
         );
 
         return (
-          <TooltipWrapper title={`Click to only show ${value} alerts`}>
+          <TooltipWrapper
+            title={`Click to only show ${value} alerts or Alt+Click to hide them`}
+          >
             <span
               className={cs.className}
               style={cs.style}

--- a/ui/src/Components/Labels/FilteringLabel/__snapshots__/index.test.js.snap
+++ b/ui/src/Components/Labels/FilteringLabel/__snapshots__/index.test.js.snap
@@ -6,7 +6,7 @@ exports[`<FilteringLabel /> matches snapshot 1`] = `
      style=\\"display: inline;\\"
      data-tooltipped
      aria-describedby=\\"tippy-tooltip-1\\"
-     data-original-title=\\"Click to only show alerts with this label\\"
+     data-original-title=\\"Click to only show alerts with this label or Alt+Click to hide them\\"
 >
   <span class=\\"components-label badge text-nowrap text-truncate mw-100 badge-warning components-label-dark components-label-with-hover\\">
     <span class=\\"components-label-name\\">

--- a/ui/src/Components/Labels/FilteringLabel/index.js
+++ b/ui/src/Components/Labels/FilteringLabel/index.js
@@ -19,7 +19,7 @@ const FilteringLabel = inject("alertStore")(
         );
 
         return (
-          <TooltipWrapper title="Click to only show alerts with this label">
+          <TooltipWrapper title="Click to only show alerts with this label or Alt+Click to hide them">
             <span
               className={cs.className}
               style={cs.style}

--- a/ui/src/Components/Labels/FilteringLabel/index.test.js
+++ b/ui/src/Components/Labels/FilteringLabel/index.test.js
@@ -20,9 +20,9 @@ const MountedFilteringLabel = (name, value) => {
   ).find(".components-label");
 };
 
-const RenderAndClick = (name, value) => {
+const RenderAndClick = (name, value, clickOptions) => {
   const tree = MountedFilteringLabel(name, value);
-  tree.find(".components-label").simulate("click");
+  tree.find(".components-label").simulate("click", clickOptions || {});
 };
 
 describe("<FilteringLabel />", () => {
@@ -38,6 +38,14 @@ describe("<FilteringLabel />", () => {
     expect(alertStore.filters.values).toHaveLength(1);
     expect(alertStore.filters.values).toContainEqual(
       NewUnappliedFilter("foo=bar")
+    );
+  });
+
+  it("calling onClick() while holding Alt key adds a new filter 'foo!=bar'", () => {
+    RenderAndClick("foo", "bar", { altKey: true });
+    expect(alertStore.filters.values).toHaveLength(1);
+    expect(alertStore.filters.values).toContainEqual(
+      NewUnappliedFilter("foo!=bar")
     );
   });
 


### PR DESCRIPTION
When user clicks on a label we apply a foo=bar filter, this change allows to add a foo!=bar filter by holding Alt key when clicking.

Fixes #485