### PR TITLE
fix(backend): ensure that we always use default timeout for am requests

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -172,6 +172,11 @@ func (config *configSchema) Read() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	for i, s := range config.Alertmanager.Servers {
+		if s.Timeout.Seconds() == 0 {
+			config.Alertmanager.Servers[i].Timeout = v.GetDuration("alertmanager.timeout")
+		}
+	}
 
 	err = v.UnmarshalKey("jira", &config.JIRA)
 	if err != nil {


### PR DESCRIPTION
Timeout attribute for each alertmanager upstream should default to the value of alertmanager.timeout flag.
Without that it will default to 0s which will cause it to timeout instantly