### PR TITLE
fix(ui): remove obsolete imports

### DIFF
--- a/ui/src/setupTests.ts
+++ b/ui/src/setupTests.ts
@@ -4,8 +4,6 @@ import Adapter from "enzyme-adapter-react-16";
 
 import { FetchRetryConfig } from "Common/Fetch";
 
-import "mobx-react-lite/batchingForReactDom";
-
 // https://github.com/airbnb/enzyme
 Enzyme.configure({ adapter: new Adapter() });
 


### PR DESCRIPTION
New mobx doesn't need it anymore