### PR TITLE
fix(ui): align labels in the overview modal

### DIFF
--- a/ui/src/Components/OverviewModal/OverviewModalContent.js
+++ b/ui/src/Components/OverviewModal/OverviewModalContent.js
@@ -16,7 +16,7 @@ const TableRows = observer(({ alertStore, nameStats }) =>
   nameStats.map(nameStats => (
     <tr key={nameStats.name}>
       <td width="25%" className="text-nowrap mw-100 p-1">
-        <span className="badge badge-light components-label mx-0 my-1 pl-0 text-left">
+        <span className="badge badge-light components-label mx-0 mt-0 mb-auto pl-0 text-left">
           <span className="bg-primary text-white mr-1 px-1 components-labelWithPercent-percent">
             {nameStats.hits}
           </span>

--- a/ui/src/Components/OverviewModal/__snapshots__/OverviewModalContent.test.js.snap
+++ b/ui/src/Components/OverviewModal/__snapshots__/OverviewModalContent.test.js.snap
@@ -24,7 +24,7 @@ exports[`<OverviewModalContent /> matches snapshot with labels to show 1`] = `
           <td width=\\"25%\\"
               class=\\"text-nowrap mw-100 p-1\\"
           >
-            <span class=\\"badge badge-light components-label mx-0 my-1 pl-0 text-left\\">
+            <span class=\\"badge badge-light components-label mx-0 mt-0 mb-auto pl-0 text-left\\">
               <span class=\\"bg-primary text-white mr-1 px-1 components-labelWithPercent-percent\\">
                 16
               </span>
@@ -131,7 +131,7 @@ exports[`<OverviewModalContent /> matches snapshot with labels to show 1`] = `
           <td width=\\"25%\\"
               class=\\"text-nowrap mw-100 p-1\\"
           >
-            <span class=\\"badge badge-light components-label mx-0 my-1 pl-0 text-left\\">
+            <span class=\\"badge badge-light components-label mx-0 mt-0 mb-auto pl-0 text-left\\">
               <span class=\\"bg-primary text-white mr-1 px-1 components-labelWithPercent-percent\\">
                 20
               </span>
@@ -439,7 +439,7 @@ exports[`<OverviewModalContent /> matches snapshot with labels to show 1`] = `
           <td width=\\"25%\\"
               class=\\"text-nowrap mw-100 p-1\\"
           >
-            <span class=\\"badge badge-light components-label mx-0 my-1 pl-0 text-left\\">
+            <span class=\\"badge badge-light components-label mx-0 mt-0 mb-auto pl-0 text-left\\">
               <span class=\\"bg-primary text-white mr-1 px-1 components-labelWithPercent-percent\\">
                 5
               </span>


### PR DESCRIPTION
Moves the left column labels to the top, since the right side will have progress bars
at the bottom which makes them taller