### PR TITLE
fix(ui): ensure that filter input labels are truncated if too long

### DIFF
--- a/ui/src/Components/Labels/FilterInputLabel/index.js
+++ b/ui/src/Components/Labels/FilterInputLabel/index.js
@@ -85,7 +85,10 @@ const FilterInputLabel = observer(
               <FontAwesomeIcon icon={faExclamationCircle} />
             </span>
           )}
-          <TooltipWrapper title="Click to edit this filter" className="my-auto">
+          <TooltipWrapper
+            title="Click to edit this filter"
+            className="my-auto mw-100 text-nowrap text-truncate"
+          >
             <RIEInput
               defaultValue=""
               value={filter.raw}


### PR DESCRIPTION
Tooltip component creates a div element which is currently missing mw-100 (and others) so it can be bigger than the wrapping label span