### PR TITLE
fix(ui): improve favicon readability on Firefox

### DIFF
--- a/ui/src/Components/FaviconBadge/index.tsx
+++ b/ui/src/Components/FaviconBadge/index.tsx
@@ -16,7 +16,6 @@ const FaviconBadge: FC<{
       position: "down",
       bgColor: "#e74c3c",
       textColor: "#fff",
-      fontStyle: "lighter",
     })
   );
 


### PR DESCRIPTION
Some browsers (like Firefox, on both high and low DPI monitors, and Google Chrome beta on low DPI monitors) render the favico.js badge too thin.

This is how it looks in Firefox without and with this patch:

![image](https://user-images.githubusercontent.com/327411/91349873-366f9c80-e7e6-11ea-8ba1-61bb889476ff.png) → ![image](https://user-images.githubusercontent.com/327411/91351879-4b99fa80-e7e9-11ea-8444-5d4c20166d7f.png)

Fixes: #2107