### PR TITLE
fix(backend): redirect to slash

### DIFF
--- a/cmd/karma/main.go
+++ b/cmd/karma/main.go
@@ -60,15 +60,14 @@ var (
 func getViewURL(sub string) string {
 	var fixedSub string
 	fixedSub = sub
-	if !strings.HasPrefix(sub, "/") {
+	if sub != "" && !strings.HasPrefix(sub, "/") {
 		fixedSub = "/" + sub
 	}
 
 	var fixedPrefix string
-	fixedPrefix = config.Config.Listen.Prefix
-	if config.Config.Listen.Prefix != "" && !strings.HasPrefix(config.Config.Listen.Prefix, "/") {
-		fixedPrefix = "/" + config.Config.Listen.Prefix
-	}
+	fixedPrefix = strings.TrimPrefix(config.Config.Listen.Prefix, "/")
+	fixedPrefix = strings.TrimSuffix(fixedPrefix, "/")
+	fixedPrefix = "/" + fixedPrefix + "/"
 
 	u := path.Join(fixedPrefix, fixedSub)
 	if strings.HasSuffix(fixedSub, "/") && !strings.HasSuffix(u, "/") {
@@ -127,6 +126,9 @@ func setupRouter(router *chi.Mux, historyPoller *historyPoller) {
 		router.Use(basicAuth(users, allowAuthBypass))
 	}
 
+	if config.Config.Listen.Prefix != "/" {
+		router.Get(getViewURL(""), redirectIndex)
+	}
 	router.Get(getViewURL("/"), index)
 	router.Get(getViewURL("/health"), pong)
 	router.Get(getViewURL("/robots.txt"), robots)

--- a/cmd/karma/views.go
+++ b/cmd/karma/views.go
@@ -94,6 +94,10 @@ func pushPath(w http.ResponseWriter, path string) {
 	}
 }
 
+func redirectIndex(w http.ResponseWriter, r *http.Request) {
+	http.Redirect(w, r, r.URL.Path+"/", http.StatusMovedPermanently)
+}
+
 func index(w http.ResponseWriter, r *http.Request) {
 	noCache(w)
 	pushPath(w, getViewURL("/custom.css"))


### PR DESCRIPTION
If listen.prefix is set to /foo we should redirect /foo => /foo/

Fixes 3084