### PR TITLE
Fix VictoriaMetrics URL handling in alert history queries

### DIFF
--- a/cmd/karma/alert_history_test.go
+++ b/cmd/karma/alert_history_test.go
@@ -147,7 +147,7 @@ func TestAlertHistory(t *testing.T) {
 					}),
 					code: 200,
 					response: AlertHistoryResponse{
-						Error:   `One or more errors occurred when querying Prometheus API: %gh&%ij: failed to create Prometheus API client: parse "%gh&%ij": invalid URL escape "%gh"`,
+						Error:   `One or more errors occurred when querying Prometheus API: %gh&%ij: failed to parse generator URL: parse "%gh&%ij": invalid URL escape "%gh"`,
 						Samples: generateHistorySamples(generateIntSlice(0, 0, 24), time.Hour),
 					},
 				},


### PR DESCRIPTION
**Problem**
The alert history functionality was incorrectly constructing API URLs when using VictoriaMetrics generator URLs. VictoriaMetrics provides generator URLs with tenant-specific UI paths like:
```
http://victoriametrics/select/0/vmui/#/?g0.expr=...
```

The code was directly using these URLs as the base for Prometheus API client calls, resulting in malformed API endpoints:
❌ /select/0/vmui/api/v1/labels
❌ /select/0/vmui/api/v1/query_range
where the correct ones will be 
✅  /select/0/prometheus/api/v1/labels
✅  /select/0/prometheus/api/v1/query_range

**Solution**
Enhanced the countAlerts function in alert_history.go to intelligently parse generator URLs and extract the correct API base URL
Added URL parsing logic to extract appropriate API base URLs from generator URLs
Added VictoriaMetrics-specific tenant path handling
Maintained backward compatibility for standard Prometheus deployments
Added debug logging to track URL transformations