### PR TITLE
fix(ui): don't resize the grid when modal is open

### DIFF
--- a/ui/src/Components/Modal/index.js
+++ b/ui/src/Components/Modal/index.js
@@ -16,7 +16,7 @@ const ModalInner = ({ size, isUpper, toggleOpen, children }) => {
 
   useEffect(() => {
     document.body.classList.add("modal-open");
-    disableBodyScroll(ref.current);
+    disableBodyScroll(ref.current, { reserveScrollBarGap: true });
 
     let modal = ref.current;
     return () => {


### PR DESCRIPTION
Modal will hide the scrollbar, which can resize everything.
Tell body-scroll-lock to reserver space for hidden scrollbar to avoid it.