### PR TITLE
fix(ui): don't crash when removing last matcher value

### DIFF
--- a/ui/src/Components/SilenceModal/SilenceMatch/LabelValueInput.js
+++ b/ui/src/Components/SilenceModal/SilenceMatch/LabelValueInput.js
@@ -57,12 +57,15 @@ const LabelValueInput = observer(
     onChange = action((newValue, actionMeta) => {
       const { matcher } = this.props;
 
-      matcher.values = newValue;
+      // we might get null if there's nothing selected
+      const value = newValue || [];
+
+      matcher.values = value;
 
       // force regex if we have multiple values
-      if (newValue.length > 1 && matcher.isRegex === false) {
+      if (value.length > 1 && matcher.isRegex === false) {
         matcher.isRegex = true;
-      } else if (newValue.length === 1 && matcher.isRegex === true) {
+      } else if (value.length === 1 && matcher.isRegex === true) {
         matcher.isRegex = false;
       }
     });

--- a/ui/src/Components/SilenceModal/SilenceMatch/LabelValueInput.test.js
+++ b/ui/src/Components/SilenceModal/SilenceMatch/LabelValueInput.test.js
@@ -125,4 +125,19 @@ describe("<LabelValueInput />", () => {
     options.at(1).simulate("click");
     expect(matcher.isRegex).toBe(true);
   });
+
+  it("removing last value sets matcher.values to []", () => {
+    matcher.values = [MatcherValueToObject("foo"), MatcherValueToObject("bar")];
+    const tree = MountedLabelValueInput(true);
+
+    tree
+      .find(".react-select__multi-value__remove")
+      .at(0)
+      .simulate("click");
+    expect(matcher.values).toHaveLength(1);
+
+    tree.find(".react-select__multi-value__remove").simulate("click");
+    expect(matcher.values).toHaveLength(0);
+    expect(matcher.values).toEqual([]);
+  });
 });


### PR DESCRIPTION
Removing last value sets the value that's expected to be a list to null, which breaks some logic, ensure we always have a list there

Fixes #827