### PR TITLE
fix(backend): correctly handle AUTHENTICATION_HEADER_VALUE_RE env variable

### DIFF
--- a/cmd/karma/tests/testscript/059_log_full_config_env.txt
+++ b/cmd/karma/tests/testscript/059_log_full_config_env.txt
@@ -1,4 +1,7 @@
 # Print out and compare logged config set via env variables
+env AUTHENTICATION_HEADER_NAME=X-Auth
+env AUTHENTICATION_HEADER_VALUE_RE='^(.+)$'
+
 env ALERTMANAGER_INTERVAL=10s
 env ALERTMANAGER_NAME=ro
 env ALERTMANAGER_URI=http://localhost:9093
@@ -51,8 +54,6 @@ env RECEIVERS_STRIP='strip1 strip2'
 env SENTRY_DSN=abcdef1234567890
 env SENTRY_PUBLIC=1234567890abcdef
 
-env SILENCEFORM_AUTHOR_POPULATE_FROM_HEADER_HEADER=CF-RAY
-env SILENCEFORM_AUTHOR_POPULATE_FROM_HEADER_VALUE_RE='^(.+)$'
 env SILENCEFORM_STRIP_LABELS='job severity region'
 
 env UI_REFRESH=10s
@@ -74,8 +75,8 @@ level=info msg="Version: dev"
 level=info msg="Parsed configuration:"
 level=info msg="authentication:"
 level=info msg="  header:"
-level=info msg="    name: \"\""
-level=info msg="    value_re: \"\""
+level=info msg="    name: X-Auth"
+level=info msg="    value_re: ^(.+)$"
 level=info msg="  basicAuth:"
 level=info msg="    users: []"
 level=info msg="authorization:"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -191,10 +191,8 @@ func readEnvVariables(k *koanf.Koanf) {
 			return "alertAcknowledgement.author"
 		case "ALERTACKNOWLEDGEMENT_COMMENTPREFIX":
 			return "alertAcknowledgement.commentPrefix"
-		case "SILENCEFORM_AUTHOR_POPULATE_FROM_HEADER_HEADER":
-			return "silenceForm.author.populate_from_header.header"
-		case "SILENCEFORM_AUTHOR_POPULATE_FROM_HEADER_VALUE_RE":
-			return "silenceForm.author.populate_from_header.value_re"
+		case "AUTHENTICATION_HEADER_VALUE_RE":
+			return "authentication.header.value_re"
 		case "SILENCEFORM_STRIP_LABELS":
 			return "silenceForm.strip.labels"
 		case "UI_HIDEFILTERSWHENIDLE":


### PR DESCRIPTION
SILENCEFORM_AUTHOR_POPULATE_FROM_HEADER_* env support was removed, but old code is still present, remove it.
Correctly parse AUTHENTICATION_HEADER_VALUE_RE env variable into authentication.header.value_re config option.

Fixes #2246