### PR TITLE
chore(ci): bump header-max-length to 100

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -2,7 +2,7 @@ module.exports = {
   rules: {
     "body-leading-blank": [1, "always"],
     "footer-leading-blank": [1, "always"],
-    "header-max-length": [2, "always", 72],
+    "header-max-length": [2, "always", 100],
     "scope-case": [2, "always", "lower-case"],
     "subject-case": [
       2,


### PR DESCRIPTION
Lots of renovate PRs include commits with long subjects since they include dependency name.
Fixing it always requires either ignoring failed CI jobs or manually editing the subject.
Better to allow long subjects