### PR TITLE
fix(ci): allow percy tests to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ os: linux
 language: shell
 
 jobs:
+  allow_failures:
+    - name: Percy UI snapshots
   include:
     - stage: Test
       name: Test Go code


### PR DESCRIPTION
If we run over 5k snapshots a month we'll get failures, so it should
be allowed to fail