### PR TITLE
WIP: feat(backend): Add option to order annotations

### DIFF
--- a/internal/config/models.go
+++ b/internal/config/models.go
@@ -92,6 +92,7 @@ type configSchema struct {
 		Visible []string
 		Keep    []string
 		Strip   []string
+		Order   []string
 	}
 	Custom struct {
 		CSS string

--- a/internal/models/annotation.go
+++ b/internal/models/annotation.go
@@ -29,6 +29,26 @@ func (a Annotations) Swap(i, j int) {
 	a[i], a[j] = a[j], a[i]
 }
 func (a Annotations) Less(i, j int) bool {
+	// Sort the anotations listed in config.Config.Annotations.Order first, in
+	// the order they appear in that list; remaining annotations are sorted alphabetically.
+	ai, aj := -1, -1
+	for index, name := range config.Config.Annotations.Order {
+		if a[i].Name == name {
+			ai = index
+		} else if a[j].Name == name {
+			aj = index
+		}
+		// If both annotations are in c.C.A.Order, sort them according to the
+		// order in that list.
+		if ai >= 0 && aj >= 0 {
+			return ai < aj
+		}
+	}
+	// If only one of the annotations was in c.C.A.Order, that one goes first.
+	if ai != aj {
+		return aj < ai
+	}
+	// If neither annotation was in c.C.A.Order, sort alphabetically.
 	return a[i].Name < a[j].Name
 }
 


### PR DESCRIPTION
The `annotations.order` option lets users pass a list of annotation names in
the order they want them displayed. Any annotation that isn't in the list is
shown after the annotations from the list, in alphabetical order.

For instance, with

```yaml
annotations:
  order:
  - summary
  - description
```

an alert with `description`, `help`, `runbook` and `summary` annotations will
have them displayed in that order:

- `summary`
- `description`
- `help`
- `runbook`

Signed-off-by: Benoît Knecht <bknecht@protonmail.ch>