### PR TITLE
fix(ui): allow any string as silence author, not just email

### DIFF
--- a/ui/src/Components/SilenceModal/SilenceForm.js
+++ b/ui/src/Components/SilenceModal/SilenceForm.js
@@ -162,9 +162,9 @@ const SilenceForm = observer(
           </TooltipWrapper>
           <DateTimeSelect silenceFormStore={silenceFormStore} />
           <IconInput
-            type="email"
+            type="text"
             autoComplete="email"
-            placeholder="Author email"
+            placeholder="Author"
             icon={faUser}
             value={silenceFormStore.data.author}
             onChange={this.onAuthorChange}

--- a/ui/src/Components/SilenceModal/SilenceForm.test.js
+++ b/ui/src/Components/SilenceModal/SilenceForm.test.js
@@ -127,7 +127,7 @@ describe("<SilenceForm /> inputs", () => {
   it("default author value comes from Settings store", () => {
     settingsStore.silenceFormConfig.config.author = "foo@example.com";
     const tree = MountedSilenceForm();
-    const input = tree.find("input[placeholder='Author email']");
+    const input = tree.find("input[placeholder='Author']");
     expect(input.props().value).toBe("foo@example.com");
     expect(silenceFormStore.data.author).toBe("foo@example.com");
   });
@@ -135,14 +135,14 @@ describe("<SilenceForm /> inputs", () => {
   it("default author value is empty if nothing is stored in Settings", () => {
     settingsStore.silenceFormConfig.config.author = "";
     const tree = MountedSilenceForm();
-    const input = tree.find("input[placeholder='Author email']");
+    const input = tree.find("input[placeholder='Author']");
     expect(input.text()).toBe("");
     expect(silenceFormStore.data.author).toBe("");
   });
 
   it("changing author input updates SilenceFormStore", () => {
     const tree = MountedSilenceForm();
-    const input = tree.find("input[placeholder='Author email']");
+    const input = tree.find("input[placeholder='Author']");
     input.simulate("change", { target: { value: "me@example.com" } });
     expect(silenceFormStore.data.author).toBe("me@example.com");
   });


### PR DESCRIPTION
Alertmanager doesn't restrict this field, so no need to force an email there.

Fixes #741