### PR TITLE
fix(deps): downgrade prettier to 2.0.2

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -18800,9 +18800,9 @@
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
     },
     "prettier": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.4.tgz",
-      "integrity": "sha512-SVJIQ51spzFDvh4fIbCLvciiDMCrRhlN3mbZvv/+ycjvmF5E73bKdGfU8QDLNmjYJf+lsGnDBC4UUnvTe5OO0w==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.2.tgz",
+      "integrity": "sha512-5xJQIPT8BraI7ZnaDwSbu5zLrB6vvi8hVV58yHQ+QK64qrY40dULy0HSRlQ2/2IdzeBpjhDkqdcFBnFeDEMVdg==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -89,7 +89,7 @@
     "jest-fetch-mock": "3.0.3",
     "markdownlint-cli": "0.22.0",
     "node-sass": "4.13.1",
-    "prettier": "2.0.4",
+    "prettier": "2.0.2",
     "source-map-explorer": "2.4.2"
   },
   "browserslist": [


### PR DESCRIPTION
atom-prettier doesn't work with the latest version, keep it on 2.0.2 until it's fixed