### PR TITLE
fix(ui): lower repack debounce

### DIFF
--- a/ui/src/Components/Grid/AlertGrid/index.js
+++ b/ui/src/Components/Grid/AlertGrid/index.js
@@ -86,7 +86,7 @@ const AlertGrid = observer(
           this.masonryComponentReference.ref.forcePack();
         }
       }),
-      50
+      10
     );
 
     // how many alert groups to render


### PR DESCRIPTION
50ms is very noticable and one can see groups overlapping each other, 10ms is nicer