### PR TITLE
fix(backend): strip labels from alert group when configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Not all labels were stripped when using `lables:keep` or `labels:strip`
+  option #2585.
+
 ## v0.78
 
 ### Fixed

--- a/internal/alertmanager/dedup.go
+++ b/internal/alertmanager/dedup.go
@@ -66,6 +66,7 @@ func DedupAlerts() []models.AlertGroup {
 			continue
 		}
 		ag := models.AlertGroup(agList[0])
+		ag.Labels = transform.StripLables(config.Config.Labels.Keep, config.Config.Labels.Strip, ag.Labels)
 		ag.Alerts = make(models.AlertList, 0, len(alerts))
 		for _, alert := range alerts {
 			alert := alert // scopelint pin


### PR DESCRIPTION
Fixes #2585