### PR TITLE
fix(ui): fix fallback sorting by timestamps

### DIFF
--- a/ui/src/Components/Grid/AlertGrid/index.test.js
+++ b/ui/src/Components/Grid/AlertGrid/index.test.js
@@ -342,9 +342,9 @@ describe("<AlertGrid />", () => {
     const tree = ShallowAlertGrid();
     const alertGroups = tree.find("AlertGroup");
     expect(alertGroups.map(g => g.props().group.id)).toEqual([
-      "id3",
+      "id2",
       "id1",
-      "id2"
+      "id3"
     ]);
   });
 


### PR DESCRIPTION
Sorting by timestaps should be reversed - most recent timestamps first