### PR TITLE
fix(ci): don't try to load fonts on Percy

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -15,6 +15,7 @@ import { BodyTheme, ThemeContext } from "Components/Theme";
 import { ErrorBoundary } from "./ErrorBoundary";
 
 import "Styles/ResetCSS.scss";
+import "Styles/FontBundle.scss";
 import "Styles/App.scss";
 
 // https://github.com/facebook/react/issues/14603

--- a/ui/src/Styles/App.scss
+++ b/ui/src/Styles/App.scss
@@ -1,6 +1,3 @@
-// bundled font assets, so we don't need to talk to Google Fonts API
-@import "~typeface-open-sans/index.css";
-
 .cursor-pointer {
   cursor: pointer;
 }

--- a/ui/src/Styles/FontBundle.scss
+++ b/ui/src/Styles/FontBundle.scss
@@ -1,0 +1,2 @@
+// bundled font assets, so we don't need to talk to Google Fonts API
+@import "~typeface-open-sans/index.css";

--- a/ui/src/Styles/Fonts.scss
+++ b/ui/src/Styles/Fonts.scss
@@ -11,5 +11,3 @@ $font-weight-bold: 600;
 $font-family-sans-serif: "Open Sans", -apple-system, BlinkMacSystemFont,
   "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji",
   "Segoe UI Emoji", "Segoe UI Symbol" !default;
-
-@import "~typeface-open-sans/index.css";


### PR DESCRIPTION
This ensures that the grid renders correctly, since load events don't seem to trigger on storybook and grid is not repacked after element heights changes.