### PR TITLE
fix(ui): labels in the overview modal have wrong close icon color in …

### DIFF
--- a/ui/src/Styles/Components/BaseLabel.scss
+++ b/ui/src/Styles/Components/BaseLabel.scss
@@ -76,6 +76,7 @@ span.badge.components-label {
 }
 
 button.components-label-bright,
+span.components-label-bright,
 .components-label-bright {
   color: $black;
   &:hover {
@@ -105,6 +106,7 @@ button.components-label-bright,
 }
 
 button.components-label-dark,
+span.components-label-dark,
 .components-label-dark {
   color: $white;
   &:hover {


### PR DESCRIPTION
…dark mode