### PR TITLE
feat(ui): hide filter counter value when not needed

### DIFF
--- a/ui/src/Components/Labels/FilterInputLabel/index.js
+++ b/ui/src/Components/Labels/FilterInputLabel/index.js
@@ -51,6 +51,11 @@ const FilterInputLabel = observer(
         "components-filteredinputlabel"
       );
 
+      const showCounter =
+        alertStore.filters.values.filter(
+          f => f.hits !== alertStore.info.totalAlerts
+        ).length > 0;
+
       return (
         <span
           className={
@@ -79,9 +84,11 @@ const FilterInputLabel = observer(
           </button>
           {filter.isValid ? (
             filter.applied ? (
-              <span className="badge badge-light badge-pill mr-1">
-                {filter.hits}
-              </span>
+              showCounter ? (
+                <span className="badge badge-light badge-pill mr-1">
+                  {filter.hits}
+                </span>
+              ) : null
             ) : (
               <span className="badge mr-1">
                 <FontAwesomeIcon icon={faSpinner} spin />
@@ -94,6 +101,7 @@ const FilterInputLabel = observer(
           )}
           <TooltipWrapper title="Click to edit this filter">
             <RIEInput
+              className={showCounter ? "" : "align-middle"}
               defaultValue=""
               value={filter.raw}
               propName="raw"


### PR DESCRIPTION
Right now counter badge is rendered on every filter instance, but if there's only one filter that counter has the same value as the total alert counter on left side. With this change counter badge will only be rendered if there's a filter with hits != total alert count