### PR TITLE
Push to new GitHub Container Registry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -273,6 +273,7 @@ jobs:
         ### GitHub
         # tag with the version only if we have a git tag (new release was pushed)
         - if [ -n "$TRAVIS_TAG" ]; then travis_retry docker login docker.pkg.github.com -u prymitive -p "${GITHUB_PACKAGES_TOKEN}" && docker tag "${LOCAL_IMAGE}" "docker.pkg.github.com/prymitive/karma/karma:${VERSION}" && travis_retry docker push "docker.pkg.github.com/prymitive/karma/karma:${VERSION}" ; fi
+        - if [ -n "$TRAVIS_TAG" ]; then travis_retry docker login gchr.io -u prymitive -p "${GITHUB_PACKAGES_TOKEN}" && docker tag "${LOCAL_IMAGE}" "gchr.io/prymitive/karma:${VERSION}" && travis_retry docker push "gchr.io/prymitive/karma:${VERSION}" ; fi
 
     - stage: Build and Deploy
       name: Deploy demo app to Heroku


### PR DESCRIPTION
This PR adds a push to the "new" [Github Container Registry](https://docs.github.com/en/free-pro-team@latest/packages/getting-started-with-github-container-registry/about-github-container-registry) (I kept the push to the "old" Github Package Registry since I guess people may have workflow dependencies on it?).

The new registry has two benefits:
- Allows for unauthenticated pulls (ie no longer need to authenticate your AM nodes with GitHub to get the image)
- Isn't affected by the [bug which appears to break containerd](https://github.com/containerd/containerd/issues/3291)
