### PR TITLE
fix(backend): fix a deadlock in ClusterMemberNames()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## [unreleased]
+## v0.81
+
+### Fixed
+
+- Fixed a deadlock issue that could cause karma to hang #2888.
 
 ### Added
 

--- a/cmd/karma/main_test.go
+++ b/cmd/karma/main_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/prymitive/karma/internal/config"
 
@@ -120,38 +119,5 @@ func TestGetViewURL(t *testing.T) {
 				t.Errorf("getViewURL(%s) returned %q, expected %q", testCase.view, result, testCase.result)
 			}
 		})
-	}
-}
-
-func TestPullFromAlertmanager(t *testing.T) {
-	zerolog.SetGlobalLevel(zerolog.FatalLevel)
-	mockConfig()
-	mockCache()
-	lastPull = time.Time{}
-
-	start := time.Now()
-	pullFromAlertmanager()
-	dur := time.Since(start)
-	if dur > time.Second {
-		t.Errorf("First pullFromAlertmanager took %s, expected <= 1s", dur)
-		return
-	}
-
-	start = time.Now()
-	pullFromAlertmanager()
-	dur = time.Since(start)
-	if dur < time.Second*5 {
-		t.Errorf("Second pullFromAlertmanager took %s, expected >= 5s", dur)
-		return
-	}
-
-	time.Sleep(time.Second * 6)
-
-	start = time.Now()
-	pullFromAlertmanager()
-	dur = time.Since(start)
-	if dur > time.Second {
-		t.Errorf("Third pullFromAlertmanager took %s, expected <= 1s", dur)
-		return
 	}
 }

--- a/cmd/karma/views_test.go
+++ b/cmd/karma/views_test.go
@@ -147,7 +147,6 @@ func mockAlerts(version string) {
 	mock.RegisterURL("http://localhost/api/v2/silences", version, "api/v2/silences")
 	mock.RegisterURL("http://localhost/api/v2/alerts/groups", version, "api/v2/alerts/groups")
 
-	lastPull = time.Time{}
 	pullFromAlertmanager()
 }
 
@@ -2309,7 +2308,6 @@ func TestUpstreamStatus(t *testing.T) {
 			for _, m := range testCase.mocks {
 				httpmock.RegisterResponder("GET", m.uri, httpmock.NewStringResponder(m.code, m.body))
 			}
-			lastPull = time.Time{}
 			pullFromAlertmanager()
 
 			req := httptest.NewRequest("GET", "/alerts.json?q=@receiver=by-cluster-service&q=alertname=HTTP_Probe_Failed&q=instance=web1", nil)
@@ -2552,7 +2550,6 @@ func TestAlertFilters(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				lastPull = time.Time{}
 				pullFromAlertmanager()
 
 				r := testRouter()


### PR DESCRIPTION
ClusterMemberNames can aquire read lock twice, which could block write locks.

Fixes #2888