### PR TITLE
fix(ui): always render alerts if multi-grid is disabled

### DIFF
--- a/ui/src/Components/Grid/AlertGrid/Grid.js
+++ b/ui/src/Components/Grid/AlertGrid/Grid.js
@@ -219,7 +219,7 @@ const Grid = observer(
             loadMore={this.loadMore}
             hasMore={false}
           >
-            {this.gridToggle.show
+            {this.gridToggle.show || grid.labelName === ""
               ? grid.alertGroups
                   .slice(0, this.groupsToRender.value)
                   .map((group) => (


### PR DESCRIPTION
If we have multi-grid on, user toggles all grids to hide details, then disables multi-grid, then we end up with alerts hidden and no way to show them.