### PR TITLE
chore: masterIssue -> dependencyDashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "extends": ["config:base"],
   "prHourlyLimit": 1,
   "rebaseStalePrs": false,
-  "masterIssue": true,
+  "dependencyDashboard": true,
   "postUpdateOptions": ["gomodTidy"],
   "packageRules": [
     {


### PR DESCRIPTION
## Changes:

- Replace `masterIssue` with `dependencyDashboard`

## Context:

Renovate bot has deprecated the use of `masterIssue`, and now uses `dependencyDashboard` instead.
The functionality of the dashboard does not change when you merge this PR, so you'll keep your dependencyDashboard. 😉 

The Renovate docs for `dependencyDashboard` can be found here: https://docs.renovatebot.com/configuration-options/#dependencydashboard

The Renovate bot _should_ have raised a PR to migrate you to the newer term (https://github.com/renovatebot/renovate/pull/6729), but I cannot find a PR like that in the PR list for your repository.
Maybe you hit some kind of bug in this repository that causes the bot to not update you via a PR.
At least now you're using the latest supported term. 👍 