### PR TITLE
fix(ui): cleanup scss variable imports

### DIFF
--- a/ui/src/App.scss
+++ b/ui/src/App.scss
@@ -1,5 +1,5 @@
 // bundled font assets, so we don't need to talk to Google Fonts API
-@import "./Fonts.scss";
+@import "src/Fonts.scss";
 
 // custom "dark" color, little less dark than flatly
 $blue: #455a64;

--- a/ui/src/Components/Labels/BaseLabel/index.scss
+++ b/ui/src/Components/Labels/BaseLabel/index.scss
@@ -1,4 +1,4 @@
-@import "~bootswatch/dist/flatly/variables";
+@import "src/App.scss";
 
 .components-label-with-hover:hover {
   filter: brightness(0.85);

--- a/ui/src/Components/Labels/FilterInputLabel/index.scss
+++ b/ui/src/Components/Labels/FilterInputLabel/index.scss
@@ -1,4 +1,4 @@
-@import "~bootswatch/dist/flatly/variables";
+@import "src/App.scss";
 
 .components-filteredinputlabel-text {
   font-size: 1rem;

--- a/ui/src/Components/Labels/LabelWithPercent/index.scss
+++ b/ui/src/Components/Labels/LabelWithPercent/index.scss
@@ -1,4 +1,4 @@
-@import "~bootswatch/dist/flatly/variables";
+@import "src/App.scss";
 
 .components-labelWithPercent-percent {
   padding-top: 0.25rem;

--- a/ui/src/Components/MainModal/Configuration/InputRange.scss
+++ b/ui/src/Components/MainModal/Configuration/InputRange.scss
@@ -1,5 +1,5 @@
 // customize colors and fonts using bootstrap variables
-@import "~bootswatch/dist/flatly/variables";
+@import "src/App.scss";
 
 $input-range-font-family: $font-family-sans-serif;
 $input-range-primary-color: $primary;

--- a/ui/src/Components/NavBar/index.scss
+++ b/ui/src/Components/NavBar/index.scss
@@ -1,6 +1,4 @@
-@import "~bootswatch/dist/flatly/variables";
-@import "~bootstrap/scss/bootstrap";
-@import "~bootswatch/dist/flatly/bootswatch";
+@import "src/App.scss";
 
 .navbar-brand {
   min-width: 2.5rem;

--- a/ui/src/Components/OverviewModal/index.scss
+++ b/ui/src/Components/OverviewModal/index.scss
@@ -1,6 +1,4 @@
-@import "~bootswatch/dist/flatly/variables";
-@import "~bootstrap/scss/bootstrap";
-@import "~bootswatch/dist/flatly/bootswatch";
+@import "src/App.scss";
 
 .navbar-brand {
   &:hover,

--- a/ui/src/Components/SilenceModal/DateTimeSelect/index.scss
+++ b/ui/src/Components/SilenceModal/DateTimeSelect/index.scss
@@ -1,4 +1,4 @@
-@import "~bootswatch/dist/flatly/variables";
+@import "src/App.scss";
 
 $datepicker__background-color: $white;
 $datepicker__border-color: $gray-300;

--- a/ui/src/Fonts.scss
+++ b/ui/src/Fonts.scss
@@ -1,7 +1,7 @@
 // this is used by bootswatch to import the font, we bundle all fonts so there
-// is nothing to import, so let's point it at an empty file
+// is nothing to import
 // https://github.com/thomaspark/bootswatch/issues/55
-$web-font-path: "./empty.css";
+$web-font-path: "data:text/css;base64,";
 
 // Default for Bootstrap is 700 and it's a bit too thick for Open Sans
 $font-weight-bold: 600;

--- a/ui/src/empty.css
+++ b/ui/src/empty.css
@@ -1,1 +1,0 @@
-/* Empty css file to be included by bootswatch, see Fonts.scss */


### PR DESCRIPTION
All scss imports needs to use App.scss, otherwise some overrides won't be present, like font swap Lato -> Open Sans