### PR TITLE
fix(backend): always zero exposed alert count metrics

### DIFF
--- a/cmd/karma/metrics.go
+++ b/cmd/karma/metrics.go
@@ -85,10 +85,11 @@ func (c *karmaCollector) Collect(ch chan<- prometheus.Metric) {
 			// count all alerts per receiver & state
 			for _, alert := range group.Alerts {
 				if _, found := alertsByReceiverByState[alert.Receiver]; !found {
-					alertsByReceiverByState[alert.Receiver] = map[string]float64{}
-				}
-				if _, found := alertsByReceiverByState[alert.Receiver][alert.State]; !found {
-					alertsByReceiverByState[alert.Receiver][alert.State] = 0
+					alertsByReceiverByState[alert.Receiver] = map[string]float64{
+						"unprocessed": 0,
+						"active":      0,
+						"suppressed":  0,
+					}
 				}
 				alertsByReceiverByState[alert.Receiver][alert.State]++
 			}


### PR DESCRIPTION
If there are no alerts for given state we won't return any metric, which leads to gaps
on metrics. Fix it by initializing all states with 0.