### PR TITLE
fix(ui): don't crash when removing last Alertmanager instance

### DIFF
--- a/ui/src/Components/SilenceModal/AlertManagerInput/index.js
+++ b/ui/src/Components/SilenceModal/AlertManagerInput/index.js
@@ -36,7 +36,7 @@ const AlertManagerInput = observer(
     onChange = action((newValue, actionMeta) => {
       const { silenceFormStore } = this.props;
 
-      silenceFormStore.data.alertmanagers = newValue;
+      silenceFormStore.data.alertmanagers = newValue || [];
     });
 
     componentDidUpdate() {

--- a/ui/src/Components/SilenceModal/AlertManagerInput/index.test.js
+++ b/ui/src/Components/SilenceModal/AlertManagerInput/index.test.js
@@ -174,4 +174,19 @@ describe("<AlertManagerInput />", () => {
     const select = tree.find("StateManager");
     expect(select.props().isDisabled).toBe(true);
   });
+
+  it("removing last options sets silenceFormStore.data.alertmanagers to []", () => {
+    const tree = MountedAlertManagerInput();
+    expect(silenceFormStore.data.alertmanagers).toHaveLength(2);
+
+    tree
+      .find(".react-select__multi-value__remove")
+      .at(0)
+      .simulate("click");
+    expect(silenceFormStore.data.alertmanagers).toHaveLength(1);
+
+    tree.find(".react-select__multi-value__remove").simulate("click");
+    expect(silenceFormStore.data.alertmanagers).toHaveLength(0);
+    expect(silenceFormStore.data.alertmanagers).toEqual([]);
+  });
 });


### PR DESCRIPTION
Removing last value sets the value that's expected to be a list to null, which breaks some logic, ensure we always have a list there.

Fixes #826