### PR TITLE
fix(ui): apply correct font color to filter input labels

### DIFF
--- a/ui/src/Components/Labels/BaseLabel/index.scss
+++ b/ui/src/Components/Labels/BaseLabel/index.scss
@@ -34,6 +34,7 @@ span.badge.components-label {
   padding-bottom: 0.25rem;
 }
 
+button.components-label-bright,
 .components-label-bright {
   color: $black;
   &:hover {
@@ -56,6 +57,7 @@ span.badge.components-label {
   }
 }
 
+button.components-label-dark,
 .components-label-dark {
   color: $white;
   &:hover {


### PR DESCRIPTION
Bootstrap classes for.btn are getting priorioty so the text is always black, even when background color is dark