### PR TITLE
Feature: keep node on even versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "node"
+        versions: [ "23.x", "25.x", "27.x", "29.x", "31.x" ]
   - package-ecosystem: "docker"
     directory: "/demo"
     schedule:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:23.0.0-alpine AS nodejs-builder
+FROM node:22.10.0-alpine AS nodejs-builder
 RUN mkdir -p /src/ui
 COPY ui/package.json ui/package-lock.json /src/ui/
 RUN cd /src/ui && npm ci && touch node_modules/.install


### PR DESCRIPTION
Closes #6274 

This PR ignores a number of off versions of nodejs image and reverts the current image back to the latest v22 image.

There seems to be no way to know if a version of node is LTS so we will end up going to a even version before it's really a LTS version.

see also https://github.com/dependabot/dependabot-core/issues/2247 for a description of the problem.