### PR TITLE
fix(project): disable automerge for node major versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,17 @@
   "travis": { "enabled": true },
   "masterIssue": true,
   "postUpdateOptions": ["gomodTidy"],
-  "automerge": true
+  "automerge": true,
+  "packageRules": [
+    {
+      "packageNames": ["node"],
+      "updateTypes": ["major"],
+      "automerge": false
+    },
+    {
+      "packageNames": ["node"],
+      "updateTypes": ["minor", "patch"],
+      "automerge": true
+    }
+  ]
 }


### PR DESCRIPTION
This prevents renovate from bumping LTS version.