### PR TITLE
fix(demo): sort alerts by cluster label

### DIFF
--- a/demo/karma.yaml
+++ b/demo/karma.yaml
@@ -33,7 +33,7 @@ grid:
   sorting:
     order: label
     reverse: false
-    label: severity
+    label: cluster
     customValues:
       labels:
         cluster:


### PR DESCRIPTION
severity is already used for multi-grid, so second level sorting should use something else