### PR TITLE
fix(backend): ensure alertmanager server uses default name if not set

### DIFF
--- a/cmd/karma/tests/testscript/duplicated_alertmanager_default_name.txt
+++ b/cmd/karma/tests/testscript/duplicated_alertmanager_default_name.txt
@@ -1,0 +1,11 @@
+# Raises an error if we have 2 instances with the same name (one using default name)
+karma.bin-should-fail --log.format=text --log.config=false --log.level=error --config.file=karma.yaml
+! stdout .
+stderr 'msg="Failed to register Alertmanager ''default'' with URI ''https://localhost:9094'': alertmanager upstream ''default'' already exist"'
+
+-- karma.yaml --
+alertmanager:
+  servers:
+    - name: default
+      uri: https://localhost:9093
+    - uri: https://localhost:9094

--- a/cmd/karma/tests/testscript/empty_alertmanager_name.txt
+++ b/cmd/karma/tests/testscript/empty_alertmanager_name.txt
@@ -1,0 +1,10 @@
+# Uses 'default' as the default alertmanager name
+karma.bin-should-work --log.format=text --log.config=false --config.file=karma.yaml --check-config
+! stdout .
+stderr 'msg="\[default\] Configured Alertmanager source at http://localhost:9093 \(proxied: false\, readonly: false\)"'
+! stderr 'level=error'
+
+-- karma.yaml --
+alertmanager:
+  servers:
+    - uri: http://localhost:9093

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -269,6 +269,9 @@ func (config *configSchema) Read(flags *pflag.FlagSet) string {
 	}
 
 	for i, s := range config.Alertmanager.Servers {
+		if s.Name == "" {
+			config.Alertmanager.Servers[i].Name = "default"
+		}
 		if s.Timeout.Seconds() == 0 {
 			config.Alertmanager.Servers[i].Timeout = config.Alertmanager.Timeout
 		}


### PR DESCRIPTION
Fixes #1646