### PR TITLE
deploy: Add k8s manifest & kustomization.yaml

### DIFF
--- a/deploy/karma.yaml
+++ b/deploy/karma.yaml
@@ -1,0 +1,53 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: karma
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: karma
+spec:
+  template:
+    spec:
+      containers:
+      - name: karma
+        image: lmierzwa/karma
+        securityContext:
+          readOnlyRootFilesystem: true
+        ports:
+        - name: http
+          containerPort: 8080
+        livenessProbe:
+          initialDelaySeconds: 30
+          timeoutSeconds: 10
+          httpGet:
+            path: /
+            port: 8080
+        readinessProbe:
+          timeoutSeconds: 5
+          httpGet:
+            path: /
+            port: 8080
+        resources:
+          requests:
+            memory: 20Mi
+            cpu: 5m
+          limits:
+            memory: 100Mi
+            cpu: 50m
+        volumeMounts:
+        - name: config
+          mountPath: /karma.yaml
+          subPath: karma.yaml
+          readOnly: true
+      volumes:
+      - name: config
+        configMap:
+          name: karma

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: karma
+commonLabels:
+  app.kubernetes.io/name: karma
+resources:
+- deploy/karma.yaml
+configMapGenerator:
+- files:
+  - karma.yaml=docs/example.yaml
+  name: karma


### PR DESCRIPTION
This PR adds a `kustomization.yaml` + a `karma.yaml` for a kubernetes deployment.

This way users can rely on the repo for the basic setup and override things like the configuration themselves, without having to copy & paste everything.

e.g.:
`kustomization.yaml`
```yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
namespace: monitoring
resources:
- github.com/prymitive/karma?ref=v0.55
- karma-ingress.yaml
patchesStrategicMerge:
- karma.yaml
configMapGenerator:
- behavior: replace
  files:
  - karma.yaml=karma-config.yaml
  name: karma
```