### PR TITLE
fix(ui): Reverse ToggleIcon

### DIFF
--- a/ui/src/Components/ToggleIcon/index.tsx
+++ b/ui/src/Components/ToggleIcon/index.tsx
@@ -1,7 +1,7 @@
 import type { FC } from "react";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faChevronDown } from "@fortawesome/free-solid-svg-icons/faChevronDown";
+import { faChevronUp } from "@fortawesome/free-solid-svg-icons/faChevronUp";
 
 const ToggleIcon: FC<{
   isOpen: boolean;
@@ -10,7 +10,7 @@ const ToggleIcon: FC<{
 }> = ({ className, isOpen, onClick }) => {
   return (
     <FontAwesomeIcon
-      icon={faChevronDown}
+      icon={faChevronUp}
       rotation={isOpen ? undefined : 180}
       className={className}
       style={{ transition: "transform 0.25s ease-in-out" }}


### PR DESCRIPTION
The ToggleIcon works counterintuitive to how you would expect. The chevron direction should indicate what the button SHOULD do, rather that the present state. Currently when the details are hidden, the chevron points up, as if the details view is already seen, and you can hide it, rather than expand it.

The change reverses the chevron direction, so its more intuitive.