### PR TITLE
Fix for an error in views.go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.89
+
+### Fixed
+
+- API could error if multiple alertmanager upstreams belonging to the
+  same cluster were configured, but `cluster` option was unset
+  #3372 (@valihanov).
+
 ## v0.88
 
 ### Added

--- a/cmd/karma/views.go
+++ b/cmd/karma/views.go
@@ -424,6 +424,9 @@ func alerts(w http.ResponseWriter, r *http.Request) {
 					for _, am := range alert.Alertmanager {
 						for _, silence := range am.Silences {
 							if _, found := silences[am.Cluster][silence.ID]; !found {
+								if _, found :=  silences[am.Cluster]; !found {
+									silences[am.Cluster] = map[string]models.Silence{}
+								}
 								silences[am.Cluster][silence.ID] = *silence
 							}
 						}

--- a/cmd/karma/views.go
+++ b/cmd/karma/views.go
@@ -240,24 +240,14 @@ func alerts(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	matchFilters := getFiltersFromQuery(request.Filters)
-
 	grids := map[string]models.APIGrid{}
 	colors := models.LabelsColorMap{}
+	silences := map[string]map[string]models.Silence{}
+	allReceivers := map[string]bool{}
 
 	dedupedAlerts := alertmanager.DedupAlerts()
 	dedupedColors := alertmanager.DedupColors()
-
-	silences := map[string]map[string]models.Silence{}
-	for _, am := range alertmanager.GetAlertmanagers() {
-		key := am.ClusterName()
-		if _, found := silences[key]; !found {
-			silences[key] = map[string]models.Silence{}
-		}
-	}
-
-	allReceivers := map[string]bool{}
-
+	matchFilters := getFiltersFromQuery(request.Filters)
 	filtered := filterAlerts(dedupedAlerts, matchFilters)
 
 	gridLabel := request.GridLabel
@@ -424,7 +414,7 @@ func alerts(w http.ResponseWriter, r *http.Request) {
 					for _, am := range alert.Alertmanager {
 						for _, silence := range am.Silences {
 							if _, found := silences[am.Cluster][silence.ID]; !found {
-								if _, found :=  silences[am.Cluster]; !found {
+								if _, found := silences[am.Cluster]; !found {
 									silences[am.Cluster] = map[string]models.Silence{}
 								}
 								silences[am.Cluster][silence.ID] = *silence


### PR DESCRIPTION
Fix error:


```
2021/07/23 15:19:54 http: panic serving 127.0.0.1:65037: assignment to entry in nil map
goroutine 654 [running]:
net/http.(*conn).serve.func1(0xc0002114a0)
        /opt/hostedtoolcache/go/1.16.6/x64/src/net/http/server.go:1804 +0x153
panic(0xca4ae0, 0x16537f0)
        /opt/hostedtoolcache/go/1.16.6/x64/src/runtime/panic.go:971 +0x499
github.com/getsentry/sentry-go/http.(*Handler).recoverWithSentry(0xc0004a95f0, 0xc0006b97a0, 0xc0002f3e00)
        /home/runner/go/pkg/mod/github.com/getsentry/sentry-go@v0.11.0/http/sentryhttp.go:117 +0x14e
panic(0xca4ae0, 0x16537f0)
        /opt/hostedtoolcache/go/1.16.6/x64/src/runtime/panic.go:965 +0x1b9
main.alerts(0x1670bd0, 0xc000bb1400, 0xc0002f3e00)
        /home/runner/work/karma/karma/cmd/karma/views.go:427 +0x3454
net/http.HandlerFunc.ServeHTTP(0x15a0d48, 0x1670bd0, 0xc000bb1400, 0xc0002f3e00)
        /opt/hostedtoolcache/go/1.16.6/x64/src/net/http/server.go:2049 +0x44
github.com/go-chi/chi/v5.(*Mux).routeHTTP(0xc0004a2300, 0x1670bd0, 0xc000bb1400, 0xc0002f3e00)
        /home/runner/go/pkg/mod/github.com/go-chi/chi/v5@v5.0.3/mux.go:442 +0x2a9
net/http.HandlerFunc.ServeHTTP(0xc0004bb7a0, 0x1670bd0, 0xc000bb1400, 0xc0002f3e00)
        /opt/hostedtoolcache/go/1.16.6/x64/src/net/http/server.go:2049 +0x44
github.com/go-chi/cors.(*Cors).Handler.func1(0x1670bd0, 0xc000bb1400, 0xc0002f3e00)
        /home/runner/go/pkg/mod/github.com/go-chi/cors@v1.2.0/cors.go:228 +0x1b9
net/http.HandlerFunc.ServeHTTP(0xc00003c240, 0x1670bd0, 0xc000bb1400, 0xc0002f3e00)
        /opt/hostedtoolcache/go/1.16.6/x64/src/net/http/server.go:2049 +0x44
main.serverStaticFiles.func1.1(0x1670bd0, 0xc000bb1400, 0xc0002f3e00)
        /home/runner/work/karma/karma/cmd/karma/assets.go:52 +0xad0
net/http.HandlerFunc.ServeHTTP(0xc000404b80, 0x1670bd0, 0xc000bb1400, 0xc0002f3e00)
        /opt/hostedtoolcache/go/1.16.6/x64/src/net/http/server.go:2049 +0x44
main.serverStaticFiles.func1.1(0x1670bd0, 0xc000bb1400, 0xc0002f3e00)
        /home/runner/work/karma/karma/cmd/karma/assets.go:52 +0xad0
net/http.HandlerFunc.ServeHTTP(0xc000404bc0, 0x1670bd0, 0xc000bb1400, 0xc0002f3e00)
        /opt/hostedtoolcache/go/1.16.6/x64/src/net/http/server.go:2049 +0x44
main.serverStaticFiles.func1.1(0x1670bd0, 0xc000bb1400, 0xc0002f3e00)
        /home/runner/work/karma/karma/cmd/karma/assets.go:59 +0x9b5
net/http.HandlerFunc.ServeHTTP(0xc000405200, 0x1670bd0, 0xc000bb1400, 0xc0002f3e00)
        /opt/hostedtoolcache/go/1.16.6/x64/src/net/http/server.go:2049 +0x44
github.com/go-chi/chi/v5/middleware.(*Compressor).Handler.func1(0x7f5501198460, 0xc000997840, 0xc0002f3e00)
        /home/runner/go/pkg/mod/github.com/go-chi/chi/v5@v5.0.3/middleware/compress.go:213 +0x290
net/http.HandlerFunc.ServeHTTP(0xc00003c260, 0x7f5501198460, 0xc000997840, 0xc0002f3e00)
        /opt/hostedtoolcache/go/1.16.6/x64/src/net/http/server.go:2049 +0x44
github.com/go-chi/chi/v5/middleware.RealIP.func1(0x7f5501198460, 0xc000997840, 0xc0002f3e00)
        /home/runner/go/pkg/mod/github.com/go-chi/chi/v5@v5.0.3/middleware/realip.go:34 +0x9d
net/http.HandlerFunc.ServeHTTP(0xc00000daa0, 0x7f5501198460, 0xc000997840, 0xc0002f3e00)
        /opt/hostedtoolcache/go/1.16.6/x64/src/net/http/server.go:2049 +0x44
github.com/getsentry/sentry-go/http.(*Handler).handle.func1(0x7f5501198460, 0xc000997840, 0xc0002f3d00)
        /home/runner/go/pkg/mod/github.com/getsentry/sentry-go@v0.11.0/http/sentryhttp.go:103 +0x402
net/http.HandlerFunc.ServeHTTP(0xc00003c280, 0x7f5501198460, 0xc000997840, 0xc0002f3d00)
        /opt/hostedtoolcache/go/1.16.6/x64/src/net/http/server.go:2049 +0x44
main.promMiddleware.func1(0x1671f50, 0xc000a7b0a0, 0xc0002f3d00)
        /home/runner/work/karma/karma/cmd/karma/exporter.go:52 +0x119
net/http.HandlerFunc.ServeHTTP(0xc00000dab8, 0x1671f50, 0xc000a7b0a0, 0xc0002f3d00)
        /opt/hostedtoolcache/go/1.16.6/x64/src/net/http/server.go:2049 +0x44
github.com/go-chi/chi/v5.(*Mux).ServeHTTP(0xc0004a2300, 0x1671f50, 0xc000a7b0a0, 0xc0002f3b00)
        /home/runner/go/pkg/mod/github.com/go-chi/chi/v5@v5.0.3/mux.go:88 +0x310
net/http.serverHandler.ServeHTTP(0xc000810000, 0x1671f50, 0xc000a7b0a0, 0xc0002f3b00)
        /opt/hostedtoolcache/go/1.16.6/x64/src/net/http/server.go:2867 +0xa3
net/http.(*conn).serve(0xc0002114a0, 0x16740d8, 0xc000997700)
        /opt/hostedtoolcache/go/1.16.6/x64/src/net/http/server.go:1932 +0x8cd
created by net/http.(*Server).Serve
        /opt/hostedtoolcache/go/1.16.6/x64/src/net/http/server.go:2993 +0x39b
```

![image](https://user-images.githubusercontent.com/44205973/126789411-bcca2e30-ac87-453a-91db-be27091407bc.png)

We got this error, when configured karma to gather data from multiple alertmanagers.