### PR TITLE
chore(ui): only fetch updates if  seconds passed since last fetch

### DIFF
--- a/ui/src/Components/Fetcher/index.test.js
+++ b/ui/src/Components/Fetcher/index.test.js
@@ -25,7 +25,9 @@ beforeEach(() => {
   alertStore = new AlertStore(["label=value"]);
   fetchSpy = jest
     .spyOn(alertStore, "fetchWithThrottle")
-    .mockImplementation(() => {});
+    .mockImplementation(() => {
+      alertStore.status.setIdle();
+    });
 
   settingsStore = new Settings();
   settingsStore.fetchConfig.config.interval = 30;

--- a/ui/src/Stores/AlertStore.js
+++ b/ui/src/Stores/AlertStore.js
@@ -6,6 +6,8 @@ import equal from "fast-deep-equal";
 
 import qs from "qs";
 
+import moment from "moment";
+
 import { FetchWithCredentials } from "Common/Fetch";
 
 const QueryStringEncodeOptions = {
@@ -210,11 +212,13 @@ class AlertStore {
   status = observable(
     {
       value: AlertStoreStatuses.Idle,
+      lastUpdateAt: 0,
       error: null,
       paused: false,
       setIdle() {
         this.value = AlertStoreStatuses.Idle;
         this.error = null;
+        this.lastUpdateAt = moment();
       },
       setFetching() {
         this.value = AlertStoreStatuses.Fetching;
@@ -226,6 +230,7 @@ class AlertStore {
       setFailure(err) {
         this.value = AlertStoreStatuses.Failure;
         this.error = err;
+        this.lastUpdateAt = moment();
       },
       pause() {
         this.paused = true;


### PR DESCRIPTION
Right now fetcher will always trigger fetch if enough time passes, make it aware of the last fetch timestamp so the timer resets after each fetch