### PR TITLE
chore(ci): run build CI jobs only from master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -107,8 +107,8 @@ jobs:
 
     - stage: Build and Deploy
       # we build and push docker image on merge and tag, so this should only
-      # run for pull requests, to test that they don't break docker builds
-      if: repo = prymitive/karma AND (branch != master OR type = pull_request) AND tag IS NOT present
+      # run for new branches, to test that they don't break docker builds
+      if: repo = prymitive/karma AND type != pull_request
       language: generic
       addons:
         apt:
@@ -119,6 +119,7 @@ jobs:
       script: travis_retry make docker-image
 
     - stage: Build and Deploy
+      if: repo = prymitive/karma AND type != pull_request
       <<: *DEFAULTS_GO
       env:
         - DESC="Cross compile binaries"


### PR DESCRIPTION
Right now CI jobs that build all binaries and/or docker images run twice - for branch job and PR job.
Those jobs are slow so skip PR jobs, one is enough.