### PR TITLE
feat(backend): use fewer histogram buckets for request latency

### DIFF
--- a/cmd/karma/exporter.go
+++ b/cmd/karma/exporter.go
@@ -23,8 +23,9 @@ var (
 
 	reqDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name: "http_request_duration_seconds",
-			Help: "HTTP request latencies in seconds.",
+			Name:    "http_request_duration_seconds",
+			Help:    "HTTP request latencies in seconds.",
+			Buckets: []float64{0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1},
 		}, labels,
 	)
 


### PR DESCRIPTION
Default buckets cover up to 10 seconds, which is unnecessarily wide.

Checking our installation, highest p99.9 among all endpoints is 0.34s (somewhat unexpectedly, the notFound handler).