### PR TITLE
fix(ci): disable yarn & npm lock file deduplication

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,5 @@
   "rebaseStalePrs": false,
   "travis": { "enabled": true },
   "masterIssue": true,
-  "postUpdateOptions": ["gomodTidy", "npmDedupe", "yarnDedupeFewer"]
+  "postUpdateOptions": ["gomodTidy"]
 }


### PR DESCRIPTION
This change caused lock file to be generated in a way that generates local changes on build, drop it