### PR TITLE
fix(ui): only hide group footer if there's nothing to render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.110
+
+### Fixed
+
+- Alert group footer was always hidden when displaying only one alert,
+  even if there were shared labels or annotations to display - #4892.
+
 ## v0.109
 
 ### Added

--- a/ui/src/Components/Grid/AlertGrid/AlertGroup/GroupFooter/index.tsx
+++ b/ui/src/Components/Grid/AlertGrid/AlertGroup/GroupFooter/index.tsx
@@ -25,6 +25,23 @@ const GroupFooter: FC<{
   showAnnotations = true,
   showSilences = true,
 }) => {
+  const total =
+    (showAnnotations
+      ? group.shared.annotations.filter((a) => a.isLink === false).length +
+        group.shared.annotations
+          .filter((a) => a.isLink === true)
+          .filter((a) => a.isAction === false).length
+      : 0) +
+    group.shared.labels.length +
+    (Object.keys(alertStore.data.upstreams.clusters).length > 1
+      ? group.shared.clusters.length
+      : 0) +
+    (alertStore.data.receivers.length > 1 ? 1 : 0) +
+    (showSilences ? Object.keys(group.shared.silences).length : 0);
+  if (total === 0) {
+    return null;
+  }
+
   return (
     <div className="card-footer components-grid-alertgrid-alertgroup-footer px-2 py-1">
       <div className="mb-1">

--- a/ui/src/Components/Grid/AlertGrid/AlertGroup/index.tsx
+++ b/ui/src/Components/Grid/AlertGrid/AlertGroup/index.tsx
@@ -228,7 +228,7 @@ const AlertGroup: FC<{
             </ul>
           </div>
         )}
-        {isCollapsed === false && group.alerts.length > 1 ? (
+        {isCollapsed === false ? (
           <GroupFooter
             group={group}
             afterUpdate={afterUpdate}


### PR DESCRIPTION
Fixes #4890