### PR TITLE
fix(backend): don't set cache headers for 404s

### DIFF
--- a/assets.go
+++ b/assets.go
@@ -93,9 +93,12 @@ func serveFileOr404(path string, contentType string, c *gin.Context) {
 func staticHeaders(prefix string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if strings.HasPrefix(c.Request.URL.Path, prefix) {
-			c.Header("Cache-Control", "public, max-age=31536000")
-			expiresTime := time.Now().AddDate(0, 0, 365).Format(http.TimeFormat)
-			c.Header("Expires", expiresTime)
+			c.Next()
+			if c.IsAborted() {
+				c.Header("Cache-Control", "public, max-age=31536000")
+				expiresTime := time.Now().AddDate(0, 0, 365).Format(http.TimeFormat)
+				c.Header("Expires", expiresTime)
+			}
 		}
 	}
 }

--- a/assets_test.go
+++ b/assets_test.go
@@ -80,3 +80,15 @@ func TestCustomizationAssets(t *testing.T) {
 		}
 	}
 }
+
+func TestStaticExpires404(t *testing.T) {
+	mockConfig()
+	r := ginTestEngine()
+
+	req := httptest.NewRequest("GET", "/static/foobar.js", nil)
+	resp := httptest.NewRecorder()
+	r.ServeHTTP(resp, req)
+	if resp.Result().Header.Get("Expires") != "" {
+		t.Errorf("Got Expires: '%s' header on a 404 /static/ response", resp.Result().Header.Get("Expires"))
+	}
+}


### PR DESCRIPTION
Right now all requests for /static/ will have huge expires header, even if it's a 404. Only set headers if previous middleware did abort the request, meaning it found the file in static assets