### PR TITLE
fix(deps): revert update dependency moment to v2.25.0

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -16628,9 +16628,9 @@
       }
     },
     "moment": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.25.0.tgz",
-      "integrity": "sha512-vbrf6kJGpevOxmDRvCCvGuCSXvRj93264WcFzjm3Z3pV4lfjrXll8rvSP+EbmCte64udj1LkJMILxQnjXAQBzg=="
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "moo": {
       "version": "0.5.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -29,7 +29,7 @@
     "mobx-react": "6.2.2",
     "mobx-react-lite": "2.0.6",
     "mobx-stored": "1.1.0",
-    "moment": "2.25.0",
+    "moment": "2.24.0",
     "object-hash": "2.0.3",
     "promise-retry": "1.1.1",
     "prop-types": "15.7.2",


### PR DESCRIPTION
This reverts commit 90c4bc856e4109a2cee217497a3b774f9000ae1f.

Fails to load, waiting for a fix upstream.