### PR TITLE
chore(backend): log a warning when alertmanager 0.17 or 0.18 is detected

### DIFF
--- a/internal/alertmanager/models.go
+++ b/internal/alertmanager/models.go
@@ -81,6 +81,10 @@ func (am *Alertmanager) probeVersion() string {
 		return fakeVersion
 	}
 
+	if version == "0.17.0" || version == "0.18.0" {
+		log.Warningf("Alertmanager %s might return incomplete list of alert groups in the API, please upgrade to >=0.19.0, see https://github.com/prymitive/karma/issues/812", version)
+	}
+
 	return version
 }
 


### PR DESCRIPTION
Fixes #1099